### PR TITLE
Add support for MSVC

### DIFF
--- a/.github/workflows/windows_msvc.yml
+++ b/.github/workflows/windows_msvc.yml
@@ -1,0 +1,60 @@
+name: Windows
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  BUILD_TYPE: Release
+  GTEST_FILTER: --gtest_filter=-"*"
+  CLICKHOUSE_USER: clickhouse_cpp_cicd
+  CLICKHOUSE_PASSWORD: clickhouse_cpp_cicd
+  #
+  # CLICKHOUSE_HOST: localhost
+  # CLICKHOUSE_PORT: 9000
+  # CLICKHOUSE_USER: default
+  # CLICKHOUSE_PASSWORD:
+  # CLICKHOUSE_DB:   default
+  #
+  # CLICKHOUSE_SECURE_HOST:     github.demo.trial.altinity.cloud
+  # CLICKHOUSE_SECURE_PORT:     9440
+  # CLICKHOUSE_SECURE_USER:     demo
+  # CLICKHOUSE_SECURE_PASSWORD: demo
+  # CLICKHOUSE_SECURE_DB:       default
+  #
+  # CLICKHOUSE_SECURE2_HOST:    gh-api.clickhouse.tech
+  # CLICKHOUSE_SECURE2_PORT:    9440
+  # CLICKHOUSE_SECURE2_USER:    explorer
+  # CLICKHOUSE_SECURE2_PASSWORD:
+  # CLICKHOUSE_SECURE2_DB:      default
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ilammy/msvc-dev-cmd@v1
+
+    - name: Configure CMake
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBUILD_TESTS=ON
+
+    - name: Build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+
+    - name: Start tls offoader proxy
+      shell: bash
+      # that mimics non-secure clickhouse running on localhost
+      # by tunneling queries to remote tls server
+      # (needed because we can't start real clickhouse instance on windows)
+      run: |
+            choco install wget
+            wget https://github.com/filimonov/go-tlsoffloader/releases/download/v0.1.2/go-tlsoffloader_0.1.2_Windows_x86_64.tar.gz
+            tar -xvzf go-tlsoffloader_0.1.2_Windows_x86_64.tar.gz
+            ./go-tlsoffloader.exe -l localhost:9000 -b github.demo.trial.altinity.cloud:9440 &
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build/ut
+      run: Release\clickhouse-cpp-ut.exe "${{env.GTEST_FILTER}}"

--- a/clickhouse/base/compressed.cpp
+++ b/clickhouse/base/compressed.cpp
@@ -142,7 +142,7 @@ void CompressedOutput::Compress(const void * data, size_t len) {
             (const char*)data,
             (char*)compressed_buffer_.data() + HEADER_SIZE,
             len,
-            compressed_buffer_.size() - HEADER_SIZE);
+            static_cast<int>(compressed_buffer_.size() - HEADER_SIZE));
     if (compressed_size <= 0)
         throw std::runtime_error("Failed to compress chunk of " + std::to_string(len) + " bytes, "
                 "LZ4 error: " + std::to_string(compressed_size));
@@ -164,7 +164,7 @@ void CompressedOutput::Compress(const void * data, size_t len) {
 }
 
 void CompressedOutput::PreallocateCompressBuffer(size_t input_size) {
-    const auto estimated_compressed_buffer_size = LZ4_compressBound(input_size);
+    const auto estimated_compressed_buffer_size = LZ4_compressBound(static_cast<int>(input_size));
     if (estimated_compressed_buffer_size <= 0)
         throw std::runtime_error("Failed to estimate compressed buffer size, LZ4 error: " + std::to_string(estimated_compressed_buffer_size));
 

--- a/clickhouse/base/platform.h
+++ b/clickhouse/base/platform.h
@@ -13,6 +13,8 @@
 
 #if defined(_win32_) || defined(_win64_)
 #   define _win_
+#   define _WIN32_WINNT 0x0600    // The WSAPoll function is defined on Windows Vista and later.
+#   define WIN32_LEAN_AND_MEAN 1  // don't include too much header automatically
 #endif
 
 #if defined(_linux_) || defined (_darwin_)

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include "platform.h"
 #include "input.h"
 #include "output.h"
-#include "platform.h"
 
 #include <cstddef>
 #include <string>
@@ -24,7 +24,7 @@
 #endif
 
 #include <memory>
-
+#include <system_error>
 
 struct addrinfo;
 
@@ -47,6 +47,17 @@ private:
     struct addrinfo* info_;
 };
 
