### PR TITLE
bugfix, remove items_.reserve for batch write

### DIFF
--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -247,7 +247,6 @@ void ColumnString::Append(ColumnRef column) {
         // TODO: fill up existing block with some items and then add a new one for the rest of items
         if (blocks_.size() == 0 || blocks_.back().GetAvailable() < total_size)
             blocks_.emplace_back(std::max(DEFAULT_BLOCK_SIZE, total_size));
-        items_.reserve(items_.size() + col->Size());
 
         for (size_t i = 0; i < column->Size(); ++i) {
             this->AppendUnsafe((*col)[i]);

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -248,6 +248,7 @@ void ColumnString::Append(ColumnRef column) {
         if (blocks_.size() == 0 || blocks_.back().GetAvailable() < total_size)
             blocks_.emplace_back(std::max(DEFAULT_BLOCK_SIZE, total_size));
 
+        // Intentionally not doing items_.reserve() since that cripples performance.
         for (size_t i = 0; i < column->Size(); ++i) {
             this->AppendUnsafe((*col)[i]);
         }


### PR DESCRIPTION
Platform: windows
Data: 100w,  10w/per

This is a bug for batch write.  It costs too much cpu time.

Before remove, already cost 1min and nothing insert ok. Top hot:
<img width="708" alt="a34d24f7c98b5c8408407311dc6a876" src="https://user-images.githubusercontent.com/19810905/202836584-de74856f-8c4e-47b8-8e3a-ed67b6b24fd5.png">

After remove, just cost 18.7s and all insert ok. Top hot:
<img width="910" alt="38e437dd519aa742d08d1bb8c7e26fa" src="https://user-images.githubusercontent.com/19810905/202836682-4e5858d1-bf0f-402d-9928-896b0ae84ccf.png">

