### PR TITLE
Various test fixes

### DIFF
--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -19,6 +19,7 @@ SET ( clickhouse-cpp-ut-src
     array_of_low_cardinality_tests.cpp
     CreateColumnByType_ut.cpp
     Column_ut.cpp
+    roundtrip_column.cpp
 
     utils.cpp
     value_generators.cpp

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -13,9 +13,12 @@
 #include <clickhouse/base/output.h>
 #include <clickhouse/base/socket.h> // for ipv4-ipv6 platform-specific stuff
 
+#include <clickhouse/client.h>
+
 #include <gtest/gtest.h>
 
 #include "utils.h"
+#include "roundtrip_column.h"
 #include "value_generators.h"
 
 namespace {
@@ -261,4 +264,21 @@ TYPED_TEST(GenericColumnTest, LoadAndSave) {
     }
 
     EXPECT_TRUE(CompareRecursive(*column_A, *column_B));
+}
+
+const auto LocalHostEndpoint = ClientOptions()
+        .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
+        .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
+        .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
+        .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
+        .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"));
+
+TYPED_TEST(GenericColumnTest, RoundTrip) {
+    auto [column, values] = this->MakeColumnWithValues(100);
+    EXPECT_EQ(values.size(), column->Size());
+
+    clickhouse::Client client(LocalHostEndpoint);
+
+    auto result_typed = RoundtripColumnValues(client, column)->template AsStrict<typename TestFixture::ColumnType>();
+    EXPECT_TRUE(CompareRecursive(*column, *result_typed));
 }

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -279,6 +279,21 @@ TYPED_TEST(GenericColumnTest, RoundTrip) {
 
     clickhouse::Client client(LocalHostEndpoint);
 
+    if constexpr (std::is_same_v<typename TestFixture::ColumnType, ColumnDate32>) {
+        // Date32 first appeared in v21.9.2.17-stable
+        const auto server_info = client.GetServerInfo();
+        if (versionNumber(server_info) < versionNumber(21, 9)) {
+            GTEST_SKIP() << "Date32 is availble since v21.9.2.17-stable and can't be tested against server: " << server_info;
+        }
+    }
+
+    if constexpr (std::is_same_v<typename TestFixture::ColumnType, ColumnInt128>) {
+        const auto server_info = client.GetServerInfo();
+        if (versionNumber(server_info) < versionNumber(21, 7)) {
+            GTEST_SKIP() << "ColumnInt128 is availble since v21.7.2.7-stable and can't be tested against server: " << server_info;
+        }
+    }
+
     auto result_typed = RoundtripColumnValues(client, column)->template AsStrict<typename TestFixture::ColumnType>();
     EXPECT_TRUE(CompareRecursive(*column, *result_typed));
 }

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -7,38 +7,10 @@
 
 #include <gtest/gtest.h>
 
-#include <cmath>
 #include <thread>
 #include <chrono>
 
 using namespace clickhouse;
-
-namespace {
-
-uint64_t versionNumber(
-        uint64_t version_major,
-        uint64_t version_minor,
-        uint64_t version_patch = 0,
-        uint64_t revision = 0) {
-
-    // in this case version_major can be up to 1000
-    static auto revision_decimal_places = 8;
-    static auto patch_decimal_places = 4;
-    static auto minor_decimal_places = 4;
-
-    auto const result = version_major * static_cast<uint64_t>(std::pow(10, minor_decimal_places + patch_decimal_places + revision_decimal_places))
-            + version_minor * static_cast<uint64_t>(std::pow(10, patch_decimal_places + revision_decimal_places))
-            + version_patch * static_cast<uint64_t>(std::pow(10, revision_decimal_places))
-            + revision;
-
-    return result;
-}
-
-uint64_t versionNumber(const ServerInfo & server_info) {
-    return versionNumber(server_info.version_major, server_info.version_minor, server_info.version_patch, server_info.revision);
-}
-
-}
 
 // Use value-parameterized tests to run same tests with different client
 // options.

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -3,6 +3,7 @@
 #include "readonly_client_test.h"
 #include "connection_failed_client_test.h"
 #include "utils.h"
+#include "roundtrip_column.h"
 
 #include <gtest/gtest.h>
 
@@ -976,35 +977,6 @@ TEST_P(ClientCase, DISABLED_ArrayArrayUInt64) {
         ASSERT_EQ(1u, row->Size());
         EXPECT_TRUE(CompareRecursive(std::vector<uint64_t>{}, *row->GetAsColumnTyped<ColumnUInt64>(0)));
     }
-}
-
-ColumnRef RoundtripColumnValues(Client& client, ColumnRef expected) {
-    // Create a temporary table with a single column
-    // insert values from `expected`
-    // select and aggregate all values from block into `result` column
-    auto result = expected->CloneEmpty();
-
-    const std::string type_name = result->GetType().GetName();
-    client.Execute("DROP TEMPORARY TABLE IF EXISTS temporary_roundtrip_table;");
-    client.Execute("CREATE TEMPORARY TABLE IF NOT EXISTS temporary_roundtrip_table (col " + type_name + ");");
-    {
-        Block block;
-        block.AppendColumn("col", expected);
-        block.RefreshRowCount();
-        client.Insert("temporary_roundtrip_table", block);
-    }
-
-    client.Select("SELECT col FROM temporary_roundtrip_table", [&result](const Block& b) {
-        if (b.GetRowCount() == 0)
-            return;
-
-        ASSERT_EQ(1u, b.GetColumnCount());
-        result->Append(b[0]);
-    });
-
-    EXPECT_EQ(expected->GetType(), result->GetType());
-    EXPECT_EQ(expected->Size(), result->Size());
-    return result;
 }
 
 TEST_P(ClientCase, RoundtripArrayTUint64) {

--- a/ut/roundtrip_column.cpp
+++ b/ut/roundtrip_column.cpp
@@ -1,0 +1,40 @@
+#include "roundtrip_column.h"
+
+#include <clickhouse/client.h>
+#include <clickhouse/block.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+using namespace clickhouse;
+}
+
+ColumnRef RoundtripColumnValues(Client& client, ColumnRef expected) {
+    // Create a temporary table with a single column
+    // insert values from `expected`
+    // select and aggregate all values from block into `result` column
+    auto result = expected->CloneEmpty();
+
+    const std::string type_name = result->GetType().GetName();
+    client.Execute("DROP TEMPORARY TABLE IF EXISTS temporary_roundtrip_table;");
+    client.Execute("CREATE TEMPORARY TABLE IF NOT EXISTS temporary_roundtrip_table (col " + type_name + ");");
+    {
+        Block block;
+        block.AppendColumn("col", expected);
+        block.RefreshRowCount();
+        client.Insert("temporary_roundtrip_table", block);
+    }
+
+    client.Select("SELECT col FROM temporary_roundtrip_table", [&result](const Block& b) {
+        if (b.GetRowCount() == 0)
+            return;
+
+        ASSERT_EQ(1u, b.GetColumnCount());
+        result->Append(b[0]);
+    });
+
+    EXPECT_EQ(expected->GetType(), result->GetType());
+    EXPECT_EQ(expected->Size(), result->Size());
+
+    return result;
+}