+#if defined(_win_)
+
+class windowsErrorCategory : public std::error_category {
+public:
+    char const* name() const noexcept override final;
+    std::string message(int c) const override final;
+
+    static windowsErrorCategory const& category();
+};
+
+#endif
 
 class Socket {
 public:

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -328,9 +328,10 @@ void Client::Impl::ResetConnection() {
         socket = std::make_unique<Socket>(address);
 
     if (options_.tcp_keepalive) {
-        socket->SetTcpKeepAlive(options_.tcp_keepalive_idle.count(),
-                          options_.tcp_keepalive_intvl.count(),
-                          options_.tcp_keepalive_cnt);
+        socket->SetTcpKeepAlive(
+                static_cast<int>(options_.tcp_keepalive_idle.count()),
+                static_cast<int>(options_.tcp_keepalive_intvl.count()),
+                static_cast<int>(options_.tcp_keepalive_cnt));
     }
     if (options_.tcp_nodelay) {
         socket->SetTcpNoDelay(options_.tcp_nodelay);

--- a/clickhouse/columns/decimal.cpp
+++ b/clickhouse/columns/decimal.cpp
@@ -134,7 +134,7 @@ void ColumnDecimal::Append(const std::string& value) {
     bool sign = true;
     bool has_dot = false;
 
-    int zeros = 0;
+    size_t zeros = 0;
 
     while (c != end) {
         if (*c == '-') {

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -3,7 +3,7 @@ ADD_EXECUTABLE (simple-test
 )
 
 TARGET_LINK_LIBRARIES (simple-test
-	clickhouse-cpp-lib
+	clickhouse-cpp-lib-static
 )
 
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -25,7 +25,7 @@ ADD_EXECUTABLE (clickhouse-cpp-ut
 )
 
 TARGET_LINK_LIBRARIES (clickhouse-cpp-ut
-    clickhouse-cpp-lib
+    clickhouse-cpp-lib-static
     gtest-lib
 )
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -457,8 +457,17 @@ TEST(ColumnsCase, Int128) {
             absl::MakeInt128(0x8000000000000000ll, 0),
             Int128(0)
     });
+
     EXPECT_EQ(-1, col->At(0));
-    EXPECT_EQ(0xffffffffffffffffll, col->At(1));
+
+    EXPECT_EQ(absl::MakeInt128(0, 0xffffffffffffffffll), col->At(1));
+    EXPECT_EQ(0ll,                   absl::Int128High64(col->At(1)));
+    EXPECT_EQ(0xffffffffffffffffull, absl::Int128Low64(col->At(1)));
+
+    EXPECT_EQ(absl::MakeInt128(0xffffffffffffffffll, 0), col->At(2));
+    EXPECT_EQ(static_cast<int64_t>(0xffffffffffffffffll),  absl::Int128High64(col->At(2)));
+    EXPECT_EQ(0ull,                  absl::Int128Low64(col->At(2)));
+
     EXPECT_EQ(0, col->At(4));
 }
 

--- a/ut/readonly_client_test.cpp
+++ b/ut/readonly_client_test.cpp
@@ -18,6 +18,8 @@ void ReadonlyClientTest::TearDown() {
     client_.reset();
 }
 
+// Sometimes gtest fails to detect that this test is instantiated elsewhere, suppress the error explicitly.
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ReadonlyClientTest);
 TEST_P(ReadonlyClientTest, Select) {
 
     const auto & queries = std::get<1>(GetParam());

--- a/ut/utils.h
+++ b/ut/utils.h
@@ -39,9 +39,8 @@ struct Timer
 private:
     static auto Now()
     {
-        struct timespec ts;
-        clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
-        return std::chrono::nanoseconds(ts.tv_sec * 1000000000LL + ts.tv_nsec);
+        std::chrono::nanoseconds ns = std::chrono::high_resolution_clock::now().time_since_epoch();
+        return ns;
     }
 
 private:


### PR DESCRIPTION
* github action for msvc added. Closes #130
* there is an issue with dynamic linking & DLL paths when compiling tests. I've switched tests to static linking
* added tls offoader proxy for windows tests, mimicking local clickhouse by tunneling the queries to a cloud instance of clickhouse
* get proper status codes via WSAGetLastError for windows, fixes #127 

Known issues:
- no support for secure connections (need to reimplement secure_socket with sspi.h and other windows thing). Maybe can work with openssl (not tested).
- there are some warnings at compile time