### PR TITLE
__int128 usage (c++14 compatibility)

### DIFF
--- a/clickhouse/columns/decimal.h
+++ b/clickhouse/columns/decimal.h
@@ -4,7 +4,7 @@
 
 namespace clickhouse {
 
-using Int128 = __int128;
+using Int128 = int128;
 
 /**
  * Represents a column of decimal type.

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -69,7 +69,7 @@ template class ColumnVector<int8_t>;
 template class ColumnVector<int16_t>;
 template class ColumnVector<int32_t>;
 template class ColumnVector<int64_t>;
-template class ColumnVector<__int128>;
+template class ColumnVector<int128>;
 
 template class ColumnVector<uint8_t>;
 template class ColumnVector<uint16_t>;

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -57,7 +57,7 @@ using ColumnInt8    = ColumnVector<int8_t>;
 using ColumnInt16   = ColumnVector<int16_t>;
 using ColumnInt32   = ColumnVector<int32_t>;
 using ColumnInt64   = ColumnVector<int64_t>;
-using ColumnInt128  = ColumnVector<__int128>;
+using ColumnInt128  = ColumnVector<int128>;
 
 using ColumnFloat32 = ColumnVector<float>;
 using ColumnFloat64 = ColumnVector<double>;

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -7,6 +7,9 @@
 
 namespace clickhouse {
 
+//fix to prevent warning using Wpedantic flag
+__extension__ typedef __int128 int128;
+    
 using TypeRef = std::shared_ptr<class Type>;
 
 class Type {
@@ -200,7 +203,7 @@ inline TypeRef Type::CreateSimple<int64_t>() {
 }
 
 template <>
-inline TypeRef Type::CreateSimple<__int128>() {
+inline TypeRef Type::CreateSimple<int128>() {
     return TypeRef(new Type(Int128));
 }
 


### PR DESCRIPTION
Seems like the used type "__int128" is not full c++14 compatible, but can be used as extension. To avoid warnings during compilation, we explicitly mentioned the usage of this extension.  