### PR TITLE
Allow users to explicitly access LowCardinality<WrappedColumn> columns as WrappedColumn

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -14,6 +14,7 @@ SET ( clickhouse-cpp-lib-src
     columns/ip4.cpp
     columns/ip6.cpp
     columns/lowcardinality.cpp
+    columns/lowcardinalityadaptor.h
     columns/nullable.cpp
     columns/numeric.cpp
     columns/string.cpp

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -455,6 +455,9 @@ bool Client::Impl::ReadBlock(Block* block, CodedInputStream* input) {
         return false;
     }
 
+    CreateColumnByTypeSettings create_column_settings;
+    create_column_settings.low_cardinality_as_wrapped_column = options_.backward_compatibility_lowcardinality_as_wrapped_column;
+
     std::string name;
     std::string type;
     for (size_t i = 0; i < num_columns; ++i) {
@@ -465,7 +468,7 @@ bool Client::Impl::ReadBlock(Block* block, CodedInputStream* input) {
             return false;
         }
 
-        if (ColumnRef col = CreateColumnByType(type)) {
+        if (ColumnRef col = CreateColumnByType(type, create_column_settings)) {
             if (num_rows && !col->Load(input, num_rows)) {
                 throw std::runtime_error("can't load");
             }

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -83,6 +83,14 @@ struct ClientOptions {
     // TCP options
     DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, true);
 
+    /** It helps to ease migration of the old codebases, which can't afford to switch
+    * to using ColumnLowCardinalityT or ColumnLowCardinality directly,
+    * but still want to benefit from smaller on-wire LowCardinality bandwidth footprint.
+    *
+    * @see LowCardinalitySerializationAdaptor, CreateColumnByType
+    */
+    DECLARE_FIELD(backward_compatibility_lowcardinality_as_wrapped_column, bool, SetBakcwardCompatibilityFeatureLowCardinalityAsWrappedColumn, true);
+
 #undef DECLARE_FIELD
 };
 

--- a/clickhouse/columns/factory.h
+++ b/clickhouse/columns/factory.h
@@ -4,6 +4,11 @@
 
 namespace clickhouse {
 
-ColumnRef CreateColumnByType(const std::string& type_name);
+struct CreateColumnByTypeSettings
+{
+    bool low_cardinality_as_wrapped_column = false;
+};
+
+ColumnRef CreateColumnByType(const std::string& type_name, CreateColumnByTypeSettings settings = {});
 
 }

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -109,7 +109,7 @@ public:
     {}
 
     // Create LC<T> column from existing T-column, making a deep copy of all contents.
-    explicit ColumnLowCardinalityT(const std::shared_ptr<DictionaryColumnType>& dictionary_col)
+    explicit ColumnLowCardinalityT(std::shared_ptr<DictionaryColumnType> dictionary_col)
         : ColumnLowCardinality(dictionary_col),
           typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary())),
           type_(typed_dictionary_.Type()->GetCode())

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -105,7 +105,12 @@ public:
 
     template <typename ...Args>
     explicit ColumnLowCardinalityT(Args &&... args)
-        : ColumnLowCardinality(std::make_shared<DictionaryColumnType>(std::forward<Args>(args)...)),
+        : ColumnLowCardinalityT(std::make_shared<DictionaryColumnType>(std::forward<Args>(args)...))
+    {}
+
+    // Create LC<T> column from existing T-column, making a deep copy of all contents.
+    explicit ColumnLowCardinalityT(const std::shared_ptr<DictionaryColumnType> dictionary_col)
+        : ColumnLowCardinality(dictionary_col),
           typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary())),
           type_(typed_dictionary_.Type()->GetCode())
     {}

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -109,7 +109,7 @@ public:
     {}
 
     // Create LC<T> column from existing T-column, making a deep copy of all contents.
-    explicit ColumnLowCardinalityT(const std::shared_ptr<DictionaryColumnType> dictionary_col)
+    explicit ColumnLowCardinalityT(const std::shared_ptr<DictionaryColumnType>& dictionary_col)
         : ColumnLowCardinality(dictionary_col),
           typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary())),
           type_(typed_dictionary_.Type()->GetCode())

