### PR TITLE
gcc-10 compliance

### DIFF
--- a/clickhouse/base/compressed.cpp
+++ b/clickhouse/base/compressed.cpp
@@ -3,7 +3,7 @@
 
 #include <cityhash/city.h>
 #include <lz4/lz4.h>
-
+#include <stdexcept>
 #include <system_error>
 
 #define DBMS_MAX_COMPRESSED_SIZE    0x40000000ULL   // 1GB

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -17,6 +17,7 @@
 #include <thread>
 #include <vector>
 #include <sstream>
+#include <stdexcept>
 
 #define DBMS_NAME                                       "ClickHouse"
 #define DBMS_VERSION_MAJOR                              1

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -12,6 +12,8 @@
 
 #include "../types/type_parser.h"
 
+#include <stdexcept>
+
 namespace clickhouse {
 namespace {
 

--- a/clickhouse/columns/nullable.cpp
+++ b/clickhouse/columns/nullable.cpp
@@ -1,6 +1,7 @@
 #include "nullable.h"
 
 #include <assert.h>
+#include <stdexcept>
 
 namespace clickhouse {
 

--- a/clickhouse/columns/uuid.cpp
+++ b/clickhouse/columns/uuid.cpp
@@ -1,6 +1,8 @@
 #include "uuid.h"
 #include "utils.h"
 
+#include <stdexcept>
+
 namespace clickhouse {
 
 ColumnUUID::ColumnUUID()

--- a/tests/simple/main.cpp
+++ b/tests/simple/main.cpp
@@ -2,6 +2,7 @@
 #include <clickhouse/error_codes.h>
 #include <clickhouse/types/type_parser.h>
 
+#include <stdexcept>
 #include <iostream>
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
Seems like gcc's version 10 will be quite strict about missing headers (Our RClickhouse package is build on top of this c++ lib: https://www.stats.ox.ac.uk/pub/bdr/gcc10/RClickhouse.log). Therefore, I just added the required stdexcept headers.