### PR TITLE
"thread safe" client

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -28,7 +28,8 @@ SET ( clickhouse-cpp-lib-src
 
     block.cpp
     client.cpp
-    query.cpp
+        thread_safe_client.cpp
+        query.cpp
 )
 
 IF (WITH_OPENSSL)

--- a/clickhouse/thread_safe_client.cpp
+++ b/clickhouse/thread_safe_client.cpp
@@ -1,0 +1,49 @@
+#include "thread_safe_client.h"
+
+#include <utility>
+
+namespace clickhouse {
+
+ThreadSafeClient::ThreadSafeClient(const ClientOptions& opts) : client_(opts) {
+}
+
+void ThreadSafeClient::Execute(const Query& query) {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.Execute(query);
+}
+
+void ThreadSafeClient::Select(const std::string& query, SelectCallback cb) {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.Select(query, std::move(cb));
+}
+
+void ThreadSafeClient::SelectCancelable(const std::string& query, SelectCancelableCallback cb) {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.SelectCancelable(query, std::move(cb));
+}
+
+void ThreadSafeClient::Select(const Query& query) {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.Select(query);
+}
+
+void ThreadSafeClient::Insert(const std::string& table_name, const Block& block) {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.Insert(table_name, block);
+}
+
+void ThreadSafeClient::Ping() {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.Ping();
+}
+
+void ThreadSafeClient::ResetConnection() {
+    auto lock = std::unique_lock(stream_mutex_);
+    client_.ResetConnection();
+}
+
+const ServerInfo& ThreadSafeClient::GetServerInfo() const {
+    return client_.GetServerInfo();
+}
+
+}  // namespace clickhouse

--- a/clickhouse/thread_safe_client.h
+++ b/clickhouse/thread_safe_client.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "client.h"
+
+namespace clickhouse {
+class ThreadSafeClient {
+public:
+    explicit ThreadSafeClient(const ClientOptions& opts);
+
+    /// Intends for execute arbitrary queries.
+    void Execute(const Query& query);
+
+    /// Intends for execute select queries.  Data will be returned with
+    /// one or more call of \p cb.
+    void Select(const std::string& query, SelectCallback cb);
+
+    /// Executes a select query which can be canceled by returning false from
+    /// the data handler function \p cb.
+    void SelectCancelable(const std::string& query, SelectCancelableCallback cb);
+
+    /// Alias for Execute.
+    void Select(const Query& query);
+
+    /// Intends for insert block of data into a table \p table_name.
+    void Insert(const std::string& table_name, const Block& block);
+
+    /// Ping server for aliveness.
+    void Ping();
+
+    /// Reset connection with initial params.
+    void ResetConnection();
+
+    [[nodiscard]] const ServerInfo& GetServerInfo() const;
+
+private:
+    Client client_;
+
+    std::recursive_mutex stream_mutex_;
+};
+}  // namespace clickhouse


### PR DESCRIPTION
From previous PR #122, advice was taken and now there is a wrapper class where only 1 thread can access any method at any given time. 

There were suggestions to create some wrapper class. So now there is `ThreadSafeClient` (Might need to be renamed to `SingleThreadClient` possibly. 

`ThreadSafeClient` just wraps a regular `Client` and projects all methods with a mutex / lock. 