### PR TITLE
Removed SELECT statement that is not supported on some remote endpoints

### DIFF
--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1196,7 +1196,6 @@ const auto QUERIES = std::vector<std::string>{
     "SELECT fqdn()",
     "SELECT buildId()",
     "SELECT uptime()",
-    "SELECT filesystemFree()",
     "SELECT now()"
 };
 }

--- a/ut/ssl_ut.cpp
+++ b/ut/ssl_ut.cpp
@@ -16,7 +16,6 @@ namespace {
         "SELECT fqdn()",
         "SELECT buildId()",
         "SELECT uptime()",
-        "SELECT filesystemFree()",
         "SELECT now()"
     };
 }


### PR DESCRIPTION
Looks like `filesystemFree()` is not supported on `explorer@play.clickhouse.com:9440` endpoint anymore