### PR TITLE
OpenSSL updates: allow to configure or skip verification

### DIFF
--- a/clickhouse/base/sslsocket.h
+++ b/clickhouse/base/sslsocket.h
@@ -3,6 +3,8 @@
 #include "socket.h"
 
 #include <memory>
+#include <optional>
+#include <vector>
 
 typedef struct ssl_ctx_st SSL_CTX;
 typedef struct ssl_st SSL;
@@ -18,6 +20,10 @@ struct SSLParams
     int min_protocol_version;
     int max_protocol_version;
     bool use_SNI;
+    bool skip_verification;
+    int host_flags;
+    using ConfigurationType = std::vector<std::pair<std::string, std::optional<std::string>>>;
+    ConfigurationType configuration;
 };
 
 class SSLContext

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <optional>
 
 #if defined(WITH_OPENSSL)
 typedef struct ssl_ctx_st SSL_CTX;
@@ -105,10 +106,7 @@ struct ClientOptions {
      */
     DECLARE_FIELD(max_compression_chunk_size, unsigned int, SetMaxCompressionChunkSize, 65535);
 
-#if defined(WITH_OPENSSL)
     struct SSLOptions {
-        bool use_ssl = true; // not expected to be set manually.
-
         /** There are two ways to configure an SSL connection:
          *  - provide a pre-configured SSL_CTX, which is not modified and not owned by the Client.
          *  - provide a set of options and allow the Client to create and configure SSL_CTX by itself.
@@ -118,6 +116,9 @@ struct ClientOptions {
          *  If NOT null client DONES NOT take ownership of context and it must be valid for client lifetime.
          *  If null client initlaizes OpenSSL and creates his own context, initializes it using
          *  other options, like path_to_ca_files, path_to_ca_directory, use_default_ca_locations, etc.
+         *
+         *  Either way context is used to create an SSL-connection, which is then configured with
+         *  whatever was provided as `configuration`, `host_flags`, `skip_verification` and `use_sni`.
          */
         SSL_CTX * ssl_context = nullptr;
         auto & SetExternalSSLContext(SSL_CTX * new_ssl_context) {
@@ -147,16 +148,45 @@ struct ClientOptions {
         */
         DECLARE_FIELD(context_options, int, SetContextOptions, DEFAULT_VALUE);
 
-        /** Use SNI at ClientHello and verify that certificate is issued to the hostname we are trying to connect to
+        /** Use SNI at ClientHello
          */
         DECLARE_FIELD(use_sni, bool, SetUseSNI, true);
+
+        /** Skip SSL session verification (server's certificate, etc).
+         *
+         *  WARNING: settig to true will bypass all SSL session checks, which
+         *  is dangerous, but can be used against self-signed certificates, e.g. for testing purposes.
+         */
+        DECLARE_FIELD(skip_verification, bool, SetSkipVerification, false);
+
+        /** Mode of verifying host ssl certificate against name of the host, set with SSL_set_hostflags.
+         *  For details see https://www.openssl.org/docs/man1.1.1/man3/SSL_set_hostflags.html
+         */
+        DECLARE_FIELD(host_flags, int, SetHostVerifyFlags, DEFAULT_VALUE);
+
+        struct CommandAndValue {
+            std::string command;
+            std::optional<std::string> value = std::nullopt;
+        };
+        /** Extra configuration options, set with SSL_CONF_cmd.
+         *  For deatils see https://www.openssl.org/docs/man1.1.1/man3/SSL_CONF_cmd.html
+         *
+         *  Takes multiple pairs of command-value strings, all commands are supported,
+         *  and prefix is empty.
+         *  i.e. pass `sigalgs` or `SignatureAlgorithms` instead of `-sigalgs`.
+         *
+         *  Rewrites any other options/flags if set in other ways.
+         */
+        DECLARE_FIELD(configuration, std::vector<CommandAndValue>, SetConfiguration, {});
 
         static const int DEFAULT_VALUE = -1;
     };
 
-    // By default SSL is turned off, hence the `{false}`
-    DECLARE_FIELD(ssl_options, SSLOptions, SetSSLOptions, {false});
-#endif
+    // By default SSL is turned off.
+    std::optional<SSLOptions> ssl_options = std::nullopt;
+
+    // Will throw an exception if client was built without SSL support.
+    ClientOptions& SetSSLOptions(SSLOptions options);
 
 #undef DECLARE_FIELD
 };

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -1,4 +1,5 @@
 ADD_EXECUTABLE (simple-test
+    ../../ut/utils.cpp
 	main.cpp
 )
 

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -894,27 +894,31 @@ const auto QUERIES = std::vector<std::string>{"SELECT version()", "SELECT fqdn()
 }
 
 INSTANTIATE_TEST_SUITE_P(ClientLocalReadonly, ReadonlyClientTest,
-                         ::testing::Values(ReadonlyClientTest::ParamType{
-                             ClientOptions()
-                                 .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
-                                 .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_PORT",     "9000")))
-                                 .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
-                                 .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
-                                 .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
-                                 .SetSendRetries(1)
-                                 .SetPingBeforeQuery(true)
-                                 .SetCompressionMethod(CompressionMethod::None),
-                             QUERIES}));
+    ::testing::Values(ReadonlyClientTest::ParamType{
+        ClientOptions()
+            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
+            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_PORT",     "9000")))
+            .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
+            .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
+            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
+            .SetSendRetries(1)
+            .SetPingBeforeQuery(true)
+            .SetCompressionMethod(CompressionMethod::None),
+        QUERIES
+    }
+));
 
 INSTANTIATE_TEST_SUITE_P(ClientLocalFailed, ConnectionFailedClientTest,
-                         ::testing::Values(ConnectionFailedClientTest::ParamType{
-                             ClientOptions()
-                                 .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
-                                 .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_PORT",     "9000")))
-                                 .SetUser("non_existing_user_clickhouse_cpp_test")
-                                 .SetPassword("wrongpwd")
-                                 .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
-                                 .SetSendRetries(1)
-                                 .SetPingBeforeQuery(true)
-                                 .SetCompressionMethod(CompressionMethod::None),
-                             "Authentication failed: password is incorrect"}));
+    ::testing::Values(ConnectionFailedClientTest::ParamType{
+        ClientOptions()
+            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
+            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_PORT",     "9000")))
+            .SetUser("non_existing_user_clickhouse_cpp_test")
+            .SetPassword("wrongpwd")
+            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
+            .SetSendRetries(1)
+            .SetPingBeforeQuery(true)
+            .SetCompressionMethod(CompressionMethod::None),
+        ExpectingException{"Authentication failed: password is incorrect"}
+    }
+));

