### PR TITLE
Support client write info 

### DIFF
--- a/clickhouse/block.cpp
+++ b/clickhouse/block.cpp
@@ -71,6 +71,11 @@ const BlockInfo& Block::Info() const {
     return info_;
 }
 
+/// Set block info
+void Block::SetInfo(BlockInfo info) {
+    info_ = std::move(info);
+}
+
 /// Count of rows in the block.
 size_t Block::GetRowCount() const {
     return rows_;

--- a/clickhouse/block.h
+++ b/clickhouse/block.h
@@ -73,6 +73,9 @@ public:
 
     const BlockInfo& Info() const;
 
+    /// Set block info
+    void SetInfo(BlockInfo info);
+
     /// Count of rows in the block.
     size_t GetRowCount() const;
 

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -35,8 +35,9 @@
 #define DBMS_MIN_REVISION_WITH_VERSION_PATCH            54401
 #define DBMS_MIN_REVISION_WITH_LOW_CARDINALITY_TYPE     54405
 #define DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA 54410
+#define DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO        54420
 
-#define REVISION  DBMS_MIN_REVISION_WITH_COLUMN_DEFAULTS_METADATA
+#define REVISION DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO
 
 namespace clickhouse {
 
@@ -405,6 +406,15 @@ bool Client::Impl::ReceivePacket(uint64_t* server_packet) {
         }
         if (REVISION >= DBMS_MIN_REVISION_WITH_TOTAL_ROWS_IN_PROGRESS) {
             if (!WireFormat::ReadUInt64(*input_, &info.total_rows)) {
+                return false;
+            }
+        }
+        if (REVISION >= DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO)
+        {
+            if (!WireFormat::ReadUInt64(*input_, &info.written_rows)) {
+                return false;
+            }
+            if (!WireFormat::ReadUInt64(*input_, &info.written_bytes)) {
                 return false;
             }
         }

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -485,7 +485,7 @@ bool Client::Impl::ReadBlock(InputStream& input, Block* block) {
             return false;
         }
 
-        // TODO use data
+        block->SetInfo(std::move(info));
     }
 
     uint64_t num_columns = 0;

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -94,7 +94,6 @@ public:
         return query_id_;
     }
 
-
     /// Set handler for receiving result data.
     inline Query& OnData(SelectCallback cb) {
         select_cb_ = std::move(cb);

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -48,6 +48,8 @@ struct Progress {
     uint64_t rows = 0;
     uint64_t bytes = 0;
     uint64_t total_rows = 0;
+    uint64_t written_rows = 0;
+    uint64_t written_bytes = 0;
 };
 
 
@@ -91,6 +93,7 @@ public:
     inline const std::string& GetQueryID() const {
         return query_id_;
     }
+
 
     /// Set handler for receiving result data.
     inline Query& OnData(SelectCallback cb) {

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1021,7 +1021,7 @@ TEST_P(ClientCase, OnProgress) {
         });
     client_->Execute(query);
 
-    EXPECT_TRUE(received_progress.has_value());
+    ASSERT_TRUE(received_progress.has_value());
 
     EXPECT_GE(received_progress->rows, 0u);
     EXPECT_LE(received_progress->rows, 2u);

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1010,7 +1010,7 @@ TEST_P(ClientCase, RoundtripArrayTString) {
     EXPECT_TRUE(CompareRecursive(*array, *result_typed));
 }
 
-TEST_P(ClientCase, WriteInfo) {
+TEST_P(ClientCase, OnProgress) {
     Block block;
     createTableWithOneColumn<ColumnString>(block);
 
@@ -1022,9 +1022,8 @@ TEST_P(ClientCase, WriteInfo) {
     client_->Execute(query);
 
     EXPECT_TRUE(received_progress.has_value());
-    // server for some reason sent "rows" instead "written_rows"
-    EXPECT_GT(received_progress->rows + received_progress->written_rows , 0ul);
-    EXPECT_GT(received_progress->bytes + received_progress->written_bytes, 0ul);
+    // Unfortunately server has different behavior in different version.
+    // So checking value of rows, bytes, etc is absolutely useless
 }
 
 const auto LocalHostEndpoint = ClientOptions()

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1022,8 +1022,21 @@ TEST_P(ClientCase, OnProgress) {
     client_->Execute(query);
 
     EXPECT_TRUE(received_progress.has_value());
-    // Unfortunately server has different behavior in different version.
-    // So checking value of rows, bytes, etc is absolutely useless
+
+    EXPECT_GE(received_progress->rows, 0u);
+    EXPECT_LE(received_progress->rows, 2u);
+
+    EXPECT_GE(received_progress->bytes, 0u);
+    EXPECT_LE(received_progress->bytes, 10000u);
+
+    EXPECT_GE(received_progress->total_rows, 0u);
+    EXPECT_LE(received_progress->total_rows, 2u);
+
+    EXPECT_GE(received_progress->written_rows, 0u);
+    EXPECT_LE(received_progress->written_rows, 2u);
+
+    EXPECT_GE(received_progress->written_bytes, 0u);
+    EXPECT_LE(received_progress->written_bytes, 10000u);
 }
 
 const auto LocalHostEndpoint = ClientOptions()


### PR DESCRIPTION
I want to implement supporting query parameters. It requires raising the version of the protocol. The gap between the current server version of the protocol and the current client library version of the protocol is huge for one PR. So I decided to create several small PR and raise versions step by step. 