### PR TITLE
Add recv/send timeouts to socket

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -112,6 +112,16 @@ void SetNonBlock(SOCKET fd, bool value) {
 #endif
 }
 
+void SetTimeout(SOCKET fd, const SocketTimeoutParams& timeout_params) {
+#if defined(_unix_)
+    timeval recv_timeout { .tv_sec = timeout_params.recv_timeout.count(), .tv_usec = 0 };
+    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &recv_timeout, sizeof(recv_timeout));
+
+    timeval send_timeout { .tv_sec = timeout_params.send_timeout.count(), .tv_usec = 0 };
+    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &send_timeout, sizeof(send_timeout));
+#endif
+};
+
 ssize_t Poll(struct pollfd* fds, int nfds, int timeout) noexcept {
 #if defined(_win_)
     return WSAPoll(fds, nfds, timeout);
@@ -120,7 +130,7 @@ ssize_t Poll(struct pollfd* fds, int nfds, int timeout) noexcept {
 #endif
 }
 
-SOCKET SocketConnect(const NetworkAddress& addr) {
+SOCKET SocketConnect(const NetworkAddress& addr, const SocketTimeoutParams& timeout_params) {
     int last_err = 0;
     for (auto res = addr.Info(); res != nullptr; res = res->ai_next) {
         SOCKET s(socket(res->ai_family, res->ai_socktype, res->ai_protocol));
@@ -130,6 +140,7 @@ SOCKET SocketConnect(const NetworkAddress& addr) {
         }
 
         SetNonBlock(s, true);
+        SetTimeout(s, timeout_params);
 
         if (connect(s, res->ai_addr, (int)res->ai_addrlen) != 0) {
             int err = getSocketErrorCode();
@@ -213,12 +224,14 @@ NetworkAddress::~NetworkAddress() {
 const struct addrinfo* NetworkAddress::Info() const {
     return info_;
 }
+
 const std::string & NetworkAddress::Host() const {
     return host_;
 }
 
 
 SocketBase::~SocketBase() = default;
+
 
 SocketFactory::~SocketFactory() = default;
 
@@ -227,8 +240,8 @@ void SocketFactory::sleepFor(const std::chrono::milliseconds& duration) {
 }
 
 
-Socket::Socket(const NetworkAddress& addr)
-    : handle_(SocketConnect(addr))
+Socket::Socket(const NetworkAddress& addr, const SocketTimeoutParams& timeout_params)
+    : handle_(SocketConnect(addr, timeout_params))
 {}
 
 Socket::Socket(Socket&& other) noexcept
@@ -300,19 +313,21 @@ std::unique_ptr<OutputStream> Socket::makeOutputStream() const {
     return std::make_unique<SocketOutput>(handle_);
 }
 
+
 NonSecureSocketFactory::~NonSecureSocketFactory()  {}
 
 std::unique_ptr<SocketBase> NonSecureSocketFactory::connect(const ClientOptions &opts) {
     const auto address = NetworkAddress(opts.host, std::to_string(opts.port));
 
-    auto socket = doConnect(address);
+    auto socket = doConnect(address, opts);
     setSocketOptions(*socket, opts);
 
     return socket;
 }
 
-std::unique_ptr<Socket> NonSecureSocketFactory::doConnect(const NetworkAddress& address) {
-    return std::make_unique<Socket>(address);
+std::unique_ptr<Socket> NonSecureSocketFactory::doConnect(const NetworkAddress& address, const ClientOptions& opts) {
+    SocketTimeoutParams timeout_params { opts.connection_recv_timeout, opts.connection_send_timeout };
+    return std::make_unique<Socket>(address, timeout_params);
 }
 
 void NonSecureSocketFactory::setSocketOptions(Socket &socket, const ClientOptions &opts) {
@@ -326,6 +341,7 @@ void NonSecureSocketFactory::setSocketOptions(Socket &socket, const ClientOption
         socket.SetTcpNoDelay(opts.tcp_nodelay);
     }
 }
+
 
 SocketInput::SocketInput(SOCKET s)
     : s_(s)

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -82,9 +82,14 @@ public:
 };
 
 
+struct SocketTimeoutParams {
+    const std::chrono::seconds recv_timeout {0};
+    const std::chrono::seconds send_timeout {0};
+};
+
 class Socket : public SocketBase {
 public:
-    Socket(const NetworkAddress& addr);
+    Socket(const NetworkAddress& addr, const SocketTimeoutParams& timeout_params);
     Socket(Socket&& other) noexcept;
     Socket& operator=(Socket&& other) noexcept;
 
@@ -119,7 +124,7 @@ public:
     std::unique_ptr<SocketBase> connect(const ClientOptions& opts) override;
 
 protected:
-    virtual std::unique_ptr<Socket> doConnect(const NetworkAddress& address);
+    virtual std::unique_ptr<Socket> doConnect(const NetworkAddress& address, const ClientOptions& opts);
 
     void setSocketOptions(Socket& socket, const ClientOptions& opts);
 };

--- a/clickhouse/base/sslsocket.cpp
+++ b/clickhouse/base/sslsocket.cpp
@@ -198,9 +198,9 @@ SSL_CTX * SSLContext::getContext() {
     << "\n\t handshake state: " << SSL_get_state(ssl_) \
     << std::endl
 */
-SSLSocket::SSLSocket(const NetworkAddress& addr, const SSLParams & ssl_params,
-                     SSLContext& context)
-    : Socket(addr)
+SSLSocket::SSLSocket(const NetworkAddress& addr, const SocketTimeoutParams& timeout_params,
+                     const SSLParams & ssl_params, SSLContext& context)
+    : Socket(addr, timeout_params)
     , ssl_(SSL_new(context.getContext()), &SSL_free)
 {
     auto ssl = ssl_.get();
@@ -267,8 +267,9 @@ SSLSocketFactory::SSLSocketFactory(const ClientOptions& opts)
 
 SSLSocketFactory::~SSLSocketFactory() = default;
 
-std::unique_ptr<Socket> SSLSocketFactory::doConnect(const NetworkAddress& address) {
-    return std::make_unique<SSLSocket>(address, ssl_params_, *ssl_context_);
+std::unique_ptr<Socket> SSLSocketFactory::doConnect(const NetworkAddress& address, const ClientOptions& opts) {
+    SocketTimeoutParams timeout_params { opts.connection_recv_timeout, opts.connection_send_timeout };
+    return std::make_unique<SSLSocket>(address, timeout_params, ssl_params_, *ssl_context_);
 }
 
 std::unique_ptr<InputStream> SSLSocket::makeInputStream() const {

--- a/clickhouse/base/sslsocket.h
+++ b/clickhouse/base/sslsocket.h
@@ -48,7 +48,9 @@ private:
 
 class SSLSocket : public Socket {
 public:
-    explicit SSLSocket(const NetworkAddress& addr, const SSLParams & ssl_params, SSLContext& context);
+    explicit SSLSocket(const NetworkAddress& addr, const SocketTimeoutParams& timeout_params,
+                       const SSLParams& ssl_params, SSLContext& context);
+
     SSLSocket(SSLSocket &&) = default;
     ~SSLSocket() override = default;
 
@@ -69,7 +71,7 @@ public:
     ~SSLSocketFactory() override;
 
 protected:
-    std::unique_ptr<Socket> doConnect(const NetworkAddress& address) override;
+    std::unique_ptr<Socket> doConnect(const NetworkAddress& address, const ClientOptions& opts) override;
 
 private:
     const SSLParams ssl_params_;

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -86,6 +86,10 @@ struct ClientOptions {
     // TCP options
     DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, true);
 
+    /// Connection socket timeout. If the timeout is set to zero then the operation will never timeout.
+    DECLARE_FIELD(connection_recv_timeout, std::chrono::seconds, SetConnectionRecvTimeout, std::chrono::seconds(0));
+    DECLARE_FIELD(connection_send_timeout, std::chrono::seconds, SetConnectionSendTimeout, std::chrono::seconds(0));
+
     // TODO deprecate setting
     /** It helps to ease migration of the old codebases, which can't afford to switch
     * to using ColumnLowCardinalityT or ColumnLowCardinality directly,


### PR DESCRIPTION
When I was working with the library, I found the following behavior: when my application is connecting to the clickhouse server, it may stick forever due to connection problems.

A connection to the server can be established, but nothing can be read from the socket because you try to connect to another running application in your system. 

For resolving this problem I added receive and send timeouts to socket.