--- a/ut/connection_failed_client_test.cpp
+++ b/ut/connection_failed_client_test.cpp
@@ -14,7 +14,7 @@ namespace {
 TEST_P(ConnectionFailedClientTest, ValidateConnectionError) {
 
     const auto & client_options = std::get<0>(GetParam());
-    const auto & exception_message = std::get<1>(GetParam());
+    const auto & ee = std::get<1>(GetParam());
 
     std::unique_ptr<Client> client;
     try {
@@ -22,7 +22,7 @@ TEST_P(ConnectionFailedClientTest, ValidateConnectionError) {
         ASSERT_EQ(nullptr, client.get()) << "Connectiong established but it should have failed";
     } catch (const std::exception & e) {
         const auto message = std::string_view(e.what());
-        ASSERT_TRUE(message.find(exception_message) != std::string_view::npos)
+        ASSERT_TRUE(message.find(ee.exception_message) != std::string_view::npos)
                 << "Actual exception message: " << e.what() << std::endl;
     }
 }

--- a/ut/connection_failed_client_test.h
+++ b/ut/connection_failed_client_test.h
@@ -7,6 +7,11 @@
 #include <tuple>
 #include <string>
 
+// Just a wrapper to stand out from strings.
+struct ExpectingException {
+    std::string exception_message;
+};
+
 /// Verify that connection fails with some specific message.
 class ConnectionFailedClientTest : public testing::TestWithParam<
-        std::tuple<clickhouse::ClientOptions, std::string /*error message*/>> {};
+        std::tuple<clickhouse::ClientOptions, ExpectingException>> {};

--- a/ut/ssl_ut.cpp
+++ b/ut/ssl_ut.cpp
@@ -40,7 +40,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(ReadonlyClientTest::ParamType {
         ClientOptions()
             .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE_HOST",     "github.demo.trial.altinity.cloud"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE_PORT",     "9440")))
+            .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_SECURE_PORT",     "9440"))
             .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE_USER",     "demo"))
             .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE_PASSWORD", "demo"))
             .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE_DB",       "default"))
@@ -53,60 +53,115 @@ INSTANTIATE_TEST_SUITE_P(
     }
 ));
 
+
+const auto ClickHouseExplorerConfig = ClientOptions()
+        .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
+        .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_SECURE2_PORT",     "9440"))
+        .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
+        .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
+        .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
+        .SetSendRetries(1)
+        .SetPingBeforeQuery(true)
+        .SetCompressionMethod(CompressionMethod::None);
+
+
 INSTANTIATE_TEST_SUITE_P(
     Remote_GH_API_TLS, ReadonlyClientTest,
     ::testing::Values(ReadonlyClientTest::ParamType {
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE2_PORT",     "9440")))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None)
+        ClientOptions(ClickHouseExplorerConfig)
             .SetSSLOptions(ClientOptions::SSLOptions()
                     .SetPathToCADirectory(DEFAULT_CA_DIRECTORY_PATH)),
         QUERIES
     }
 ));
 
