### PR TITLE
add parameterized syntax, just syntax-sugar

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -902,22 +902,6 @@ void Client::Execute(const Query& query) {
     impl_->ExecuteQuery(query);
 }
 
-void Client::Select(const std::string& query, SelectCallback cb) {
-    Execute(Query(query).OnData(std::move(cb)));
-}
-
-void Client::Select(const std::string& query, const std::string& query_id, SelectCallback cb) {
-    Execute(Query(query, query_id).OnData(std::move(cb)));
-}
-
-void Client::SelectCancelable(const std::string& query, SelectCancelableCallback cb) {
-    Execute(Query(query).OnDataCancelable(std::move(cb)));
-}
-
-void Client::SelectCancelable(const std::string& query, const std::string& query_id, SelectCancelableCallback cb) {
-    Execute(Query(query, query_id).OnDataCancelable(std::move(cb)));
-}
-
 void Client::Select(const Query& query) {
     Execute(query);
 }

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -212,14 +212,43 @@ public:
 
     /// Intends for execute select queries.  Data will be returned with
     /// one or more call of \p cb.
-    void Select(const std::string& query, SelectCallback cb);
-    void Select(const std::string& query, const std::string& query_id, SelectCallback cb);
+    /// Now it supports parameterized syntax, the placeholder should be ?
+    /// It is just syntax-sugar, all replacing happens on the client side
+    template<typename... Parameterized>
+    void Select(const std::string& query, SelectCallback cb, Parameterized&&... params) {
+        this->ExecuteInner(query, [this, &cb](auto&& new_query) {
+            Execute(Query(std::move(new_query)).OnData(std::move(cb)));
+        }, std::forward<Parameterized>(params)...);
+    }
+
+    template<typename... Parameterized>
+    void Select(const std::string& query,
+        const std::string& query_id, SelectCallback cb, Parameterized&&... params) {
+        this->ExecuteInner(query, [this, &cb, queryid = query_id](auto&& new_query) {
+            Execute(Query(std::move(new_query), std::move(queryid)).OnData(std::move(cb)));
+        }, std::forward<Parameterized>(params)...);
+    }
 
     /// Executes a select query which can be canceled by returning false from
     /// the data handler function \p cb.
-    void SelectCancelable(const std::string& query, SelectCancelableCallback cb);
-    void SelectCancelable(const std::string& query, const std::string& query_id, SelectCancelableCallback cb);
+    /// Now it supports parameterized syntax, the placeholder should be ?
+    /// It is just syntax-sugar, all replacing happens on the client side
+    template<typename... Parameterized>
+    void SelectCancelable(const std::string& query,
+        SelectCancelableCallback cb, Parameterized&&... params) {
+        this->ExecuteInner(query, [this, &cb](auto&& new_query) {
+            Execute(Query(std::move(new_query)).OnDataCancelable(std::move(cb)));
+        }, std::forward<Parameterized>(params)...);
+    }
 
+    template<typename... Parameterized>
+    void SelectCancelable(const std::string& query,
+        const std::string& query_id, SelectCancelableCallback cb, Parameterized&&... params) {
+        this->ExecuteInner(query, [this, &cb, queryid = query_id](auto&& new_query) {
+            Execute(Query(std::move(new_query), std::move(queryid)).OnDataCancelable(std::move(cb)));
+        }, std::forward<Parameterized>(params)...);
+    }
+    
     /// Alias for Execute.
     void Select(const Query& query);
 
@@ -234,6 +263,64 @@ public:
     void ResetConnection();
 
     const ServerInfo& GetServerInfo() const;
+
+private:
+    template<typename Executor, typename... Parameterized>
+    void ExecuteInner(const std::string& query, Executor&& executor, Parameterized&&... params) {
+        constexpr auto params_count = sizeof...(params);
+        if constexpr (params_count == 0) {
+            executor(query);
+        }
+        else {
+            auto params_tup = std::forward_as_tuple(std::forward<Parameterized>(params)...);
+            auto new_query = this->RecombineQuery<params_count>(query, params_tup);
+            executor(new_query);
+        }
+    }
+
+    template<typename F, std::size_t ... Index>
+    static constexpr void ForEachTuple(F&& f, std::index_sequence<Index...>) {
+        (std::forward<F>(f)(std::integral_constant<std::size_t, Index>()), ...);
+    }
+
+    template<size_t ParamsCount, typename ParamsTup>
+    std::string RecombineQuery(std::string_view query, ParamsTup&& tup) {
+        //Compute placeholder pos, 'find_first_of' for locating quickly 
+        std::vector<size_t> placeholder;
+        auto pos = query.find_first_of('?');
+        if (pos == std::string_view::npos) {
+            throw ValidationError(std::string("params_count mismath placeholder"));
+        }
+
+        placeholder.emplace_back(pos);
+        for (auto i = pos + 1; i < query.length(); ++i) {
+            if (query[i] == '?') {
+                placeholder.emplace_back(i);
+            }
+        }
+        //check placeholder and parameterized count
+        if (ParamsCount != placeholder.size()) {
+            throw ValidationError(std::string("params_count mismath placeholder"));
+        }
+
+        //replace '?' with value
+        std::string new_query;
+        new_query.reserve(query.size() + ParamsCount * 16);
+        new_query.append(query);
+        this->ForEachTuple([&new_query, &tup, &placeholder](auto index) {
+            auto element = std::get<index>(tup);
+            using type = std::remove_const_t<std::remove_reference_t<decltype(element)>>;
+            if constexpr (
+                std::is_convertible_v<type, std::string> ||
+                std::is_same_v<type, std::string_view>) {
+                new_query = new_query.replace(placeholder[index], 1, element);
+            }
+            else {
+                new_query = new_query.replace(placeholder[index], 1, std::to_string(element));
+            }
+        }, std::make_index_sequence<ParamsCount>());
+        return new_query;
+    }
 
 private:
     const ClientOptions options_;