--- a/clickhouse/columns/lowcardinalityadaptor.h
+++ b/clickhouse/columns/lowcardinalityadaptor.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "column.h"
+#include "lowcardinality.h"
+
+#include <cassert>
+
+namespace clickhouse {
+
+class CodedOutputStream;
+class CodedInputStream;
+
+/** Adapts any ColumnType to be serialized\deserialized as LowCardinality,
+ *  and to be castable to ColumnType via ColumnPtr->As<ColumnType>().
+ *
+ * It helps to ease migration of the old codebases, which can't afford to switch
+ * to using ColumnLowCardinalityT or ColumnLowCardinality directly,
+ * but still want to benefit from smaller on-wire LowCardinality bandwidth footprint.
+ *
+ * Not intended to be used by users directly.
+ *
+ * @see ClientOptions, CreateColumnByType
+ */
+template <typename AdaptedColumnType>
+class LowCardinalitySerializationAdaptor : public AdaptedColumnType
+{
+public:
+    using AdaptedColumnType::AdaptedColumnType;
+
+    /// Loads column data from input stream.
+    bool Load(CodedInputStream* input, size_t rows) override {
+        auto new_data_column = this->Slice(0, 0)->template As<AdaptedColumnType>();
+
+        ColumnLowCardinalityT<AdaptedColumnType> low_cardinality_col(new_data_column);
+        if (!low_cardinality_col.Load(input, rows))
+            return false;
+
+        // It safe to reuse `flat_data_column` later since ColumnLowCardinalityT makes a deep copy, but still check just in case.
+        assert(new_data_column->Size() == 0);
+
+        for (size_t i = 0; i < low_cardinality_col.Size(); ++i)
+            new_data_column->Append(low_cardinality_col[i]);
+
+        this->Swap(*new_data_column);
+        return true;
+    }
+
+    /// Saves column data to output stream.
+    void Save(CodedOutputStream* output) override {
+        ColumnLowCardinalityT<AdaptedColumnType>(this->template As<AdaptedColumnType>()).Save(output);
+    }
+};
+
+}

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -631,6 +631,19 @@ TEST(ColumnsCase, UnmatchedBrackets) {
     ASSERT_EQ(nullptr, CreateColumnByType("Array(LowCardinality(Nullable(FixedString(10000)))"));
 }
 
+TEST(ColumnsCase, LowCardinalityAsWrappedColumn) {
+    // When type string has unmatched brackets, CreateColumnByType must return nullptr.
+    CreateColumnByTypeSettings create_column_settings;
+    create_column_settings.low_cardinality_as_wrapped_column = true;
+
+    ASSERT_EQ(Type::String, CreateColumnByType("LowCardinality(String)", create_column_settings)->GetType().GetCode());
+    ASSERT_EQ(Type::String, CreateColumnByType("LowCardinality(String)", create_column_settings)->As<ColumnString>()->GetType().GetCode());
+
+    ASSERT_EQ(Type::FixedString, CreateColumnByType("LowCardinality(FixedString(10000))", create_column_settings)->GetType().GetCode());
+    ASSERT_EQ(Type::FixedString, CreateColumnByType("LowCardinality(FixedString(10000))", create_column_settings)->As<ColumnFixedString>()->GetType().GetCode());
+}
+
+
 class ColumnsCaseWithName : public ::testing::TestWithParam<const char* /*Column Type String*/>
 {};
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -632,7 +632,6 @@ TEST(ColumnsCase, UnmatchedBrackets) {
 }
 
 TEST(ColumnsCase, LowCardinalityAsWrappedColumn) {
-    // When type string has unmatched brackets, CreateColumnByType must return nullptr.
     CreateColumnByTypeSettings create_column_settings;
     create_column_settings.low_cardinality_as_wrapped_column = true;
 


### PR DESCRIPTION
Ease migration of the old codebases, which can't afford to switch to using ColumnLowCardinalityT or ColumnLowCardinality directly, but still want to benefit from smaller on-wire LowCardinality bandwidth footprint.

Please [see test](https://github.com/ClickHouse/clickhouse-cpp/compare/master...Enmk:LowCardinality_as_wrapped_column?expand=1#diff-d72200167c0e04ada10b43afbfed7c51247357076f27386ca07b4be7a876a7deR240) for details.