### PR TITLE
fix bug in ColumnLowCardinality::Load

### DIFF
--- a/clickhouse/columns/lowcardinality.cpp
+++ b/clickhouse/columns/lowcardinality.cpp
@@ -281,7 +281,7 @@ auto Load(ColumnRef new_dictionary_column, InputStream& input, size_t rows) {
 
     if (auto nullable = new_dictionary_column->As<ColumnNullable>()) {
         nullable->Append(true);
-        for(std::size_t i = 1; i < new_index_column->Size(); i++) {
+        for(std::size_t i = 1; i < dataColumn->Size(); i++) {
             nullable->Append(false);
         }
     }


### PR DESCRIPTION
`ColumnLowCardinality::Load` allocate the wrong amount rows for `LowCardinality(Nullable(X))` columns. In most cases, it leads to extra memory allocation than required. But in case then the number of rows in a column is less than the dictionary size exception "`can't load column 'some column' of type LowCardinality(Nullable(X))`" happened. The dictionary always contains null and default values. So if the column contains every unique value once and doesn't contain a null or default value, then such a situation happens.