### PR TITLE
Add connect timeout to socket

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -207,6 +207,13 @@ SOCKET SocketConnect(const NetworkAddress& addr, const SocketTimeoutParams& time
                 if (rval == -1) {
                     throw std::system_error(getSocketErrorCode(), getErrorCategory(), "fail to connect");
                 }
+                if (rval == 0) {
+#if defined(_win_)
+                    last_err = WSAETIMEDOUT;
+#else
+                    last_err = ETIMEDOUT;
+#endif
+                }
                 if (rval > 0) {
                     socklen_t len = sizeof(err);
                     getsockopt(*s, SOL_SOCKET, SO_ERROR, (char*)&err, &len);

--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -202,7 +202,7 @@ SOCKET SocketConnect(const NetworkAddress& addr, const SocketTimeoutParams& time
                 fd.fd = *s;
                 fd.events = POLLOUT;
                 fd.revents = 0;
-                ssize_t rval = Poll(&fd, 1, 5000);
+                ssize_t rval = Poll(&fd, 1, timeout_params.connect_timeout.count());
 
                 if (rval == -1) {
                     throw std::system_error(getSocketErrorCode(), getErrorCategory(), "fail to connect");
@@ -372,7 +372,7 @@ std::unique_ptr<SocketBase> NonSecureSocketFactory::connect(const ClientOptions 
 }
 
 std::unique_ptr<Socket> NonSecureSocketFactory::doConnect(const NetworkAddress& address, const ClientOptions& opts) {
-    SocketTimeoutParams timeout_params { opts.connection_recv_timeout, opts.connection_send_timeout };
+    SocketTimeoutParams timeout_params { opts.connection_connect_timeout, opts.connection_recv_timeout, opts.connection_send_timeout };
     return std::make_unique<Socket>(address, timeout_params);
 }
 

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -83,6 +83,7 @@ public:
 
 
 struct SocketTimeoutParams {
+    std::chrono::milliseconds connect_timeout{ 5000 };
     std::chrono::milliseconds recv_timeout{ 0 };
     std::chrono::milliseconds send_timeout{ 0 };
 };

--- a/clickhouse/base/sslsocket.cpp
+++ b/clickhouse/base/sslsocket.cpp
@@ -268,7 +268,7 @@ SSLSocketFactory::SSLSocketFactory(const ClientOptions& opts)
 SSLSocketFactory::~SSLSocketFactory() = default;
 
 std::unique_ptr<Socket> SSLSocketFactory::doConnect(const NetworkAddress& address, const ClientOptions& opts) {
-    SocketTimeoutParams timeout_params { opts.connection_recv_timeout, opts.connection_send_timeout };
+    SocketTimeoutParams timeout_params { opts.connection_connect_timeout, opts.connection_recv_timeout, opts.connection_send_timeout };
     return std::make_unique<SSLSocket>(address, timeout_params, ssl_params_, *ssl_context_);
 }
 

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -88,6 +88,9 @@ struct ClientOptions {
     // TCP options
     DECLARE_FIELD(tcp_nodelay, bool, TcpNoDelay, true);
 
+    /// Connection socket connect timeout. If the timeout is negative then the connect operation will never timeout.
+    DECLARE_FIELD(connection_connect_timeout, std::chrono::milliseconds, SetConnectionConnectTimeout, std::chrono::seconds(5));
+
     /// Connection socket timeout. If the timeout is set to zero then the operation will never timeout.
     DECLARE_FIELD(connection_recv_timeout, std::chrono::milliseconds, SetConnectionRecvTimeout, std::chrono::milliseconds(0));
     DECLARE_FIELD(connection_send_timeout, std::chrono::milliseconds, SetConnectionSendTimeout, std::chrono::milliseconds(0));


### PR DESCRIPTION
Following up on #205, it would be nice to have control over the connection timeout as well.

Currently it is limited at 5 seconds regardless of configured recv/send timeouts.