### PR TITLE
Add empty arrays to LC(Array) existing unit test

### DIFF
--- a/ut/array_of_low_cardinality_tests.cpp
+++ b/ut/array_of_low_cardinality_tests.cpp
@@ -72,7 +72,9 @@ TEST(ArrayOfLowCardinality, InsertAndQuery) {
 
     const auto testData = std::vector<std::vector<std::string>> {
         { "aa", "bb" },
-        { "cc" }
+        {},
+        { "cc" },
+        {}
     };
 
     auto column = buildTestColumn(testData);


### PR DESCRIPTION
In https://github.com/ClickHouse/clickhouse-cpp/issues/178 was reported that empty arrays in LC(Array) was crashing the client. This PR adds empty arrays to the existing unit test.

Not closing the issue because I am waiting for more OP information.