### PR TITLE
Avoid memory copy in ColumnString and Add Reserve function to reduce memory allocation times

### DIFF
--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -100,6 +100,9 @@ public:
     /// @params nodelay whether to enable TCP_NODELAY
     void SetTcpNoDelay(bool nodelay) noexcept;
 
+    /// @params time the time (in seconds) the socket recv timeout.
+    void SetSocketTimeoutTime(unsigned int time) noexcept;
+
     std::unique_ptr<InputStream> makeInputStream() const override;
     std::unique_ptr<OutputStream> makeOutputStream() const override;
 

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -86,6 +86,9 @@ struct ClientOptions {
     // TCP options
     DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, true);
 
+    /// Set the socket recv timeout in seconds.
+    DECLARE_FIELD(socket_timeout_sec, unsigned int, SetSocketTimeoutTime, 0);
+
     // TODO deprecate setting
     /** It helps to ease migration of the old codebases, which can't afford to switch
     * to using ColumnLowCardinalityT or ColumnLowCardinality directly,

--- a/clickhouse/columns/array.cpp
+++ b/clickhouse/columns/array.cpp
@@ -24,6 +24,8 @@ ColumnArray::ColumnArray(ColumnArray&& other)
 {
 }
 
+void ColumnArray::Reserve(size_t rows) { data_->Reserve(rows); }
+
 void ColumnArray::AppendAsColumn(ColumnRef array) {
     if (!data_->Type()->IsEqual(array->Type())) {
         throw ValidationError(

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -46,6 +46,9 @@ public:
     }
 
 public:
+    /// Reserve column capacity to reduce memory allocation times.
+    void Reserve(size_t rows) override;
+
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
 

--- a/clickhouse/columns/column.h
+++ b/clickhouse/columns/column.h
@@ -49,6 +49,9 @@ public:
     inline TypeRef Type() const { return type_; }
     inline const class Type& GetType() const { return *type_; }
 
+    /// Reserve column capacity to reduce memory allocation times.
+    virtual void Reserve(size_t rows) {}
+
     /// Appends content of given column to the end of current one.
     virtual void Append(ColumnRef column) = 0;
 

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -8,6 +8,8 @@ ColumnDate::ColumnDate()
 {
 }
 
+void ColumnDate::Reserve(size_t rows) { data_->Reserve(rows); }
+
 void ColumnDate::Append(const std::time_t& value) {
     /// TODO: This code is fundamentally wrong.
     data_->Append(static_cast<uint16_t>(value / std::time_t(86400)));
@@ -68,6 +70,8 @@ ColumnDate32::ColumnDate32()
     , data_(std::make_shared<ColumnInt32>())
 {
 }
+
+void ColumnDateTime::Reserve(size_t rows) { data_->Reserve(rows); }
 
 void ColumnDate32::Append(const std::time_t& value) {
     /// TODO: This code is fundamentally wrong.

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -14,6 +14,9 @@ public:
 
     ColumnDate();
 
+    /// Reserve column capacity to reduce memory allocation times.
+    void Reserve(size_t rows) override;
+
     /// Appends one element to the end of column.
     /// TODO: The implementation is fundamentally wrong.
     void Append(const std::time_t& value);
@@ -54,6 +57,9 @@ public:
     using ValueType = std::time_t;
 
     ColumnDate32();
+
+    /// Reserve column capacity to reduce memory allocation times.
+    void Reserve(size_t rows);
 
     /// Appends one element to the end of column.
     /// TODO: The implementation is fundamentally wrong.

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -26,6 +26,11 @@ ColumnVector<T>::ColumnVector(std::vector<T> && data)
 }
 
 template <typename T>
+void ColumnVector<T>::Reserve(size_t rows) {
+    data_.reserve(rows);
+}
+
+template <typename T>
 void ColumnVector<T>::Append(const T& value) {
     data_.push_back(value);
 }

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -31,6 +31,9 @@ public:
     void Erase(size_t pos, size_t count = 1);
 
 public:
+    /// Reserve column capacity to reduce memory allocation times.
+    void Reserve(size_t rows) override;
+
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
 


### PR DESCRIPTION
Avoid memory copy in ColumnString and Add Reserve function to reduce memory allocation times.