--- a/ut/roundtrip_column.h
+++ b/ut/roundtrip_column.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <clickhouse/columns/column.h>
+
+namespace clickhouse {
+    class Client;
+}
+
+clickhouse::ColumnRef RoundtripColumnValues(clickhouse::Client& client, clickhouse::ColumnRef expected);

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -18,6 +18,7 @@
 #include <iomanip>
 #include <sstream>
 
+
 namespace {
 using namespace clickhouse;
 std::ostream & printColumnValue(const ColumnRef& c, const size_t row, std::ostream & ostr);

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -267,3 +267,7 @@ std::ostream & operator<<(std::ostream & ostr, const ServerInfo & server_info) {
 }
 
 }
+
+uint64_t versionNumber(const ServerInfo & server_info) {
+    return versionNumber(server_info.version_major, server_info.version_minor, server_info.version_patch, server_info.revision);
+}

--- a/ut/utils.h
+++ b/ut/utils.h
@@ -11,6 +11,7 @@
 #include <system_error>
 #include <type_traits>
 #include <vector>
+#include <cmath>
 
 #include <time.h>
 
@@ -135,3 +136,24 @@ std::ostream& operator<<(std::ostream & ostr, const PrintContainer<T>& print_con
 
     return ostr << "]";
 }
+
+inline uint64_t versionNumber(
+        uint64_t version_major,
+        uint64_t version_minor,
+        uint64_t version_patch = 0,
+        uint64_t revision = 0) {
+
+    // in this case version_major can be up to 1000
+    static auto revision_decimal_places = 8;
+    static auto patch_decimal_places = 4;
+    static auto minor_decimal_places = 4;
+
+    auto const result = version_major * static_cast<uint64_t>(std::pow(10, minor_decimal_places + patch_decimal_places + revision_decimal_places))
+            + version_minor * static_cast<uint64_t>(std::pow(10, patch_decimal_places + revision_decimal_places))
+            + version_patch * static_cast<uint64_t>(std::pow(10, revision_decimal_places))
+            + revision;
+
+    return result;
+}
+
+uint64_t versionNumber(const clickhouse::ServerInfo & server_info);

--- a/ut/utils.h
+++ b/ut/utils.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <clickhouse/base/platform.h>
-#include <clickhouse/columns/uuid.h>
 
 #include "utils_meta.h"
 #include "utils_comparison.h"
@@ -18,6 +17,7 @@
 #include <gtest/gtest.h>
 
 namespace clickhouse {
+    class Client;
     class Block;
     class Type;
     struct ServerInfo;
@@ -135,5 +135,3 @@ std::ostream& operator<<(std::ostream & ostr, const PrintContainer<T>& print_con
 
     return ostr << "]";
 }
-
-

--- a/ut/value_generators.h
+++ b/ut/value_generators.h
@@ -2,6 +2,7 @@
 
 #include <clickhouse/base/socket.h> // for ipv4-ipv6 platform-specific stuff
 #include <clickhouse/columns/numeric.h>
+#include <clickhouse/columns/uuid.h>
 
 #include "utils.h"
 


### PR DESCRIPTION
Roundtrip column values to server in generic tests
Fixed `ArrayOfLowCardinality.InsertAndQuery` if `backward_compatibility_lowcardinality_as_wrapped_column` is false