### PR TITLE
Allow clients that lack absl to built and use the library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,13 @@ matrix:
 
 before_install: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+    set -x
     sudo apt-get install apt-transport-https ca-certificates dirmngr
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4
     echo "deb https://repo.clickhouse.tech/deb/stable/ main/" | sudo tee \
         /etc/apt/sources.list.d/clickhouse.list
-    sudo apt-get update -q && sudo apt-get install -q -y --allow-unauthenticated clickhouse-server
+    sudo apt-get update -q
+    sudo apt-get install -q -y --allow-unauthenticated clickhouse-server
     sudo service clickhouse-server start
   fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,14 @@ before_install: |
   fi
 
 # Build steps
-script:
-  - eval "${MATRIX_EVAL}"
-  - mkdir build
-  - cd build
-  - cmake .. -DBUILD_TESTS=ON && make
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ut/clickhouse-cpp-ut ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./ut/clickhouse-cpp-ut --gtest_filter=-"Client/*:*Performance*" ; fi
+script: |
+  eval "${MATRIX_EVAL}"
+  mkdir build
+  cd build
+  cmake .. -DBUILD_TESTS=ON && cmake --build . --target all
+  if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ut/clickhouse-cpp-ut ; fi
+  if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./ut/clickhouse-cpp-ut --gtest_filter=-"Client/*:*Performance*" ; fi
+  # Test clients that do not have absl in the system still can be built
+  cmake --build . --target install . && cmake --build . --target clean
+  cd ./tests/simple && mkdir build && cd ./build
+  cmake .. -DBUILD_SAMPLE_WITH_INT128=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON && cmake --build . --target all

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ matrix:
 
 before_install: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-    set -x
     sudo apt-get install apt-transport-https ca-certificates dirmngr
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv E0C56BD4
     echo "deb https://repo.clickhouse.tech/deb/stable/ main/" | sudo tee \
@@ -59,6 +58,6 @@ script: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./ut/clickhouse-cpp-ut ; fi
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ./ut/clickhouse-cpp-ut --gtest_filter=-"Client/*:*Performance*" ; fi
   # Test clients that do not have absl in the system still can be built
-  cmake --build . --target install . && cmake --build . --target clean
-  cd ./tests/simple && mkdir build && cd ./build
+  cmake --install . && cmake --build . --target clean
+  cd ../tests/simple && mkdir build && cd ./build
   cmake .. -DBUILD_SAMPLE_WITH_INT128=ON -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON && cmake --build . --target all

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,9 +10,9 @@ PROJECT (CLICKHOUSE-CLIENT)
 
     USE_CXX17()
 
-	IF ("${CMAKE_BUILD_TYPE}" STREQUAL "")
-		set(CMAKE_BUILD_TYPE "Debug")
-	ENDIF()
+    IF ("${CMAKE_BUILD_TYPE}" STREQUAL "")
+        set(CMAKE_BUILD_TYPE "Debug")
+    ENDIF()
 
     IF (UNIX)
         IF (APPLE)
@@ -43,4 +43,4 @@ PROJECT (CLICKHOUSE-CLIENT)
             tests/simple
             ut
         )
-	ENDIF (BUILD_TESTS)
+    ENDIF (BUILD_TESTS)

--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -100,3 +100,4 @@ INSTALL(FILES columns/uuid.h DESTINATION include/clickhouse/columns/)
 # types
 INSTALL(FILES types/type_parser.h DESTINATION include/clickhouse/types/)
 INSTALL(FILES types/types.h DESTINATION include/clickhouse/types/)
+INSTALL(FILES types/int128.h DESTINATION include/clickhouse/types/)

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -1,5 +1,7 @@
 #include "date.h"
 
