### PR TITLE
CI/CD: fixing  MacOS OpenSSL variant

### DIFF
--- a/.github/workflows/macos_ssl.yml
+++ b/.github/workflows/macos_ssl.yml
@@ -14,4 +14,4 @@ jobs:
       extra_cmake_flags: -DWITH_OPENSSL=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/
       extra_install: openssl
       # There is no CH server running locally, so disable tests that try to connect to it.
-      gtest_filter: "-*ColumnPerformanceTest*:-*ClientCase*"
+      gtest_filter: "-*Client*:*Local*:*ColumnPerformanceTest*"

--- a/.github/workflows/macos_ssl.yml
+++ b/.github/workflows/macos_ssl.yml
@@ -13,4 +13,5 @@ jobs:
     with:
       extra_cmake_flags: -DWITH_OPENSSL=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/
       extra_install: openssl
-#     gtest_filter: "-*LocalhostTLS*"
+      # There is no CH server running locally, so disable tests that try to connect to it.
+      gtest_filter: "-*ColumnPerformanceTest*"

--- a/.github/workflows/macos_ssl.yml
+++ b/.github/workflows/macos_ssl.yml
@@ -14,4 +14,4 @@ jobs:
       extra_cmake_flags: -DWITH_OPENSSL=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/
       extra_install: openssl
       # There is no CH server running locally, so disable tests that try to connect to it.
-      gtest_filter: "-*ColumnPerformanceTest*"
+      gtest_filter: "-*ColumnPerformanceTest*:-*ClientCase*"

--- a/.github/workflows/macos_ssl.yml
+++ b/.github/workflows/macos_ssl.yml
@@ -11,6 +11,6 @@ jobs:
   build-and-test:
     uses: ClickHouse/clickhouse-cpp/.github/workflows/macos.yml@master
     with:
-      extra_cmake_flags: -DWITH_OPENSSL=ON
+      extra_cmake_flags: -DWITH_OPENSSL=ON -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl/
       extra_install: openssl
 #     gtest_filter: "-*LocalhostTLS*"


### PR DESCRIPTION
Setting OPENSSL_ROOT_DIR to a directory where brew usually installs openssl