### PR TITLE
Fix getaddrinfo error reporting

### DIFF
--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -274,7 +274,7 @@ NetworkAddress::NetworkAddress(const std::string& host, const std::string& port)
     const int error = getaddrinfo(host.c_str(), port.c_str(), &hints, &info_);
 
 #if defined(_unix_)
-    if (error != EAI_SYSTEM) {
+    if (error && error != EAI_SYSTEM) {
         throw std::system_error(error, getaddrinfoErrorCategory::category());
     }
 #endif

--- a/clickhouse/base/socket.cpp
+++ b/clickhouse/base/socket.cpp
@@ -43,6 +43,21 @@ windowsErrorCategory const& windowsErrorCategory::category() {
 }
 #endif
 
+#if defined(_unix_)
+char const* getaddrinfoErrorCategory::name() const noexcept {
+    return "getaddrinfoError";
+}
+
+std::string getaddrinfoErrorCategory::message(int c) const {
+    return gai_strerror(c);
+}
+
+getaddrinfoErrorCategory const& getaddrinfoErrorCategory::category() {
+    static getaddrinfoErrorCategory c;
+    return c;
+}
+#endif
+
 namespace {
 
 class LocalNames : public std::unordered_set<std::string> {
@@ -257,6 +272,12 @@ NetworkAddress::NetworkAddress(const std::string& host, const std::string& port)
 #endif
 
     const int error = getaddrinfo(host.c_str(), port.c_str(), &hints, &info_);
+
+#if defined(_unix_)
+    if (error != EAI_SYSTEM) {
+        throw std::system_error(error, getaddrinfoErrorCategory::category());
+    }
+#endif
 
     if (error) {
         throw std::system_error(getSocketErrorCode(), getErrorCategory());

--- a/clickhouse/base/socket.h
+++ b/clickhouse/base/socket.h
@@ -60,6 +60,18 @@ public:
 
 #endif
 
+#if defined(_unix_)
+
+class getaddrinfoErrorCategory : public std::error_category {
+public:
+    char const* name() const noexcept override final;
+    std::string message(int c) const override final;
+
+    static getaddrinfoErrorCategory const& category();
+};
+
+#endif
+
 
 class SocketBase {
 public:

--- a/ut/socket_ut.cpp
+++ b/ut/socket_ut.cpp
@@ -4,10 +4,16 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
-#include <netdb.h>
 #include <stdio.h>
 #include <string.h>
 #include <thread>
+
+// for EAI_* error codes
+#if defined(_win_)
+#   include <ws2tcpip.h>
+#else
+#   include <netdb.h>
+#endif
 
 using namespace clickhouse;
 
@@ -69,7 +75,7 @@ TEST(Socketcase, gaierror) {
         NetworkAddress addr("host.invalid", "80");  // never resolves
         FAIL();
     } catch (const std::system_error& e) {
-        ASSERT_EQ(EAI_NONAME, e.code().value());
+        ASSERT_PRED1([](int error) { return error == EAI_NONAME || error == EAI_AGAIN || error == EAI_FAIL; }, e.code().value());
     }
 }
 

--- a/ut/socket_ut.cpp
+++ b/ut/socket_ut.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <iostream>
+#include <netdb.h>
 #include <stdio.h>
 #include <string.h>
 #include <thread>
@@ -61,6 +62,15 @@ TEST(Socketcase, timeoutrecv) {
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     server.stop();
+}
+
+TEST(Socketcase, gaierror) {
+    try {
+        NetworkAddress addr("host.invalid", "80");  // never resolves
+        FAIL();
+    } catch (const std::system_error& e) {
+        ASSERT_EQ(EAI_NONAME, e.code().value());
+    }
 }
 
 // Test to verify that reading from empty socket doesn't hangs.


### PR DESCRIPTION
`getaddrinfo` error reporting is currently broken on non-Windows platforms as only a subset of its errors are reported via `errno`.
(On Windows everything gets combined in `WSAGetLastError()` and `gai_strerror` is declared not thread-safe for some reason.)