### PR TITLE
Update bench.cpp

### DIFF
--- a/bench/bench.cpp
+++ b/bench/bench.cpp
@@ -1,6 +1,7 @@
 #include <benchmark/benchmark.h>
 
 #include <clickhouse/client.h>
+#include <ut/utils.h>
 
 namespace clickhouse {
 


### PR DESCRIPTION
fix bench compile error
I encountered a compilation error when I tried to `cmake` with `-DBUILD_TESTS=ON -DBUILD_BENCHMARK=ON` and `make` on Centos7. The error messages were:
```
/root/clickhouse-cpp/bench/bench.cpp:8:29: error: 'getEnvOrDefault' was not declared in this scope
         .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
                             ^~~~~~~~~~~~~~~
/root/clickhouse-cpp/bench/bench.cpp:9:29: error: 'getEnvOrDefault' was not declared in this scope
         .SetPort( std::stoi(getEnvOrDefault("CLICKHOUSE_PORT",     "9000")))
                             ^~~~~~~~~~~~~~~
/root/clickhouse-cpp/bench/bench.cpp:10:29: error: 'getEnvOrDefault' was not declared in this scope
         .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
                             ^~~~~~~~~~~~~~~
/root/clickhouse-cpp/bench/bench.cpp:11:29: error: 'getEnvOrDefault' was not declared in this scope
         .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
                             ^~~~~~~~~~~~~~~
/root/clickhouse-cpp/bench/bench.cpp:12:29: error: 'getEnvOrDefault' was not declared in this scope
         .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
```
After adding `#include <ut/utils.h>` in `bench/bench.cpp`, the compilation succeeded.