### PR TITLE
Separate building static and shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ INCLUDE (cmake/openssl.cmake)
 
 OPTION (BUILD_BENCHMARK "Build benchmark" OFF)
 OPTION (BUILD_TESTS "Build tests" OFF)
+OPTION (BUILD_SHARED_LIBS "Build shared libs" OFF)
 OPTION (WITH_OPENSSL "Use OpenSSL for TLS connections" OFF)
 
 PROJECT (CLICKHOUSE-CLIENT)
@@ -26,6 +27,12 @@ PROJECT (CLICKHOUSE-CLIENT)
         # -Wno-deprecated-declarations to produce less cluttered output when building library itself (`deprecated` attributes are for library users)
         SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror -Wno-deprecated-declarations")
     ENDIF ()
+
+    IF (APPLE OR MSVC)
+        IF(BUILD_SHARED_LIBS)
+            MESSAGE(FATAL "Does not support shared on this platform")
+        ENDIF()
+    ENDIF()
 
     SUBDIRS (
         clickhouse

--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -38,8 +38,8 @@ IF (WITH_OPENSSL)
     LIST(APPEND clickhouse-cpp-lib-src base/sslsocket.cpp)
 ENDIF ()
 
-ADD_LIBRARY (clickhouse-cpp-lib SHARED ${clickhouse-cpp-lib-src})
-SET_TARGET_PROPERTIES(clickhouse-cpp-lib PROPERTIES LINKER_LANGUAGE CXX)
+ADD_LIBRARY (clickhouse-cpp-lib ${clickhouse-cpp-lib-src})
+SET_TARGET_PROPERTIES (clickhouse-cpp-lib PROPERTIES LINKER_LANGUAGE CXX)
 TARGET_LINK_LIBRARIES (clickhouse-cpp-lib
     absl-lib
     cityhash-lib
@@ -49,15 +49,10 @@ TARGET_INCLUDE_DIRECTORIES (clickhouse-cpp-lib
     PUBLIC ${PROJECT_SOURCE_DIR}
 )
 
-ADD_LIBRARY (clickhouse-cpp-lib-static STATIC ${clickhouse-cpp-lib-src})
-TARGET_LINK_LIBRARIES (clickhouse-cpp-lib-static
-    absl-lib
-    cityhash-lib
-    lz4-lib
-)
-TARGET_INCLUDE_DIRECTORIES (clickhouse-cpp-lib-static
-    PUBLIC ${PROJECT_SOURCE_DIR}
-)
+IF (NOT BUILD_SHARED_LIBS)
+    ADD_LIBRARY (clickhouse-cpp-lib-static ALIAS clickhouse-cpp-lib)
+ENDIF()
+
 
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     INCLUDE (CheckCXXSourceCompiles)
@@ -76,16 +71,19 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # /usr/bin/ld: CMakeFiles/simple-test.dir/main.cpp.o: undefined reference to symbol '_Unwind_Resume@@GCC_3.0'
         # /usr/bin/ld: /lib/x86_64-linux-gnu/libgcc_s.so.1: error adding symbols: DSO missing from command line
         # FIXME: that workaround breaks clang build on mingw
-        TARGET_LINK_LIBRARIES (clickhouse-cpp-lib gcc_s)
-        TARGET_LINK_LIBRARIES (clickhouse-cpp-lib-static gcc_s)
+        IF (BUILD_SHARED_LIBS)
+            TARGET_LINK_LIBRARIES (clickhouse-cpp-lib gcc_s)
+        ELSE()
+            TARGET_LINK_LIBRARIES (clickhouse-cpp-lib-static gcc_s)
+        ENDIF()
     ENDIF ()
 ENDIF ()
 
-INSTALL (TARGETS clickhouse-cpp-lib clickhouse-cpp-lib-static
+
+INSTALL (TARGETS clickhouse-cpp-lib
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
 )
-
 
 # general
 INSTALL(FILES block.h DESTINATION include/clickhouse/)
@@ -137,10 +135,8 @@ INSTALL(FILES types/types.h DESTINATION include/clickhouse/types/)
 
 IF (WITH_OPENSSL)
     TARGET_LINK_LIBRARIES (clickhouse-cpp-lib OpenSSL::SSL)
-    TARGET_LINK_LIBRARIES (clickhouse-cpp-lib-static OpenSSL::SSL)
 ENDIF ()
 
 IF (WIN32 OR MINGW)
     TARGET_LINK_LIBRARIES (clickhouse-cpp-lib wsock32 ws2_32)
-    TARGET_LINK_LIBRARIES (clickhouse-cpp-lib-static wsock32 ws2_32)
 ENDIF ()

--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -71,11 +71,7 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         # /usr/bin/ld: CMakeFiles/simple-test.dir/main.cpp.o: undefined reference to symbol '_Unwind_Resume@@GCC_3.0'
         # /usr/bin/ld: /lib/x86_64-linux-gnu/libgcc_s.so.1: error adding symbols: DSO missing from command line
         # FIXME: that workaround breaks clang build on mingw
-        IF (BUILD_SHARED_LIBS)
-            TARGET_LINK_LIBRARIES (clickhouse-cpp-lib gcc_s)
-        ELSE()
-            TARGET_LINK_LIBRARIES (clickhouse-cpp-lib-static gcc_s)
-        ENDIF()
+        TARGET_LINK_LIBRARIES (clickhouse-cpp-lib gcc_s)
     ENDIF ()
 ENDIF ()
 

--- a/tests/simple/CMakeLists.txt
+++ b/tests/simple/CMakeLists.txt
@@ -4,7 +4,7 @@ ADD_EXECUTABLE (simple-test
 )
 
 TARGET_LINK_LIBRARIES (simple-test
-    clickhouse-cpp-lib-static
+    clickhouse-cpp-lib
 )
 
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -35,7 +35,7 @@ ADD_EXECUTABLE (clickhouse-cpp-ut
 )
 
 TARGET_LINK_LIBRARIES (clickhouse-cpp-ut
-    clickhouse-cpp-lib-static
+    clickhouse-cpp-lib
     gtest-lib
 )
 IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
Introduce separating building static and shared libs, depends on cmake out-of-the-box option BUILD_SHARED_LIBS https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html. Also creates alias target for transparently linking to static or shared lib. 