### PR TITLE
FixedString::Append checks

### DIFF
--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -32,7 +32,7 @@ ColumnFixedString::ColumnFixedString(size_t n)
 
 void ColumnFixedString::Append(std::string_view str) {
     if (str.size() != string_size_) {
-        throw std::runtime_error("Expected string of length " + string_size_ ", received \"" + str + "\"");
+        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + str + "\"");
     }
     if (data_.capacity() - data_.size() < str.size())
     {

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -31,7 +31,10 @@ ColumnFixedString::ColumnFixedString(size_t n)
 }
 
 void ColumnFixedString::Append(std::string_view str) {
-    if (data_.capacity() < str.size())
+    if (str.size() != string_size_) {
+        throw std::runtime_error("Expected string of length " + string_size_ ", received \"" + str + "\"");
+    }
+    if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
         const auto new_size = (((data_.size() + string_size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -31,9 +31,12 @@ ColumnFixedString::ColumnFixedString(size_t n)
 }
 
 void ColumnFixedString::Append(std::string_view str) {
-    if (str.size() != string_size_) {
-        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + std::string(str) + "\"");
+    if (str.size() > string_size_) {
+        throw std::runtime_error("Expected string of length not greater than "
+                                 + std::to_string(string_size_) + " bytes, received "
+                                 + std::to_string(str.size()) + " bytes.");
     }
+
     if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
@@ -42,6 +45,9 @@ void ColumnFixedString::Append(std::string_view str) {
     }
 
     data_.insert(data_.size(), str);
+    // Pad up to string_size_ with zeroes.
+    const auto padding_size = string_size_ - str.size();
+    data_.resize(data_.size() + padding_size, char(0));
 }
 
 void ColumnFixedString::Clear() {

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -37,8 +37,7 @@ void ColumnFixedString::Append(std::string_view str) {
     if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
-        const auto new_size = (((data_.size() + 
-                                 _size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
+        const auto new_size = (((data_.size() + string_size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
         data_.reserve(new_size);
     }
 

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -32,12 +32,13 @@ ColumnFixedString::ColumnFixedString(size_t n)
 
 void ColumnFixedString::Append(std::string_view str) {
     if (str.size() != string_size_) {
-        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + str + "\"");
+        throw std::runtime_error("Expected string of length " + std::to_string(string_size_) + ", received \"" + std::string(str) + "\"");
     }
     if (data_.capacity() - data_.size() < str.size())
     {
         // round up to the next block size
-        const auto new_size = (((data_.size() + string_size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
+        const auto new_size = (((data_.size() + 
+                                 _size_) / DEFAULT_BLOCK_SIZE) + 1) * DEFAULT_BLOCK_SIZE;
         data_.reserve(new_size);
     }
 

--- a/clickhouse/columns/string.h
+++ b/clickhouse/columns/string.h
@@ -18,6 +18,14 @@ public:
 
     explicit ColumnFixedString(size_t n);
 
+    template <typename Values>
+    ColumnFixedString(size_t n, const Values & values)
+        : ColumnFixedString(n)
+    {
+        for (const auto & v : values)
+            Append(v);
+    }
+
     /// Appends one element to the column.
     void Append(std::string_view str);
 


### PR DESCRIPTION
Similar to #59, but more ClickHouse - way: strings that are smaller are padded with zeroes, larger strings cause an exception (https://clickhouse.tech/docs/en/sql-reference/data-types/fixedstring/)

Closes #59