### PR TITLE
ColumnString improve performance(26%) by avoiding vector reallocate

### DIFF
--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -166,6 +166,13 @@ ColumnString::ColumnString()
 {
 }
 
+ColumnString::ColumnString(size_t element_count)
+    : Column(Type::CreateString())
+{
+    items_.reserve(element_count);
+    blocks_.reserve(element_count / 2);
+}
+
 ColumnString::ColumnString(const std::vector<std::string>& data)
     : ColumnString()
 {
@@ -291,7 +298,7 @@ size_t ColumnString::Size() const {
 }
 
 ColumnRef ColumnString::Slice(size_t begin, size_t len) const {
-    auto result = std::make_shared<ColumnString>();
+    auto result = std::make_shared<ColumnString>(len);
 
     if (begin < items_.size()) {
         len = std::min(len, items_.size() - begin);

--- a/clickhouse/columns/string.h
+++ b/clickhouse/columns/string.h
@@ -78,6 +78,7 @@ public:
     ColumnString();
     ~ColumnString();
 
+    explicit ColumnString(size_t element_count);
     explicit ColumnString(const std::vector<std::string> & data);
     explicit ColumnString(std::vector<std::string>&& data);
     ColumnString& operator=(const ColumnString&) = delete;


### PR DESCRIPTION
By estimating the total element count, code like this:
```c++
constexpr size_t total = 100000;
for (int i = 0; i < 10; i++) {
    clickhouse::Block block;
    auto a_ptr = std::make_shared<clickhouse::ColumnInt32>();
    auto b_ptr = std::make_shared<clickhouse::ColumnUInt64>();
    auto c_ptr = std::make_shared<clickhouse::ColumnString>(total);
    auto d_ptr = std::make_shared<clickhouse::ColumnArray>(std::make_shared<clickhouse::ColumnString>(total * 3));
    auto e_ptr = std::make_shared<clickhouse::ColumnArray>(
                         std::make_shared<clickhouse::ColumnArray>(
                         std::make_shared<clickhouse::ColumnString>(total * 3 * 4)));
...
```
Before estimating, total time(18720), network time(7353), other time(18720-7353=11367),  top hot:

<img width="1057" alt="6ebcdc78d97e6d82d517696842bcf0d" src="https://user-images.githubusercontent.com/19810905/202853045-ab8f7794-b87f-4a35-b37e-fc8ceaa920c7.png">

After estimating, total time(15728), network time(7317) _**same as above(7353)**_, other time(15728-7317=8411),  top hot:

<img width="1066" alt="5461431e29c7ec072527b01c980033b" src="https://user-images.githubusercontent.com/19810905/202853216-23ec998e-2487-4e6a-bae8-3156a414bf10.png">

improve performance: (11367-8411)/11367 = 26%