+#include "../types/int128.h"
+
 namespace clickhouse {
 
 ColumnDate::ColumnDate()

--- a/clickhouse/columns/decimal.cpp
+++ b/clickhouse/columns/decimal.cpp
@@ -1,5 +1,7 @@
 #include "decimal.h"
 
+#include "../types/int128.h"
+
 namespace
 {
 using namespace clickhouse;
@@ -117,6 +119,10 @@ ColumnDecimal::ColumnDecimal(TypeRef type, ColumnRef data)
 {
 }
 
+void ColumnDecimal::Append(Int64 value) {
+    Append(static_cast<Int128>(value));
+}
+
 void ColumnDecimal::Append(const Int128& value) {
     if (data_->Type()->GetCode() == Type::Int32) {
         data_->As<ColumnInt32>()->Append(static_cast<ColumnInt32::DataType>(value));
@@ -189,6 +195,10 @@ Int128 ColumnDecimal::At(size_t i) const {
         default:
             throw std::runtime_error("Invalid data_ column type in ColumnDecimal");
     }
+}
+
+Int64 ColumnDecimal::AtAsInt64(size_t i) const {
+    return static_cast<Int64>(At(i));
 }
 
 void ColumnDecimal::Append(ColumnRef column) {

--- a/clickhouse/columns/decimal.h
+++ b/clickhouse/columns/decimal.h
@@ -12,10 +12,12 @@ class ColumnDecimal : public Column {
 public:
     ColumnDecimal(size_t precision, size_t scale);
 
+    void Append(Int64 value); /// When Int128 is not supported by\not available to users.
     void Append(const Int128& value);
     void Append(const std::string& value);
 
     Int128 At(size_t i) const;
+    Int64 AtAsInt64(size_t i) const; /// result will overflow if value doesn't fit into Int64.
 
 public:
     void Append(ColumnRef column) override;

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -16,6 +16,7 @@
 #include "uuid.h"
 
 #include "../types/type_parser.h"
+#include "../types/int128.h"
 
 #include <stdexcept>
 

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -1,6 +1,8 @@
 #include "numeric.h"
 #include "utils.h"
 
+#include "../types/int128.h"
+
 namespace clickhouse {
 
 template <typename T>

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include "column.h"
-#include "absl/numeric/int128.h"
+
+namespace absl
+{
+class int128;
+}
 
 namespace clickhouse {
 

--- a/clickhouse/types/int128.h
+++ b/clickhouse/types/int128.h
@@ -1,0 +1,9 @@
+#pragma once
+
+/// In a separate header to allow basic non-Int128 functionality on systems that lack absl.
+#include <absl/numeric/int128.h>
+
+namespace clickhouse
+{
+using Int128 = absl::int128;
+}

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "absl/numeric/int128.h"
-
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
 #include <stdexcept>
+
+namespace absl
+{
+class int128;
+}
 
 namespace clickhouse {
 

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -2,6 +2,12 @@ ADD_EXECUTABLE (simple-test
 	main.cpp
 )
 
+OPTION(BUILD_SAMPLE_WITH_INT128 "Build sample program with Int128 support" ON)
+
 TARGET_LINK_LIBRARIES (simple-test
 	clickhouse-cpp-lib
 )
+
+if (BUILD_TESTS_WITH_INT128)
+    target_compile_definitions(simple-test WITH_INT128)
+endif()

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1,6 +1,8 @@
 #include <clickhouse/client.h>
 #include <contrib/gtest/gtest.h>
 
+#include <clickhouse/types/int128.h>
+
 #include <cmath>
 
 using namespace clickhouse;

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -7,6 +7,7 @@
 #include <clickhouse/columns/numeric.h>
 #include <clickhouse/columns/string.h>
 #include <clickhouse/columns/uuid.h>
+#include <clickhouse/types/int128.h>
 
 #include <contrib/gtest/gtest.h>
 #include "utils.h"

--- a/ut/itemview_ut.cpp
+++ b/ut/itemview_ut.cpp
@@ -1,5 +1,6 @@
 #include <clickhouse/columns/itemview.h>
 #include <clickhouse/columns/numeric.h>
+#include <clickhouse/types/int128.h>
 
 #include <contrib/gtest/gtest.h>
 #include "utils.h"


### PR DESCRIPTION
Moved Int128 definition to a separate header
Added few extra methods to ColumnDecimal that do not rely on Int128
Ensured that client programs can be built without absl headers present.

closes: #86 