### PR TITLE
replace explicit string_view initialization from {nullptr, 0} with default ctor

### DIFF
--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -43,7 +43,7 @@ public:
     }
 
     explicit ItemView()
-        : ItemView(Type::Void, {nullptr, 0})
+        : ItemView(Type::Void, {})
     {}
 
     template <typename T>


### PR DESCRIPTION
Submitted on behalf of a third-party: Yandex N.V.