### PR TITLE
Support get value at.

### DIFF
--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -21,6 +21,10 @@ public:
         return columns_[n];
     }
 
+    ColumnRef At(size_t n) const {
+        return columns_[n];
+    }
+
 public:
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;


### PR DESCRIPTION
- Added get value at function, along with operator [].

Reason:

The current implement operator [] does not work in Objective-C, so adding the ->At().

Update:
Sorry, my bad, it works with the syntax:  

``` 
auto cols = tup->operator[](c); 
````
but it's a bit ugly IMO.