### PR TITLE
OpenSSL updates: allow to configure or skip verification

### DIFF
--- a/clickhouse/base/sslsocket.h
+++ b/clickhouse/base/sslsocket.h
@@ -3,6 +3,8 @@
 #include "socket.h"
 
 #include <memory>
+#include <optional>
+#include <vector>
 
 typedef struct ssl_ctx_st SSL_CTX;
 typedef struct ssl_st SSL;
@@ -18,6 +20,10 @@ struct SSLParams
     int min_protocol_version;
     int max_protocol_version;
     bool use_SNI;
+    bool skip_verification;
+    int host_flags;
+    using ConfigurationType = std::vector<std::pair<std::string, std::optional<std::string>>>;
+    ConfigurationType configuration;
 };
 
 class SSLContext
@@ -42,8 +48,7 @@ private:
 
 class SSLSocket : public Socket {
 public:
-    explicit SSLSocket(const NetworkAddress& addr, const SSLParams & ssl_params,
-                       SSLContext& context);
+    explicit SSLSocket(const NetworkAddress& addr, const SSLParams & ssl_params, SSLContext& context);
     SSLSocket(SSLSocket &&) = default;
     ~SSLSocket() override = default;
 
@@ -53,6 +58,7 @@ public:
     std::unique_ptr<InputStream> makeInputStream() const override;
     std::unique_ptr<OutputStream> makeOutputStream() const override;
 
+    static void validateParams(const SSLParams & ssl_params);
 private:
     std::unique_ptr<SSL, void (*)(SSL *s)> ssl_;
 };

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -1,4 +1,5 @@
 ADD_EXECUTABLE (simple-test
+    ../../ut/utils.cpp
 	main.cpp
 )
 

--- a/ut/connection_failed_client_test.cpp
+++ b/ut/connection_failed_client_test.cpp
@@ -14,7 +14,7 @@ namespace {
 TEST_P(ConnectionFailedClientTest, ValidateConnectionError) {
 
     const auto & client_options = std::get<0>(GetParam());
-    const auto & exception_message = std::get<1>(GetParam());
+    const auto & ee = std::get<1>(GetParam());
 
     std::unique_ptr<Client> client;
     try {
@@ -22,7 +22,8 @@ TEST_P(ConnectionFailedClientTest, ValidateConnectionError) {
         ASSERT_EQ(nullptr, client.get()) << "Connectiong established but it should have failed";
     } catch (const std::exception & e) {
         const auto message = std::string_view(e.what());
-        ASSERT_TRUE(message.find(exception_message) != std::string_view::npos)
-                << "Actual exception message: " << e.what() << std::endl;
+        ASSERT_TRUE(message.find(ee.exception_message) != std::string_view::npos)
+                << "Expected exception message: " << ee.exception_message << "\n"
+                << "Actual exception message  : " << e.what() << std::endl;
     }
 }

--- a/ut/connection_failed_client_test.h
+++ b/ut/connection_failed_client_test.h
@@ -7,6 +7,11 @@
 #include <tuple>
 #include <string>
 
+// Just a wrapper to stand out from strings.
+struct ExpectingException {
+    std::string exception_message;
+};
+
 /// Verify that connection fails with some specific message.
 class ConnectionFailedClientTest : public testing::TestWithParam<
-        std::tuple<clickhouse::ClientOptions, std::string /*error message*/>> {};
+        std::tuple<clickhouse::ClientOptions, ExpectingException>> {};

--- a/ut/ssl_ut.cpp
+++ b/ut/ssl_ut.cpp
@@ -40,7 +40,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::Values(ReadonlyClientTest::ParamType {
         ClientOptions()
             .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE_HOST",     "github.demo.trial.altinity.cloud"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE_PORT",     "9440")))
+            .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_SECURE_PORT",     "9440"))
             .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE_USER",     "demo"))
             .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE_PASSWORD", "demo"))
             .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE_DB",       "default"))
@@ -53,60 +53,120 @@ INSTANTIATE_TEST_SUITE_P(
     }
 ));
 
+
+const auto ClickHouseExplorerConfig = ClientOptions()
+        .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
+        .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_SECURE2_PORT",     "9440"))
+        .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
+        .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
+        .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
+        .SetSendRetries(1)
+        .SetPingBeforeQuery(true)
+        .SetCompressionMethod(CompressionMethod::None);
+
+
 INSTANTIATE_TEST_SUITE_P(
     Remote_GH_API_TLS, ReadonlyClientTest,
     ::testing::Values(ReadonlyClientTest::ParamType {
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE2_PORT",     "9440")))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None)
+        ClientOptions(ClickHouseExplorerConfig)
             .SetSSLOptions(ClientOptions::SSLOptions()
                     .SetPathToCADirectory(DEFAULT_CA_DIRECTORY_PATH)),
         QUERIES
     }
 ));
 
