### PR TITLE
Allow macOS builds to compile and run SSL tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -13,9 +13,10 @@ on:
       extra_install:
         required: false
         type: string
-      gtest_args:
+      gtest_filter:
         required: false
         type: string
+        default: "*"
 
 env:
   BUILD_TYPE: Release
@@ -44,8 +45,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      run: |
-        sudo apt-get install -y ${{ matrix.INSTALL }} ${{ inputs.extra_install }}
+      run: sudo apt-get install -y cmake ${{ matrix.INSTALL }} ${{ inputs.extra_install }}
 
     - name: Configure CMake
       run: |
@@ -56,11 +56,8 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON \
           ${{ inputs.extra_cmake_flags }}
 
-
     - name: Build
-      # Build your program with the given configuration
-      run: |
-        cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target all
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target all
 
     - name: Start ClickHouse server
       run: |
@@ -76,4 +73,4 @@ jobs:
 
     - name: Test
       working-directory: ${{github.workspace}}/build/ut
-      run: ./clickhouse-cpp-ut "${{ inputs.gtest_args }}"
+      run: ./clickhouse-cpp-ut --gtest_filter="${{inputs.gtest_filter}}"

--- a/.github/workflows/linux_ssl.yml
+++ b/.github/workflows/linux_ssl.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
   build-and-test:
-    uses: Enmk/clickhouse-cpp/.github/workflows/linux.yml@master
+    uses: ClickHouse/clickhouse-cpp/.github/workflows/linux.yml@master
     with:
       extra_cmake_flags: -DWITH_OPENSSL=ON
       extra_install: libssl-dev
-#      gtest_args: --gtest_filter="-*LocalhostTLS*"
+#     gtest_filter: "-*LocalhostTLS*"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -5,26 +5,42 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_call:
+    inputs:
+      extra_cmake_flags:
+        required: false
+        type: string
+      extra_install:
+        required: false
+        type: string
+      gtest_filter:
+        required: false
+        type: string
+        default: "*"
 
 env:
   BUILD_TYPE: Release
-  # It is impossible to start CH server in docker on macos due to github actions limitations,
-  # so limit tests to ones that do no require server interaction.
-  GTEST_FILTER: --gtest_filter=-"Client/*:*Performance*"
 
 jobs:
   build:
-    runs-on: macos-11
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v2
 
+    - name: Install dependencies
+      run: brew install cmake ${{inputs.extra_install}}
+
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON ${{inputs.extra_cmake_flags}}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --target all
 
     - name: Test
       working-directory: ${{github.workspace}}/build/ut
-      run: ./clickhouse-cpp-ut "${{env.GTEST_FILTER}}"
+      env:
+        # It is impossible to start CH server in docker on macOS due to github actions limitations,
+        # so limit tests to ones that do no require server interaction.
+        GTEST_FILTER_ONLY_LOCAL: "-Client/*"
+      run: ./clickhouse-cpp-ut --gtest_filter="${{inputs.gtest_filter}}:${{env.GTEST_FILTER_ONLY_LOCAL}}"

--- a/.github/workflows/macos_ssl.yml
+++ b/.github/workflows/macos_ssl.yml
@@ -1,0 +1,16 @@
+name: macOS-ssl
+# Almost the same as regular macOS builds, BUT with enabled SSL support, requires OpenSSL installed via Homebrew (openssl@1.1)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-and-test:
+    uses: ClickHouse/clickhouse-cpp/.github/workflows/macos.yml@master
+    with:
+      extra_cmake_flags: -DWITH_OPENSSL=ON
+      extra_install: openssl
+#     gtest_filter: "-*LocalhostTLS*"

--- a/ut/ssl_ut.cpp
+++ b/ut/ssl_ut.cpp
@@ -24,6 +24,8 @@ namespace {
 // On Ubuntu 20.04 /etc/ssl/certs is a default directory with the CA files
 const auto DEAFULT_CA_DIRECTORY_PATH = "/etc/ssl/certs";
 #elif defined(__APPLE__)
+// On macOS we will rely on Homebrew's OpenSSL installation
+const auto DEAFULT_CA_DIRECTORY_PATH = "/usr/local/etc/openssl@1.1/cert.pem";
 #elif defined(_win_)
 #endif
 


### PR DESCRIPTION
Assuming OpenSSL from Homebrew is installed.