+TEST(OpenSSLConfiguration, ValidValues) {
+    // Verify that Client with valid configuration set via SetConfiguration is able to connect.
+
+    EXPECT_NO_THROW(
+        Client(ClientOptions(ClickHouseExplorerConfig)
+                .SetSSLOptions(ClientOptions::SSLOptions()
+                        .SetConfiguration({
+                                {"VerifyCAPath", DEFAULT_CA_DIRECTORY_PATH},
+                                {"MinProtocol", "TLSv1.3"},
+                                {"VerifyMode", "Peer"},
+                                {"no_comp"} // shorthand for command with no value
+                        })
+        ))
+    );
+}
+
+TEST(OpenSSLConfiguration, InValidValues) {
+    // Verify that invalid options cause throwing exception.
+    std::vector<ClientOptions::SSLOptions::CommandAndValue> configurations = {
+        {"VerifyCAPath", std::nullopt},              // missing required value
+        {"VerifyCAPath"},                            // missing required value, shorthand
+        {"MinProtocol", "NOT A STRING"},             // invalid value
+        {"MinProtocol", ""},                         // invalid value
+        {"unknownCommand"},                          // invalid command, shorthand
+        {"unknownCommand", "with unexpected value"}, // invalid command + some value
+        {"", std::nullopt},                          // empty command with no value
+        {""},                                        // empty command with no value
+        {"no_comp", "unexpected value"}              // value for command that doesn't require a value.
+    };
+
+    // Unfortunately, there is no way of checking configuration validity without
+    // creating a Client and pointing that client to a working CH server.
+    // So we mix valid and invalid configurations by providing the correct
+    // server config but incorrect single Command-Value pair individually.
+    for (const auto & cv : configurations) {
+        EXPECT_ANY_THROW(
+            Client(ClientOptions(ClickHouseExplorerConfig)
+                    .SetSSLOptions(ClientOptions::SSLOptions()
+                            .SetConfiguration({cv})
+            ));
+        ) << "On command \'" << cv.command << "\' and value: " << (cv.value ? *cv.value : "<EMPTY>");
+    }
+}
+
+
+//INSTANTIATE_TEST_SUITE_P(
+//    Remote_GH_API_TLS_WithStringConfig, ReadonlyClientTest,
+//    ::testing::Values(ReadonlyClientTest::ParamType {
+//        ClientOptions(ClickHouseExplorerConfig)
+//            .SetSSLOptions(ClientOptions::SSLOptions()
+//                    .SetConfiguration({{"", DEFAULT_CA_DIRECTORY_PATH}})
+//        QUERIES
+//    }
+//));
+
+INSTANTIATE_TEST_SUITE_P(
+    Remote_GH_API_TLS_no_CA, ReadonlyClientTest,
+    ::testing::Values(ReadonlyClientTest::ParamType {
+        ClientOptions(ClickHouseExplorerConfig)
+            .SetSSLOptions(ClientOptions::SSLOptions()
+                     .SetUseDefaultCALocations(false)
+                     .SetSkipVerification(true)), // No CA loaded, but verfication is skipped
+        {"SELECT 1;"}
+    }
+));
+
 INSTANTIATE_TEST_SUITE_P(
     Remote_GH_API_TLS_no_CA, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType {
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE2_PORT",     "9440")))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None)
+        ClientOptions(ClickHouseExplorerConfig)
             .SetSSLOptions(ClientOptions::SSLOptions()
                      .SetUseDefaultCALocations(false)),
-        "X509_v error: 20 unable to get local issuer certificate"
+        ExpectingException{"X509_v error: 20 unable to get local issuer certificate"}
     }
 ));
 
 INSTANTIATE_TEST_SUITE_P(
     Remote_GH_API_TLS_wrong_TLS_version, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType {
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE2_PORT",     "9440")))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None)
+        ClientOptions(ClickHouseExplorerConfig)
             .SetSSLOptions(ClientOptions::SSLOptions()
                     .SetUseDefaultCALocations(false)
                     .SetMaxProtocolVersion(SSL3_VERSION)),
-        "no protocols available"
+        ExpectingException{"no protocols available"}
     }
 ));
+
 
 //// Special test that require properly configured TLS-enabled version of CH running locally
 //INSTANTIATE_TEST_SUITE_P(

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -91,9 +91,3 @@ std::ostream& operator<<(std::ostream & ostr, const Block & block) {
 
     return ostr;
 }
-
-std::string getEnvOrDefault(const std::string& env, const std::string& default_val)
-{
-    const char* v = std::getenv(env.c_str());
-    return v ? v : default_val;
-}


### PR DESCRIPTION
Added ClientOptions:
  - skip_verification - to skip all verification
  - host_flags - to set hostname verification mode
  - configuration - to configure SSL connection

Updated and refactored tests.
Updated tests/simple/main.cpp to reuse so utility code from unit-tests.