### PR TITLE
Better performance for Type::IsEqual()

### DIFF
--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -99,7 +99,7 @@ uint64_t Type::GetTypeUniqueId() const {
         case IPv4:
         case IPv6:
         case Date:
-            // For non-parametric types, unique ID is the same as Type::Code
+            // For simple types, unique ID is the same as Type::Code
             return code_;
 
         case FixedString:
@@ -115,7 +115,7 @@ uint64_t Type::GetTypeUniqueId() const {
         case Decimal64:
         case Decimal128:
         case LowCardinality: {
-            // For paramatric types, exact unique ID depends on nested types and/or parameters,
+            // For complex types, exact unique ID depends on nested types and/or parameters,
             // the easiest way is to lazy-compute unique ID from name once.
             // Here we do not care if multiple thread are computing value simultaneosly since:
             //   1. it is going to be the same

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -117,9 +117,9 @@ uint64_t Type::GetTypeUniqueId() const {
         case LowCardinality: {
             // For complex types, exact unique ID depends on nested types and/or parameters,
             // the easiest way is to lazy-compute unique ID from name once.
-            // Here we do not care if multiple thread are computing value simultaneosly since:
-            //   1. it is going to be the same
-            //   2. it is going to be stored atomically
+            // Here we do not care if multiple threads are computing value simultaneosly since it is both:
+            //   1. going to be the same
+            //   2. going to be stored atomically
 
             if (type_unique_id_ == 0) {
                 const auto name = GetName();
@@ -129,6 +129,8 @@ uint64_t Type::GetTypeUniqueId() const {
             return type_unique_id_;
         }
     }
+    assert(false);
+    return 0;
 }
 
 TypeRef Type::CreateArray(TypeRef item_type) {

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -1,10 +1,15 @@
 #include "types.h"
 
+#include <cityhash/city.h>
+
 #include <stdexcept>
 
 namespace clickhouse {
 
-Type::Type(const Code code) : code_(code) {}
+Type::Type(const Code code)
+    : code_(code)
+    , type_unique_id_(0)
+{}
 
 std::string Type::GetName() const {
     switch (code_) {
@@ -70,6 +75,60 @@ std::string Type::GetName() const {
 
     // XXX: NOT REACHED!
     return std::string();
+}
+
+uint64_t Type::GetTypeUniqueId() const {
+    // Helper method to optimize equality checks of types with Type::IsEqual(),
+    // base invariant: types with same names produce same unique id (and hence considered equal).
+    // As an optimization, full type name is constructed at most once, and only for complex types.
+    switch (code_) {
+        case Void:
+        case Int8:
+        case Int16:
+        case Int32:
+        case Int64:
+        case Int128:
+        case UInt8:
+        case UInt16:
+        case UInt32:
+        case UInt64:
+        case UUID:
+        case Float32:
+        case Float64:
+        case String:
+        case IPv4:
+        case IPv6:
+        case Date:
+            // For non-parametric types, unique ID is the same as Type::Code
+            return code_;
+
+        case FixedString:
+        case DateTime:
+        case DateTime64:
+        case Array:
+        case Nullable:
+        case Tuple:
+        case Enum8:
+        case Enum16:
+        case Decimal:
+        case Decimal32:
+        case Decimal64:
+        case Decimal128:
+        case LowCardinality: {
+            // For paramatric types, exact unique ID depends on nested types and/or parameters,
+            // the easiest way is to lazy-compute unique ID from name once.
+            // Here we do not care if multiple thread are computing value simultaneosly since:
+            //   1. it is going to be the same
+            //   2. it is going to be stored atomically
+
+            if (type_unique_id_ == 0) {
+                const auto name = GetName();
+                type_unique_id_ = CityHash64WithSeed(name.c_str(), name.size(), code_);
+            }
+
+            return type_unique_id_;
+        }
+    }
 }
 
 TypeRef Type::CreateArray(TypeRef item_type) {


### PR DESCRIPTION
Performance improvement for `Type:IsEqual()`:
- it shortcuts for completely different types.
- should now be much more performant for simple types
- executes `Type::GetName()` about 1 time per type

For complex types, `Type::IsEqual()` relies on computing hash of the `Type::GetName()`, that hash is computed at least once and reused later.
In the worst case, name is generated multiple times by multiple threads if they manage to hit the same spot of the code at the same time.

According to (a quite synthetic) tests, new implementation is about ~150 times faster:
```c++
    const std::string type_names[] = {
        "UInt8",
        "Int8",
        "UInt128",
        "String",
        "FixedString(0)",
        "FixedString(10000)",
        "DateTime('UTC')",
        "DateTime64(3, 'UTC')",
        "Decimal(9,3)",
        "Decimal(18,3)",
        "Enum8()",
        "Enum16()",
        "Enum8('ONE' = 1)",
        "Enum8('ONE' = 1, 'TWO' = 2)",
        "Enum16('ONE' = 1, 'TWO' = 2, 'THREE' = 3, 'FOUR' = 4)",
        "Nullable(FixedString(10000))",
        "Nullable(LowCardinality(FixedString(10000)))",
        "Array(Int8)",
        "Array(UInt8)",
        "Array(String)",
        "Array(Nullable(LowCardinality(FixedString(10000))))",
        "Array(Enum8('ONE' = 1, 'TWO' = 2))"
        "Tuple(String, Int8, Date, DateTime)",
        "Nullable(Tuple(String, Int8, Date, DateTime))",
        "Array(Nullable(Tuple(String, Int8, Date, DateTime)))",
        "Array(Array(Nullable(Tuple(String, Int8, Date, DateTime))))",
        "Array(Array(Array(Nullable(Tuple(String, Int8, Date, DateTime)))))",
        "Array(Array(Array(Array(Nullable(Tuple(String, Int8, Date, DateTime('UTC')))))))"
        "Array(Array(Array(Array(Nullable(Tuple(String, Int8, Date, DateTime('UTC'), Tuple(LowCardinality(String), Enum8('READ'=1, 'WRITE'=0))))))))",
    };

    std::vector<TypeRef> types;
    for (const auto & type_name : type_names) {
        types.push_back(clickhouse::CreateColumnByType(type_name)->Type());
    }
    for (const auto & type_name : type_names) {
        types.push_back(clickhouse::CreateColumnByType(type_name)->Type());
    }

    {
        Timer<std::chrono::microseconds> timer;
        const auto iterations = 1000;
        for (int i = 0; i < iterations; ++i) {
            for (const auto & t1 : types) {
                for (const auto & t2 : types) {
                    t1->IsEqual(*t2);
                }
            }
        }
        std::cerr << iterations << " iterations of " << types.size() * types.size() << " comparisons took " << timer.Elapsed() << std::endl;
    }
```

Closes: #25 