### PR TITLE
fix: avoid throwing exception in destructor

### DIFF
--- a/clickhouse/base/compressed.cpp
+++ b/clickhouse/base/compressed.cpp
@@ -111,7 +111,16 @@ CompressedOutput::CompressedOutput(OutputStream * destination, size_t max_compre
 }
 
 CompressedOutput::~CompressedOutput() {
-    Flush();
+    try
+    {
+        Flush();
+    }
+    catch (...)
+    {
+        // That means we've failed to flush some data e.g. to the socket,
+        // but there is nothing we can do at this point (can't bring the socket back),
+        // and throwing in destructor is really a bad idea.
+    }
 }
 
 size_t CompressedOutput::DoWrite(const void* data, size_t len) {


### PR DESCRIPTION
When data compression is enabled,  `CompressedOutput` will be created in `Client::Impl::SendData`. If the socket is unfortunately broken during the execution of `SocketOutput::DoWrite`, a `std::system_error` exception will be thrown. Next, the destructor of `CompressedOutput` will be called during stack unwinding, and then `Flush()` in `~CompressedOutput` will call `SocketOutput::DoWrite` again, eventually causing the program to terminate.
