### PR TITLE
Force gnu++17 for building (for is_fundamental_v<__int128>==1)

### DIFF
--- a/cmake/cpp17.cmake
+++ b/cmake/cpp17.cmake
@@ -4,5 +4,7 @@ MACRO (USE_CXX17)
     ELSE ()
       SET (CMAKE_CXX_STANDARD 17)
       SET (CMAKE_CXX_STANDARD_REQUIRED ON)
+      # require gnu++17 over c++17 for std::is_fundamental_v<__int128>==1
+      SET (CMAKE_CXX_EXTENSIONS ON)
     ENDIF ()
 ENDMACRO (USE_CXX17)


### PR DESCRIPTION
Since:
- `-std=gnu++17: std::is_fundamental_v<__int128> == 1`
- `-std=c++17:   std::is_fundamental_v<__int128> == 0`

And there is code that requires __int128 "to be fundamental"