### PR TITLE
Add TCP_NODELAY option

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -169,6 +169,11 @@ void SocketHolder::SetTcpKeepAlive(int idle, int intvl, int cnt) noexcept {
 #endif
 }
 
+void SocketHolder::SetTcpNoDelay(bool nodelay) noexcept {
+    int val = nodelay;
+    setsockopt(handle_, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));
+}
+
 SocketHolder& SocketHolder::operator = (SocketHolder&& other) noexcept {
     if (this != &other) {
         Close();

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -62,6 +62,9 @@ public:
     ///         before dropping the connection.
     void SetTcpKeepAlive(int idle, int intvl, int cnt) noexcept;
 
+    /// @params nodelay whether to enable TCP_NODELAY
+    void SetTcpNoDelay(bool nodelay) noexcept;
+
     SocketHolder& operator = (SocketHolder&& other) noexcept;
 
     operator SOCKET () const noexcept;

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -277,6 +277,9 @@ void Client::Impl::ResetConnection() {
                           options_.tcp_keepalive_intvl.count(),
                           options_.tcp_keepalive_cnt);
     }
+    if (options_.tcp_nodelay) {
+        s.SetTcpNoDelay(options_.tcp_nodelay);
+    }
 
     socket_ = std::move(s);
     socket_input_ = SocketInput(socket_);

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -80,6 +80,9 @@ struct ClientOptions {
     DECLARE_FIELD(tcp_keepalive_intvl, std::chrono::seconds, SetTcpKeepAliveInterval, std::chrono::seconds(5));
     DECLARE_FIELD(tcp_keepalive_cnt, unsigned int, SetTcpKeepAliveCount, 3);
 
+    // TCP options
+    DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, false);
+
 #undef DECLARE_FIELD
 };
 

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -81,7 +81,7 @@ struct ClientOptions {
     DECLARE_FIELD(tcp_keepalive_cnt, unsigned int, SetTcpKeepAliveCount, 3);
 
     // TCP options
-    DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, false);
+    DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, true);
 
 #undef DECLARE_FIELD
 };


### PR DESCRIPTION
During benchmark, I found there are significant delay when the block is smaller than the buffer size (defaults to 8192 bytes).

Test program:

``` cpp
#include <clickhouse/client.h>
#include <cstdlib>
#include <chrono>
#include <iostream>

using namespace clickhouse;

int main(int argc, char **argv)
{
    Client client(ClientOptions().SetHost("localhost").SetPassword("qwerty"));

    client.Execute("CREATE TABLE IF NOT EXISTS test.delay (id UInt8) ENGINE = Memory");

    int count = atoi(argv[1]); // count

    for (int i = 0; i < 10; i++) {
	Block block;

	auto id = std::make_shared<ColumnUInt8>();

	for (int j = 0; j < count; j++) {
	    id->Append(65);
	}
	block.AppendColumn("id"  , id);

	auto start = std::chrono::steady_clock::now();
	client.Insert("test.delay", block);
	auto end = std::chrono::steady_clock::now();

	std::cout << std::chrono::duration_cast<std::chrono::microseconds>(end - start).count() << " ms" << std::endl;
    }

}
```

When data (8171 bytes + some header) is larger than bufffer:

``` shell
./test-insert-delay 8171
434 ms
567 ms
366 ms
252 ms
354 ms
265 ms
630 ms
237 ms
234 ms
181 ms
````

When data is  smaller than bufffer, there are significant delay:

``` shell
./test-insert-delay 8170
213 ms
155 ms
43767 ms
43270 ms
46539 ms
46627 ms
43114 ms
43273 ms
394 ms
42893 ms
```

To resolve this problem, I add an option to enable TCP_NODELAY. It's enabled by default, same as [clickhouse-client](https://github.com/ClickHouse/ClickHouse/blob/c0d1416bbd564fa1e9b3ae5e58b1a5785b5d891a/src/Client/Connection.cpp#L91).
