### PR TITLE
Scheduling CI/CD runs on Monday midnight

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,8 @@
 name: Linux
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,8 @@
 name: macOS
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/windows_mingw.yml
+++ b/.github/workflows/windows_mingw.yml
@@ -1,6 +1,8 @@
 name: Windows mingw
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/windows_msvc.yml
+++ b/.github/workflows/windows_msvc.yml
@@ -1,6 +1,8 @@
 name: Windows
 
 on:
+  schedule:
+    - cron: '0 0 * * 1'
   push:
     branches: [ master ]
   pull_request:


### PR DESCRIPTION
To make sure that CI/CD is always up-to-date and nothing is broken due to stale dependencies