+// For some reasons doen't work on MacOS.
+// Looks like `VerifyCAPath` has no effect, while parsing and setting value works.
+// Also for some reason SetPathToCADirectory() + SSL_CTX_load_verify_locations() works.
+#if !defined(__APPLE__)
+TEST(OpenSSLConfiguration, ValidValues) {
+    // Verify that Client with valid configuration set via SetConfiguration is able to connect.
+
+    EXPECT_NO_THROW(
+        Client(ClientOptions(ClickHouseExplorerConfig)
+                .SetSSLOptions(ClientOptions::SSLOptions()
+                        .SetConfiguration({
+                                {"VerifyCAPath", DEFAULT_CA_DIRECTORY_PATH},
+                                {"MinProtocol", "TLSv1.3"},
+                                {"VerifyMode", "Peer"},
+                                {"no_comp"} // shorthand for command with no value
+                        })
+        ))
+    );
+}
+#endif
+
+TEST(OpenSSLConfiguration, InValidValues) {
+    // Verify that invalid options cause throwing exception.
+    std::vector<ClientOptions::SSLOptions::CommandAndValue> configurations = {
+        {"VerifyCAPath", std::nullopt},              // missing required value
+        {"VerifyCAPath"},                            // missing required value, shorthand
+        {"MinProtocol", "NOT A STRING"},             // invalid value
+        {"MinProtocol", ""},                         // invalid value
+        {"unknownCommand"},                          // invalid command, shorthand
+        {"unknownCommand", "with unexpected value"}, // invalid command + some value
+        {"", std::nullopt},                          // empty command with no value
+        {""},                                        // empty command with no value
+        {"no_comp", "unexpected value"}              // value for command that doesn't require a value.
+    };
+
+    // Unfortunately, there is no way of checking configuration validity without
+    // creating a Client and pointing that client to a working CH server.
+    // So we mix valid and invalid configurations by providing the correct
+    // server config but incorrect single Command-Value pair individually.
+    for (const auto & cv : configurations) {
+        EXPECT_ANY_THROW(
+            Client(ClientOptions(ClickHouseExplorerConfig)
+                    .SetSSLOptions(ClientOptions::SSLOptions()
+                            .SetConfiguration({cv})
+            ));
+        ) << "On command \'" << cv.command << "\' and value: " << (cv.value ? *cv.value : "<EMPTY>");
+    }
+}
+
+
+//INSTANTIATE_TEST_SUITE_P(
+//    Remote_GH_API_TLS_WithStringConfig, ReadonlyClientTest,
+//    ::testing::Values(ReadonlyClientTest::ParamType {
+//        ClientOptions(ClickHouseExplorerConfig)
+//            .SetSSLOptions(ClientOptions::SSLOptions()
+//                    .SetConfiguration({{"", DEFAULT_CA_DIRECTORY_PATH}})
+//        QUERIES
+//    }
+//));
+
+INSTANTIATE_TEST_SUITE_P(
+    Remote_GH_API_TLS_no_CA, ReadonlyClientTest,
+    ::testing::Values(ReadonlyClientTest::ParamType {
+        ClientOptions(ClickHouseExplorerConfig)
+            .SetSSLOptions(ClientOptions::SSLOptions()
+                     .SetUseDefaultCALocations(false)
+                     .SetSkipVerification(true)), // No CA loaded, but verfication is skipped
+        {"SELECT 1;"}
+    }
+));
+
 INSTANTIATE_TEST_SUITE_P(
     Remote_GH_API_TLS_no_CA, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType {
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE2_PORT",     "9440")))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None)
+        ClientOptions(ClickHouseExplorerConfig)
             .SetSSLOptions(ClientOptions::SSLOptions()
                      .SetUseDefaultCALocations(false)),
-        "X509_v error: 20 unable to get local issuer certificate"
+        ExpectingException{"X509_v error: 20 unable to get local issuer certificate"}
     }
 ));
 
 INSTANTIATE_TEST_SUITE_P(
     Remote_GH_API_TLS_wrong_TLS_version, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType {
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE2_HOST",     "gh-api.clickhouse.tech"))
-            .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_SECURE2_PORT",     "9440")))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE2_USER",     "explorer"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE2_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE2_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None)
+        ClientOptions(ClickHouseExplorerConfig)
             .SetSSLOptions(ClientOptions::SSLOptions()
                     .SetUseDefaultCALocations(false)
                     .SetMaxProtocolVersion(SSL3_VERSION)),
-        "no protocols available"
+        ExpectingException{"no protocols available"}
     }
 ));
+
 
 //// Special test that require properly configured TLS-enabled version of CH running locally
 //INSTANTIATE_TEST_SUITE_P(

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -97,8 +97,7 @@ std::ostream& operator<<(std::ostream & ostr, const Block & block) {
     return ostr;
 }
 
-std::ostream& operator<<(std::ostream& ostr, const in_addr& addr)
-{
+std::ostream& operator<<(std::ostream& ostr, const in_addr& addr) {
     char buf[INET_ADDRSTRLEN];
     const char* ip_str = inet_ntop(AF_INET, &addr, buf, sizeof(buf));
 
@@ -108,8 +107,7 @@ std::ostream& operator<<(std::ostream& ostr, const in_addr& addr)
     return ostr << ip_str;
 }
 
-std::ostream& operator<<(std::ostream& ostr, const in6_addr& addr)
-{
+std::ostream& operator<<(std::ostream& ostr, const in6_addr& addr) {
     char buf[INET6_ADDRSTRLEN];
     const char* ip_str = inet_ntop(AF_INET6, &addr, buf, sizeof(buf));
 
@@ -117,10 +115,4 @@ std::ostream& operator<<(std::ostream& ostr, const in6_addr& addr)
         return ostr << "<!INVALID IPv6 VALUE!>";
 
     return ostr << ip_str;
-}
-
-std::string getEnvOrDefault(const std::string& env, const std::string& default_val)
-{
-    const char* v = std::getenv(env.c_str());
-    return v ? v : default_val;
 }


### PR DESCRIPTION
Added ClientOptions:
  - skip_verification - to skip all verification
  - host_flags - to set hostname verification mode
  - configuration - to configure SSL connection

Updated and refactored tests.
Updated tests/simple/main.cpp to reuse so utility code from unit-tests.

Closes: #142