### PR TITLE
Implemented reading values of SimpleAggregateFunction

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -55,16 +55,6 @@ struct ClientInfo {
     uint32_t client_revision = 0;
 };
 
-struct ServerInfo {
-    std::string name;
-    std::string timezone;
-    std::string display_name;
-    uint64_t    version_major;
-    uint64_t    version_minor;
-    uint64_t    version_patch;
-    uint64_t    revision;
-};
-
 std::ostream& operator<<(std::ostream& os, const ClientOptions& opt) {
     os << "Client(" << opt.user << '@' << opt.host << ":" << opt.port
        << " ping_before_query:" << opt.ping_before_query
@@ -90,6 +80,8 @@ public:
     void Ping();
 
     void ResetConnection();
+
+    const ServerInfo& GetServerInfo() const;
 
 private:
     bool Handshake();
@@ -295,6 +287,10 @@ void Client::Impl::ResetConnection() {
     if (!Handshake()) {
         throw std::runtime_error("fail to connect to " + options_.host);
     }
+}
+
+const ServerInfo& Client::Impl::GetServerInfo() const {
+    return server_info_;
 }
 
 bool Client::Impl::Handshake() {
@@ -787,6 +783,10 @@ void Client::Ping() {
 
 void Client::ResetConnection() {
     impl_->ResetConnection();
+}
+
+const ServerInfo& Client::GetServerInfo() const {
+    return impl_->GetServerInfo();
 }
 
 }

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -23,6 +23,16 @@
 
 namespace clickhouse {
 
+struct ServerInfo {
+    std::string name;
+    std::string timezone;
+    std::string display_name;
+    uint64_t    version_major;
+    uint64_t    version_minor;
+    uint64_t    version_patch;
+    uint64_t    revision;
+};
+
 /// Methods of block compression.
 enum class CompressionMethod {
     None    = -1,
@@ -105,6 +115,8 @@ public:
 
     /// Reset connection with initial params.
     void ResetConnection();
+
+    const ServerInfo& GetServerInfo() const;
 
 private:
     ClientOptions options_;

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -147,6 +147,9 @@ static ColumnRef CreateColumnFromAst(const TypeAst& ast) {
                     throw std::runtime_error("LowCardinality(" + nested.name + ") is not supported");
             }
         }
+        case TypeAst::SimpleAggregateFunction: {
+            return CreateTerminalColumn(ast.elements.back());
+        }
 
         case TypeAst::Null:
         case TypeAst::Number:

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -139,7 +139,12 @@ bool TypeParser::Parse(TypeAst* type) {
                 type_ = &type_->elements.back();
                 break;
             case Token::EOS:
+            {
+                // Ubalanced braces, brackets, etc is an error.
+                if (open_elements_.size() != 1)
+                    return false;
                 return true;
+            }
             case Token::Invalid:
                 return false;
         }

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -79,6 +79,10 @@ static TypeAst::Meta GetTypeMeta(const StringView& name) {
         return TypeAst::LowCardinality;
     }
 
+    if (name == "SimpleAggregateFunction") {
+        return TypeAst::SimpleAggregateFunction;
+    }
+
     return TypeAst::Terminal;
 }
 

--- a/clickhouse/types/type_parser.h
+++ b/clickhouse/types/type_parser.h
@@ -19,6 +19,7 @@ struct TypeAst {
         Tuple,
         Enum,
         LowCardinality,
+        SimpleAggregateFunction
     };
 
     /// Type's category.

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1,6 +1,7 @@
 #include <clickhouse/columns/array.h>
 #include <clickhouse/columns/date.h>
 #include <clickhouse/columns/enum.h>
+#include <clickhouse/columns/factory.h>
 #include <clickhouse/columns/lowcardinality.h>
 #include <clickhouse/columns/nullable.h>
 #include <clickhouse/columns/numeric.h>
@@ -257,4 +258,12 @@ TEST(ColumnsCase, LowCardinalityString_Save) {
     for (size_t i = 0; i < items_count; ++i) {
         EXPECT_EQ(col.At(i), foobar(i)) << " at pos: " << i;
     }
+}
+
+TEST(ColumnsCase, CreateSimpleAggregateFunction) {
+    auto col = CreateColumnByType("SimpleAggregateFunction(funt, Int32");
+
+    ASSERT_EQ("Int32", col->Type()->GetName());
+    ASSERT_EQ(Type::Int32, col->Type()->GetCode());
+    ASSERT_NE(nullptr, col->As<ColumnInt32>());
 }

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -261,9 +261,24 @@ TEST(ColumnsCase, LowCardinalityString_Save) {
 }
 
 TEST(ColumnsCase, CreateSimpleAggregateFunction) {
-    auto col = CreateColumnByType("SimpleAggregateFunction(funt, Int32");
+    auto col = CreateColumnByType("SimpleAggregateFunction(funt, Int32)");
 
     ASSERT_EQ("Int32", col->Type()->GetName());
     ASSERT_EQ(Type::Int32, col->Type()->GetCode());
     ASSERT_NE(nullptr, col->As<ColumnInt32>());
+}
+
+
+TEST(CreateColumnByType, UnmatchedBrackets) {
+    // When type string has unmatched brackets, CreateColumnByType must return nullptr.
+    ASSERT_EQ(nullptr, CreateColumnByType("FixedString(10"));
+    ASSERT_EQ(nullptr, CreateColumnByType("Nullable(FixedString(10000"));
+    ASSERT_EQ(nullptr, CreateColumnByType("Nullable(FixedString(10000)"));
+    ASSERT_EQ(nullptr, CreateColumnByType("LowCardinality(Nullable(FixedString(10000"));
+    ASSERT_EQ(nullptr, CreateColumnByType("LowCardinality(Nullable(FixedString(10000)"));
+    ASSERT_EQ(nullptr, CreateColumnByType("LowCardinality(Nullable(FixedString(10000))"));
+    ASSERT_EQ(nullptr, CreateColumnByType("Array(LowCardinality(Nullable(FixedString(10000"));
+    ASSERT_EQ(nullptr, CreateColumnByType("Array(LowCardinality(Nullable(FixedString(10000)"));
+    ASSERT_EQ(nullptr, CreateColumnByType("Array(LowCardinality(Nullable(FixedString(10000))"));
+    ASSERT_EQ(nullptr, CreateColumnByType("Array(LowCardinality(Nullable(FixedString(10000)))"));
 }

--- a/ut/type_parser_ut.cpp
+++ b/ut/type_parser_ut.cpp
@@ -190,3 +190,20 @@ TEST(TypeParserCase, LowCardinality_FixedString) {
     auto param = TypeAst{TypeAst::Number, Type::Void, "", 10, {}};
     ASSERT_EQ(ast.elements[0].elements[0], param);
 }
+
+TEST(TypeParserCase, SimpleAggregateFunction_UInt64) {
+    TypeAst ast;
+    TypeParser("SimpleAggregateFunction(func, UInt64)").Parse(&ast);
+    ASSERT_EQ(ast.meta, TypeAst::SimpleAggregateFunction);
+    ASSERT_EQ(ast.name, "SimpleAggregateFunction");
+    ASSERT_EQ(ast.code, Type::Void);
+    ASSERT_EQ(ast.elements.size(), 2u);
+    ASSERT_EQ(ast.elements[0].name, "func");
+    ASSERT_EQ(ast.elements[0].code, Type::Void);
+    ASSERT_EQ(ast.elements[0].meta, TypeAst::Terminal);
+    ASSERT_EQ(ast.elements[0].value, 0);
+    ASSERT_EQ(ast.elements[1].name, "UInt64");
+    ASSERT_EQ(ast.elements[1].code, Type::UInt64);
+    ASSERT_EQ(ast.elements[1].meta, TypeAst::Terminal);
+    ASSERT_EQ(ast.elements[1].value, 0);
+}


### PR DESCRIPTION
Columns of `SimpleAggregateFunction(func, X)` are now handled properly and can be read from client's code as Column-`X`.