### PR TITLE
Fixes #66  to allow using absl::int128 as Int128

### DIFF
--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -135,7 +135,7 @@ void ColumnDateTime64::Append(const Int64& value) {
 
 Int64 ColumnDateTime64::At(size_t n) const {
     // make sure to use Absl's Int128 conversion
-    return static_cast<long long>(data_->At(n));
+    return static_cast<Int64>(data_->At(n));
 }
 
 void ColumnDateTime64::Append(ColumnRef column) {

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -134,7 +134,8 @@ void ColumnDateTime64::Append(const Int64& value) {
 //}
 
 Int64 ColumnDateTime64::At(size_t n) const {
-    return data_->At(n);
+    // make sure to use Absl's Int128 conversion
+    return static_cast<long long>(data_->At(n));
 }
 
 void ColumnDateTime64::Append(ColumnRef column) {

--- a/clickhouse/columns/decimal.cpp
+++ b/clickhouse/columns/decimal.cpp
@@ -1,7 +1,5 @@
 #include "decimal.h"
 
-#include <iostream>
-
 namespace
 {
 using namespace clickhouse;

--- a/clickhouse/columns/itemview.cpp
+++ b/clickhouse/columns/itemview.cpp
@@ -3,52 +3,69 @@
 namespace clickhouse {
 
 void ItemView::ValidateData(Type::Code type, DataType data) {
-    static const int ANY = -1; // value can be of any size
-    static const int ERR = -2; // value is not allowed inside ItemView
-    static const int value_size_by_type[] = {
-        0,   /*Void*/
-        1,   /*Int8*/
-        2,   /*Int16*/
-        4,   /*Int32*/
-        8,   /*Int64*/
-        1,   /*UInt8*/
-        2,   /*UInt16*/
-        4,   /*UInt32*/
-        8,   /*UInt64*/
-        4,   /*Float32*/
-        8,   /*Float64*/
-        ANY, /*String*/
-        ANY, /*FixedString*/
-        4,   /*DateTime*/
-        2,   /*Date*/
-        ERR, /*Array*/
-        ERR, /*Nullable*/
-        ERR, /*Tuple*/
-        1,   /*Enum8*/
-        2,   /*Enum16*/
-        16,  /*UUID*/
-        4,   /*IPv4*/
-        8,   /*IPv6*/
-        16,  /*Int128*/
-        16,  /*Decimal*/
-        4,   /*Decimal32*/
-        8,   /*Decimal64*/
-        16,  /*Decimal128*/
-        ERR, /*LowCardinality*/
-        8,   /*DateTime64*/
-    };
+    int expected_size = 0;
+    switch (type) {
+        case Type::Code::Void:
+            expected_size = 0;
+            break;
 
-    if (type >= sizeof(value_size_by_type)/sizeof(value_size_by_type[0]) || type < 0) {
-        throw std::runtime_error("Unknon type code:" + std::to_string(static_cast<int>(type)));
-    } else {
-        const auto expected_size = value_size_by_type[type];
-        if (expected_size == ERR) {
+        case Type::Code::Int8:
+        case Type::Code::UInt8:
+        case Type::Code::Enum8:
+            expected_size = 1;
+            break;
+
+        case Type::Code::Int16:
+        case Type::Code::UInt16:
+        case Type::Code::Date:
+        case Type::Code::Enum16:
+            expected_size = 2;
+            break;
+
+        case Type::Code::Int32:
+        case Type::Code::UInt32:
+        case Type::Code::Float32:
+        case Type::Code::DateTime:
+        case Type::Code::IPv4:
+        case Type::Code::Decimal32:
+            expected_size = 4;
+            break;
+
+        case Type::Code::Int64:
+        case Type::Code::UInt64:
+        case Type::Code::Float64:
+        case Type::Code::DateTime64:
+        case Type::Code::IPv6:
+        case Type::Code::Decimal64:
+            expected_size = 8;
+            break;
+
+        case Type::Code::String:
+        case Type::Code::FixedString:
+            // value can be of any size
+            return;
+
+        case Type::Code::Array:
+        case Type::Code::Nullable:
+        case Type::Code::Tuple:
+        case Type::Code::LowCardinality:
             throw std::runtime_error("Unsupported type in ItemView: " + std::to_string(static_cast<int>(type)));
-        } else if (expected_size != ANY && expected_size != static_cast<int>(data.size())) {
-            throw std::runtime_error("Value size mismatch for type "
-                    + std::to_string(static_cast<int>(type)) + " expected: "
-                    + std::to_string(expected_size) + ", got: " + std::to_string(data.size()));
-        }
+
+        case Type::Code::UUID:
+        case Type::Code::Int128:
+        case Type::Code::Decimal:
+        case Type::Code::Decimal128:
+            expected_size = 16;
+            break;
+
+        default:
+            throw std::runtime_error("Unknon type code:" + std::to_string(static_cast<int>(type)));
+    }
+
+    if (expected_size != static_cast<int>(data.size())) {
+        throw std::runtime_error("Value size mismatch for type "
+                + std::to_string(static_cast<int>(type)) + " expected: "
+                + std::to_string(expected_size) + ", got: " + std::to_string(data.size()));
     }
 }
 

--- a/clickhouse/columns/itemview.cpp
+++ b/clickhouse/columns/itemview.cpp
@@ -20,7 +20,6 @@ void ItemView::ValidateData(Type::Code type, DataType data) {
         ANY, /*String*/
         ANY, /*FixedString*/
         4,   /*DateTime*/
-        8,   /*DateTime64*/
         2,   /*Date*/
         ERR, /*Array*/
         ERR, /*Nullable*/
@@ -36,6 +35,7 @@ void ItemView::ValidateData(Type::Code type, DataType data) {
         8,   /*Decimal64*/
         16,  /*Decimal128*/
         ERR, /*LowCardinality*/
+        8,   /*DateTime64*/
     };
 
     if (type >= sizeof(value_size_by_type)/sizeof(value_size_by_type[0]) || type < 0) {

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -26,13 +26,10 @@ private:
     inline auto ConvertToStorageValue(const T& t) {
         if constexpr (std::is_same_v<std::string_view, T> || std::is_same_v<std::string, T>) {
             return std::string_view{t};
-        } else if constexpr (std::is_fundamental_v<T>) {
-            return std::string_view{reinterpret_cast<const char*>(&t), sizeof(T)};
-        }
-        else if constexpr (std::is_same_v<Int128, std::decay_t<T>>) {
+        } else if constexpr (std::is_fundamental_v<T> || std::is_same_v<Int128, std::decay_t<T>>) {
             return std::string_view{reinterpret_cast<const char*>(&t), sizeof(T)};
         } else {
-            // will caue error at compile-time
+            // will cause a compile-time error
             return;
         }
     }

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -58,7 +58,7 @@ public:
     T get() const {
         if constexpr (std::is_same_v<std::string_view, T> || std::is_same_v<std::string, T>) {
             return data;
-        } else if constexpr (std::is_fundamental_v<T>) {
+        } else if constexpr (std::is_fundamental_v<T> || std::is_same_v<Int128, T>) {
             if (sizeof(T) == data.size()) {
                 return *reinterpret_cast<const T*>(data.data());
             } else {

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -28,6 +28,9 @@ private:
             return std::string_view{t};
         } else if constexpr (std::is_fundamental_v<T>) {
             return std::string_view{reinterpret_cast<const char*>(&t), sizeof(T)};
+        }
+        else if constexpr (std::is_same_v<Int128, std::decay_t<T>>) {
+            return std::string_view{reinterpret_cast<const char*>(&t), sizeof(T)};
         } else {
             // will caue error at compile-time
             return;

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -29,7 +29,7 @@ private:
         } else if constexpr (std::is_fundamental_v<T> || std::is_same_v<Int128, std::decay_t<T>>) {
             return std::string_view{reinterpret_cast<const char*>(&t), sizeof(T)};
         } else {
-            // will cause a compile-time error
+            static_assert(!std::is_same_v<T, T>, "Unknown type, which can't be stored in ItemView");
             return;
         }
     }

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -10,6 +10,9 @@
 
 namespace clickhouse {
 
+using Int128 = absl::int128;
+using Int64 = int64_t;
+
 using TypeRef = std::shared_ptr<class Type>;
 
 class Type {

--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -3,6 +3,7 @@ ADD_EXECUTABLE (clickhouse-cpp-ut
 
     client_ut.cpp
     columns_ut.cpp
+    itemview_ut.cpp
     socket_ut.cpp
     stream_ut.cpp
     type_parser_ut.cpp

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -403,6 +403,62 @@ TEST(ColumnsCase, UUIDSlice) {
     ASSERT_EQ(sub->At(1), UInt128(0x3507213c178649f9llu, 0x9faf035d662f60aellu));
 }
 
+TEST(ColumnsCase, Int128) {
+    auto col = std::make_shared<ColumnInt128>(std::vector<Int128>{
+            absl::MakeInt128(0xffffffffffffffffll, 0xffffffffffffffffll), // -1
+            absl::MakeInt128(0, 0xffffffffffffffffll),  // 2^64
+            absl::MakeInt128(0xffffffffffffffffll, 0),
+            absl::MakeInt128(0x8000000000000000ll, 0),
+            Int128(0)
+    });
+    EXPECT_EQ(-1, col->At(0));
+    EXPECT_EQ(0xffffffffffffffffll, col->At(1));
+    EXPECT_EQ(0, col->At(4));
+}
+
+TEST(ColumnsCase, ColumnDecimal128_from_string) {
+    auto col = std::make_shared<ColumnDecimal>(38, 0);
+
+    const auto values = {
+        Int128(0),
+        Int128(-1),
+        Int128(1),
+        std::numeric_limits<Int128>::min() + 1,
+        std::numeric_limits<Int128>::max(),
+    };
+
+    for (size_t i = 0; i < values.size(); ++i)
+    {
+        const auto value = values.begin()[i];
+        SCOPED_TRACE(::testing::Message() << "# index: " << i << " Int128 value: " << value);
+
+        {
+            std::stringstream sstr;
+            sstr << value;
+            const auto string_value = sstr.str();
+
+            EXPECT_NO_THROW(col->Append(string_value));
+        }
+
+        ASSERT_EQ(i + 1, col->Size());
+        EXPECT_EQ(value, col->At(i));
+    }
+}
+
+TEST(ColumnsCase, ColumnDecimal128_from_string_overflow) {
+    auto col = std::make_shared<ColumnDecimal>(38, 0);
+
+    // 2^128 overflows
+    EXPECT_ANY_THROW(col->Append("340282366920938463463374607431768211456"));
+    // special case for number bigger than 2^128, ending in zeroes.
+    EXPECT_ANY_THROW(col->Append("400000000000000000000000000000000000000"));
+
+#ifndef ABSL_HAVE_INTRINSIC_INT128
+    // unfortunatelly std::numeric_limits<Int128>::min() overflows when there is no __int128 intrinsic type.
+    EXPECT_ANY_THROW(col->Append("-170141183460469231731687303715884105728"));
+#endif
+}
+
 TEST(ColumnsCase, ColumnLowCardinalityString_Append_and_Read) {
     const size_t items_count = 11;
     ColumnLowCardinalityT<ColumnString> col;

--- a/ut/itemview_ut.cpp
+++ b/ut/itemview_ut.cpp
@@ -1,0 +1,212 @@
+#include <clickhouse/columns/itemview.h>
+#include <clickhouse/columns/numeric.h>
+
+#include <contrib/gtest/gtest.h>
+#include "utils.h"
+
+#include <string_view>
+#include <limits>
+
+namespace
+{
+using namespace clickhouse;
+}
+
+TEST(ItemView, StorableTypes) {
+/// Validate that is it possible to store proper value of a proper type into a ItemView.
+
+#define TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, NativeValue) \
+    EXPECT_EQ(static_cast<NativeType>(NativeValue), ItemView(TypeCode, static_cast<NativeType>(NativeValue)).get<NativeType>()) \
+        << " TypeCode:" << #TypeCode << " NativeType: " << #NativeType;
+
+#define TEST_ITEMVIEW_TYPE_VALUES(TypeCode, NativeType) \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, std::numeric_limits<NativeType>::min()); \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, std::numeric_limits<NativeType>::min() + 1); \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, -1); \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, 0); \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, 1); \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, std::numeric_limits<NativeType>::max() - 1); \
+    TEST_ITEMVIEW_TYPE_VALUE(TypeCode, NativeType, std::numeric_limits<NativeType>::max());
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Int8,  int8_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Int16, int16_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Int32, int32_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Int64, int64_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Int128, Int128);
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::UInt8,  uint8_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::UInt16, uint16_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::UInt32, uint32_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::UInt64, uint64_t);
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Float32, float);
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::Float32, float, 0.5);
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Float64, double);
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::Float64, double, 0.5);
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Date,       uint16_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::DateTime,   uint32_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::DateTime64, int64_t);
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Decimal,    Int128);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Decimal32,  int32_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Decimal64,  int64_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Decimal128, Int128);
+
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Enum8, uint8_t);
+    TEST_ITEMVIEW_TYPE_VALUES(Type::Code::Enum16, uint16_t);
+
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::String, std::string_view, "");
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::String, std::string_view, "here is a string");
+
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::FixedString, std::string_view, "");
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::FixedString, std::string_view, "here is a string");
+}
+
+#define TEST_ITEMVIEW_ERROR(TypeCode, NativeType) \
+    EXPECT_ANY_THROW(ItemView(TypeCode, static_cast<NativeType>(0))) \
+        << " TypeCode:" << #TypeCode << " NativeType: " << #NativeType;
+
+TEST(ItemView, ErrorTypes) {
+    // Types that is impossible to store certain Type::Code into an ItemView.
+    TEST_ITEMVIEW_ERROR(Type::Code::Array, int);
+    TEST_ITEMVIEW_ERROR(Type::Code::Nullable, int);
+    TEST_ITEMVIEW_ERROR(Type::Code::Tuple, int);
+    TEST_ITEMVIEW_ERROR(Type::Code::LowCardinality, int);
+}
+
+TEST(ItemView, TypeSizeMismatch) {
+    // Validate that it is impossible to initialize ItemView with mismatching Type::Code and native value.
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Int8,  int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int8,  int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int8,  int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int8,  Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Int16, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int16, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int16, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int16, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Int32, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int32, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int32, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int32, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Int64, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int64, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int64, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int64, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Int128, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int128, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int128, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Int128, int64_t);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt8,  int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt8,  int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt8,  int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt8,  Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt16, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt16, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt16, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt16, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt32, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt32, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt32, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt32, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt64, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt64, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt64, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::UInt64, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Float32, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float32, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float32, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float32, Int128);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float32, double);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Float64, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float64, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float64, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float64, Int128);
+    TEST_ITEMVIEW_ERROR(Type::Code::Float64, float);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Date, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Date, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Date, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Date, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime64, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime64, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime64, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::DateTime64, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal, int64_t);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal32, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal32, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal32, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal32, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal64, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal64, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal64, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal64, Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal128, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal128, int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal128, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Decimal128, int64_t);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum8,  int16_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum8,  int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum8,  int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum8,  Int128);
+
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum16, int8_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum16, int32_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum16, int64_t);
+    TEST_ITEMVIEW_ERROR(Type::Code::Enum16, Int128);
+}
+
+TEST(ItemView, Int128_values) {
+    const auto vals = {
+        std::numeric_limits<Int128>::min() + 2,
+        std::numeric_limits<Int128>::min() + 1,
+        std::numeric_limits<Int128>::min(),
+        absl::MakeInt128(0xffffffffffffffffll - 2, 0),
+        absl::MakeInt128(0xffffffffffffffffll - 1, 0),
+        absl::MakeInt128(0xffffffffffffffffll, 0),
+        absl::MakeInt128(0xffffffffffffffffll, 0xffffffffffffffffll),
+        absl::MakeInt128(0, 0xffffffffffffffffll - 2),
+        absl::MakeInt128(0, 0xffffffffffffffffll - 1),
+        absl::MakeInt128(0, 0xffffffffffffffffll),
+        Int128(-1),
+        Int128(0),
+        Int128(1),
+        std::numeric_limits<Int128>::max() - 2,
+        std::numeric_limits<Int128>::max() - 1,
+        std::numeric_limits<Int128>::max(),
+    };
+
+    for (size_t i = 0; i < vals.size(); ++i)
+    {
+        const auto value = vals.begin()[i];
+        const ItemView item_view(Type::Code::Decimal128, value);
+
+        EXPECT_EQ(value, item_view.get<Int128>()) << "# index: " << i << " Int128 value: " << value;
+    }
+}


### PR DESCRIPTION
Fixed multiple compile-time issues using `absl::int128` as `clickhouse::Int128`
Fixed storing `Int128` value to `ItemView`

Added tests:
* Basic cases for `Int128` numeric columns
* Parsing `Decimal128` values from a string (basic and with overflow)
* `ItemView` construction tests (both positive and negative cases)

Known limitations:
* Overflow checks are broken for std::numeric_limits<Int128>::min() when there is no __int128.

Closes: #73 
Closes: #72 