### PR TITLE
Handle "Bool" columns

### DIFF
--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -20,6 +20,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
     { "Int16",       Type::Int16 },
     { "Int32",       Type::Int32 },
     { "Int64",       Type::Int64 },
+    { "Bool",        Type::UInt8 },
     { "UInt8",       Type::UInt8 },
     { "UInt16",      Type::UInt16 },
     { "UInt32",      Type::UInt32 },

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -53,6 +53,12 @@ TEST(CreateColumnByType, DateTime) {
 class CreateColumnByTypeWithName : public ::testing::TestWithParam<const char* /*Column Type String*/>
 {};
 
+TEST(CreateColumnByType, Bool) {
+    const auto col = CreateColumnByType("Bool");
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(col->GetType().GetName(), "UInt8");
+}
+
 TEST_P(CreateColumnByTypeWithName, CreateColumnByType)
 {
     const auto col = CreateColumnByType(GetParam());


### PR DESCRIPTION
Bool received columns are not recognized and mapped to "Void".
Mapping updated to treat received Bool columns as UInt8