### PR TITLE
Fix for MSVC compilation

### DIFF
--- a/clickhouse/columns/decimal.cpp
+++ b/clickhouse/columns/decimal.cpp
@@ -29,7 +29,7 @@ inline bool mulOverflow(const Int128 & l, const T & r, Int128 * result)
 template <typename T>
 inline bool getSignBit(const T & v)
 {
-    return std::signbit(v);
+    return v < static_cast<T>(0);
 }
 
 inline bool getSignBit(const Int128 & v)


### PR DESCRIPTION
On the MSVC compiler I had a compilation problem in this section of code. The problem was that `std::signbit` was only used for floats, but part of the code used this function for ints. 

The compiler error was ` Error C2668: 'signbit': ambiguous overloaded function call'.
The compiler version is 19.29