### PR TITLE
Added checks in ColumnFixedString::Append

### DIFF
--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -32,7 +32,7 @@ ColumnFixedString::ColumnFixedString(size_t n)
 
 void ColumnFixedString::Append(std::string_view str) {
     if (str.size() != string_size_) {
-        throw std::runtime_error("Expected string of length " + string_size_ ", received \"" + str + "\"");
+        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + str + "\"");
     }
     if (data_.capacity() - data_.size() < str.size())
     {

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -31,7 +31,10 @@ ColumnFixedString::ColumnFixedString(size_t n)
 }
 
 void ColumnFixedString::Append(std::string_view str) {
-    if (data_.capacity() < str.size())
+    if (str.size() != string_size_) {
+        throw std::runtime_error("Expected string of length " + string_size_ ", received \"" + str + "\"");
+    }
+    if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
         const auto new_size = (((data_.size() + string_size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -37,8 +37,7 @@ void ColumnFixedString::Append(std::string_view str) {
     if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
-        const auto new_size = (((data_.size() + 
-                                 _size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
+        const auto new_size = (((data_.size() + string_size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
         data_.reserve(new_size);
     }
 

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -32,12 +32,13 @@ ColumnFixedString::ColumnFixedString(size_t n)
 
 void ColumnFixedString::Append(std::string_view str) {
     if (str.size() != string_size_) {
-        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + str + "\"");
+        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + std::string(str) + "\"");
     }
     if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
-        const auto new_size = (((data_.size() + string_size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
+        const auto new_size = (((data_.size() + 
+                                 _size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
         data_.reserve(new_size);
     }
 


### PR DESCRIPTION
I added a check that a string passed to `ColumnFixedString::Append` has appropriate size.

Before that passing string with wrong size led to surprising behaviour such as hanging on insertion to database or errors in clickhouse server telling "wrong data length".