### PR TITLE
make ItemView compatible with libcxx

### DIFF
--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -43,7 +43,7 @@ public:
     }
 
     explicit ItemView()
-        : ItemView(Type::Void, {nullptr, 0})
+        : ItemView(Type::Void, {})
     {}
 
     template <typename T>


### PR DESCRIPTION
In libcxx version we currently use this constructor is deleted
`basic_string_view(nullptr_t, size_t) = delete;`

As of c++23 nullptr constructor is also deleted, and default constructor already does [just that](https://en.cppreference.com/w/cpp/string/basic_string_view/basic_string_view): `.data = nullptr, .size = 0` 