### PR TITLE
fix bug with load/save Array with empty arrays

### DIFF
--- a/clickhouse/columns/array.cpp
+++ b/clickhouse/columns/array.cpp
@@ -84,7 +84,11 @@ bool ColumnArray::LoadBody(InputStream* input, size_t rows) {
     if (!offsets_->LoadBody(input, rows)) {
         return false;
     }
-    if (!data_->LoadBody(input, (*offsets_)[rows - 1])) {
+    const auto nested_rows = (*offsets_)[rows - 1];
+    if (nested_rows == 0) {
+        return true;
+    }
+    if (!data_->LoadBody(input, nested_rows)) {
         return false;
     }
     return true;
@@ -96,7 +100,9 @@ void ColumnArray::SavePrefix(OutputStream* output) {
 
 void ColumnArray::SaveBody(OutputStream* output) {
     offsets_->SaveBody(output);
-    data_->SaveBody(output);
+    if (data_->Size() > 0) {
+        data_->SaveBody(output);
+    }
 }
 
 void ColumnArray::Clear() {

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1037,6 +1037,31 @@ TEST_P(ClientCase, RoundtripArrayTString) {
     EXPECT_TRUE(CompareRecursive(*array, *result_typed));
 }
 
+TEST_P(ClientCase, RoundtripArrayLowCardinalityTString) {
+    // TODO replase by Roundtrip test
+    using TestColumn = ColumnArrayT<ColumnLowCardinalityT<ColumnString>>;
+
+    Block block;
+    auto array = createTableWithOneColumn<TestColumn>(block);
+    array->Append(std::vector<std::string>{});
+    array->Append(std::vector<std::string>{});
+
+    block.RefreshRowCount();
+    client_->Insert(table_name, block);
+
+    size_t total_rows = 0;
+    client_->Select(getOneColumnSelectQuery(),
+        [&total_rows](const Block& block) {
+            total_rows += block.GetRowCount();
+            if (block.GetRowCount() == 0) {
+                return;
+            }
+        }
+    );
+
+    ASSERT_EQ(total_rows, 2u);
+}
+
 TEST_P(ClientCase, RoundtripMapTUint64String) {
     using Map = ColumnMapT<ColumnUInt64, ColumnString>;
     auto map = std::make_shared<Map>(std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>());


### PR DESCRIPTION
If column Array(Low Cardinality(T)) contains only empty arrays Save/Load methods don't work properly.