### PR TITLE
Minor fixes

### DIFF
--- a/clickhouse/base/sslsocket.cpp
+++ b/clickhouse/base/sslsocket.cpp
@@ -61,6 +61,9 @@ void configureSSL(const clickhouse::SSLParams::ConfigurationType & configuration
         SSL_CONF_CTX_set_ssl(conf_ctx, ssl);
     else if (context)
         SSL_CONF_CTX_set_ssl_ctx(conf_ctx, context);
+    else {
+        throw clickhouse::AssertionError("Either SSL or SSL_CTX should be provided");
+    }
 
     for (const auto & kv : configuration) {
         const int err = SSL_CONF_cmd(conf_ctx, kv.first.c_str(), (kv.second ? kv.second->c_str() : nullptr));

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -30,6 +30,9 @@ ColumnFixedString::ColumnFixedString(size_t n)
 {
 }
 
+ColumnFixedString::~ColumnFixedString()
+{}
+
 void ColumnFixedString::Append(std::string_view str) {
     if (str.size() > string_size_) {
         throw ValidationError("Expected string of length not greater than "

--- a/clickhouse/columns/string.h
+++ b/clickhouse/columns/string.h
@@ -18,6 +18,7 @@ public:
     using ValueType = std::string_view;
 
     explicit ColumnFixedString(size_t n);
+    ~ColumnFixedString() override;
 
     template <typename Values>
     ColumnFixedString(size_t n, const Values & values)
@@ -76,7 +77,7 @@ public:
     using ValueType = std::string_view;
 
     ColumnString();
-    ~ColumnString();
+    ~ColumnString() override;
 
     explicit ColumnString(const std::vector<std::string> & data);
     explicit ColumnString(std::vector<std::string>&& data);

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -10,30 +10,6 @@
 
 namespace clickhouse {
 
-/**
- * Settings of individual query.
- */
-struct QuerySettings {
-    /// Maximum thread to use on the server-side to process a query. Default - let the server choose.
-    int max_threads = 0;
-    /// Compute min and max values of the result.
-    bool extremes = false;
-    /// Silently skip unavailable shards.
-    bool skip_unavailable_shards = false;
-    /// Write statistics about read rows, bytes, time elapsed, etc.
-    bool output_format_write_statistics = true;
-    /// Use client timezone for interpreting DateTime string values, instead of adopting server timezone.
-    bool use_client_time_zone = false;
-
-    // connect_timeout
-    // max_block_size
-    // distributed_group_by_no_merge = false
-    // strict_insert_defaults = 0
-    // network_compression_method = LZ4
-    // priority = 0
-};
-
-
 struct Profile {
     uint64_t rows = 0;
     uint64_t blocks = 0;

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -243,6 +243,15 @@ TYPED_TEST(GenericColumnTest, Swap) {
     column_A->Swap(*column_B);
 
     EXPECT_EQ(0u, column_A->Size());
+
+    {
+        // If there are any dandling pointers/references from column_B into column_A after Swap(),
+        // then filling column_A with new values would most likely overwrite/invalidate those
+        // and CompareRecursive below would fail.
+        this->AppendValues(column_A, this->GenerateValues(1));
+        column_A.reset();
+    }
+
     EXPECT_TRUE(CompareRecursive(values, *column_B));
 }
 


### PR DESCRIPTION
- attempt to fix 'unresolved external symbol "const clickhouse::ColumnFixedString::`vftable'"' @ string.h/.cpp
- minor test improvement to verify Swap() correctness @ ut/Column_ut.cpp
- exception if SSL wouldn't be configured by configureSSL @ sslsocket.cpp
- removed unused QuerySettings @ query.h