### PR TITLE
Ensure that users can create Int128 and UUID columns

### DIFF
--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -44,6 +44,8 @@ static ColumnRef CreateTerminalColumn(const TypeAst& ast) {
         return std::make_shared<ColumnInt32>();
     case Type::Int64:
         return std::make_shared<ColumnInt64>();
+    case Type::Int128:
+        return std::make_shared<ColumnInt128>();
 
     case Type::Float32:
         return std::make_shared<ColumnFloat32>();

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -40,6 +40,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
     { "UUID",        Type::UUID },
     { "IPv4",        Type::IPv4 },
     { "IPv6",        Type::IPv6 },
+    { "Int128",      Type::Int128 },
     { "Decimal",     Type::Decimal },
     { "Decimal32",   Type::Decimal32 },
     { "Decimal64",   Type::Decimal64 },

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -285,7 +285,7 @@ inline TypeRef Type::CreateSimple<int64_t>() {
 }
 
 template <>
-inline TypeRef Type::CreateSimple<absl::int128>() {
+inline TypeRef Type::CreateSimple<Int128>() {
     return TypeRef(new Type(Int128));
 }
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -712,7 +712,8 @@ TEST_P(ColumnsCaseWithName, CreateColumnByType)
 INSTANTIATE_TEST_CASE_P(Basic, ColumnsCaseWithName, ::testing::Values(
     "Int8", "Int16", "Int32", "Int64",
     "UInt8", "UInt16", "UInt32", "UInt64",
-    "String", "Date", "DateTime"
+    "String", "Date", "DateTime",
+    "UUID", "Int128"
 ));
 
 INSTANTIATE_TEST_CASE_P(Parametrized, ColumnsCaseWithName, ::testing::Values(


### PR DESCRIPTION
Fixed bug of not being able to create Int128 from type name string.
Added test to ensure that users can create Int128 and UUID columns.