### PR TITLE
Fix TCP_NODELAY in Windows

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -171,7 +171,11 @@ void SocketHolder::SetTcpKeepAlive(int idle, int intvl, int cnt) noexcept {
 
 void SocketHolder::SetTcpNoDelay(bool nodelay) noexcept {
     int val = nodelay;
+#if defined(_unix_)
     setsockopt(handle_, IPPROTO_TCP, TCP_NODELAY, &val, sizeof(val));
+#else
+    setsockopt(handle_, IPPROTO_TCP, TCP_NODELAY, (const char*)&val, sizeof(val));
+#endif
 }
 
 SocketHolder& SocketHolder::operator = (SocketHolder&& other) noexcept {


### PR DESCRIPTION
`setsockopt` on Windows has slightly different signature.