### PR TITLE
Use `FormatMessageA`

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -27,7 +27,7 @@ char const* windowsErrorCategory::name() const noexcept {
 
 std::string windowsErrorCategory::message(int c) const {
     char error[UINT8_MAX];
-    auto len = FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, static_cast<DWORD>(c), 0, error, sizeof(error), nullptr);
+    auto len = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, static_cast<DWORD>(c), 0, error, sizeof(error), nullptr);
     if (len == 0) {
         return "unknown";
     }


### PR DESCRIPTION
`FormatMessage` expects like `FormatMessageW` a wide char array. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessage and https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagew for more information.

Using `FormatMessage` with a normal char array leads to a build failure on UWP:

```
D:\buildtrees\clickhouse-cpp\src\v2.2.1-26f006ec81.clean\clickhouse\base\socket.cpp(30): error C2664: 'DWORD FormatMessageW(DWORD,LPCVOID,DWORD,DWORD,LPWSTR,DWORD,va_list *)': cannot convert argument 5 from 'char [255]' to 'LPWSTR'
D:\buildtrees\clickhouse-cpp\src\v2.2.1-26f006ec81.clean\clickhouse\base\socket.cpp(30): note: Types pointed to are unrelated; conversion requires reinterpret_cast, C-style cast or parenthesized function-style cast
C:\Program Files (x86)\Windows Kits\10\include\10.0.22621.0\um\winbase.h(2476): note: see declaration of 'FormatMessageW'
```

`FormatMessageA` expects an ordinary char array which translates to the desired output of this function, `std::string`. See https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-formatmessagea for more information.

I didn't change the input array to a wide array because changing the return type of the function might break users of it.