--- a/clickhouse/query.cpp
+++ b/clickhouse/query.cpp
@@ -19,6 +19,11 @@ Query::Query(const std::string& query, const std::string& query_id)
 {
 }
 
+Query::Query(std::string&& query, std::string&& query_id)
+    : query_(std::move(query))
+    , query_id_(std::move(query_id))
+{}
+
 Query::~Query()
 { }
 

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -86,6 +86,7 @@ public:
      Query();
      Query(const char* query, const char* query_id = nullptr);
      Query(const std::string& query, const std::string& query_id = default_query_id);
+     Query(std::string&& query, std::string&& query_id = std::string(default_query_id));
     ~Query() override;
 
     ///

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1225,7 +1225,7 @@ TEST_P(ClientCase, OnProfileEvents) {
 }
 
 const auto LocalHostEndpoint = ClientOptions()
-        .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "192.168.152.129"))
+        .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
         .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
         .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
         .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
@@ -1267,7 +1267,7 @@ INSTANTIATE_TEST_SUITE_P(ClientLocalReadonly, ReadonlyClientTest,
 INSTANTIATE_TEST_SUITE_P(ClientLocalFailed, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType{
         ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "192.168.152.129"))
+            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
             .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
             .SetUser("non_existing_user_clickhouse_cpp_test")
             .SetPassword("wrongpwd")

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -889,6 +889,30 @@ TEST_P(ClientCase, Query_ID) {
     EXPECT_EQ(5u, total_count);
 }
 
+TEST_P(ClientCase, parameterized_syntax) {
+    const std::string table_name = "test_clickhouse_cpp_parameterized_syntax";
+    client_->Execute(Query("CREATE TEMPORARY TABLE IF NOT EXISTS " + table_name + " (a Int64)"));
+
+    {
+        Block b;
+        b.AppendColumn("a", std::make_shared<ColumnInt64>(std::vector<int64_t>{1, 2, 3}));
+        client_->Insert(table_name, b);
+    }
+
+    size_t total_count = 0;
+    client_->Select("SELECT a FROM " + table_name + " WHERE a = ?",
+        [&total_count](const Block& block) {
+            total_count += block.GetRowCount();
+    }, 4);
+    EXPECT_EQ(0u, total_count);
+
+    client_->Select("SELECT a FROM " + table_name + " WHERE a > ?",
+        [&total_count](const Block& block) {
+            total_count += block.GetRowCount();
+    }, 1);
+    EXPECT_EQ(2u, total_count);
+}
+
 // Spontaneosly fails on INSERTint data.
 TEST_P(ClientCase, DISABLED_ArrayArrayUInt64) {
     // Based on https://github.com/ClickHouse/clickhouse-cpp/issues/43
@@ -1201,7 +1225,7 @@ TEST_P(ClientCase, OnProfileEvents) {
 }
 
 const auto LocalHostEndpoint = ClientOptions()
-        .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
+        .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "192.168.152.129"))
         .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
         .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
         .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
@@ -1243,7 +1267,7 @@ INSTANTIATE_TEST_SUITE_P(ClientLocalReadonly, ReadonlyClientTest,
 INSTANTIATE_TEST_SUITE_P(ClientLocalFailed, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType{
         ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
+            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "192.168.152.129"))
             .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
             .SetUser("non_existing_user_clickhouse_cpp_test")
             .SetPassword("wrongpwd")


### PR DESCRIPTION
Now clickhouse-cpp supports parameterized syntax, and the placeholder should be ? .
It is just syntax-sugar, all replacing happens on the client side

Any document about clickhouse-server prepare statement? 
@Enmk 