### PR TITLE
Handle "Bool" columns

### DIFF
--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -32,6 +32,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
     { "Int16",       Type::Int16 },
     { "Int32",       Type::Int32 },
     { "Int64",       Type::Int64 },
+    { "Bool",        Type::UInt8 },
     { "UInt8",       Type::UInt8 },
     { "UInt16",      Type::UInt16 },
     { "UInt32",      Type::UInt32 },

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -59,6 +59,12 @@ TEST(CreateColumnByType, AggregateFunction) {
 class CreateColumnByTypeWithName : public ::testing::TestWithParam<const char* /*Column Type String*/>
 {};
 
+TEST(CreateColumnByType, Bool) {
+    const auto col = CreateColumnByType("Bool");
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ(col->GetType().GetName(), "UInt8");
+}
+
 TEST_P(CreateColumnByTypeWithName, CreateColumnByType)
 {
     const auto col = CreateColumnByType(GetParam());

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -288,16 +288,17 @@ TEST_P(ClientCase, LowCardinalityString_AsString) {
 
 TEST_P(ClientCase, Generic) {
     client_->Execute(
-            "CREATE TEMPORARY TABLE IF NOT EXISTS test_clickhouse_cpp_client (id UInt64, name String) ");
+            "CREATE TEMPORARY TABLE IF NOT EXISTS test_clickhouse_cpp_client (id UInt64, name String, f Bool) ");
 
     const struct {
         uint64_t id;
         std::string name;
+        bool f;
     } TEST_DATA[] = {
-        { 1, "id" },
-        { 3, "foo" },
-        { 5, "bar" },
-        { 7, "name" },
+        { 1, "id", true },
+        { 3, "foo", false },
+        { 5, "bar", true },
+        { 7, "name", false },
     };
 
     /// Insert some values.
@@ -306,20 +307,23 @@ TEST_P(ClientCase, Generic) {
 
         auto id = std::make_shared<ColumnUInt64>();
         auto name = std::make_shared<ColumnString>();
+        auto f = std::make_shared<ColumnUInt8> ();
         for (auto const& td : TEST_DATA) {
             id->Append(td.id);
             name->Append(td.name);
+            f->Append(td.f);
         }
 
         block.AppendColumn("id"  , id);
         block.AppendColumn("name", name);
+        block.AppendColumn("f",    f);
 
         client_->Insert("test_clickhouse_cpp_client", block);
     }
 
     /// Select values inserted in the previous step.
     size_t row = 0;
-    client_->Select("SELECT id, name FROM test_clickhouse_cpp_client", [TEST_DATA, &row](const Block& block)
+    client_->Select("SELECT id, name, f FROM test_clickhouse_cpp_client", [TEST_DATA, &row](const Block& block)
         {
             if (block.GetRowCount() == 0) {
                 return;
@@ -329,6 +333,7 @@ TEST_P(ClientCase, Generic) {
             for (size_t c = 0; c < block.GetRowCount(); ++c, ++row) {
                 EXPECT_EQ(TEST_DATA[row].id, (*block[0]->As<ColumnUInt64>())[c]);
                 EXPECT_EQ(TEST_DATA[row].name, (*block[1]->As<ColumnString>())[c]);
+                EXPECT_EQ(TEST_DATA[row].f, (*block[2]->As<ColumnUInt8>())[c]);
             }
         }
     );


### PR DESCRIPTION
Bool table columns are not recognized and mapped to "Void".
Mapping updated to treat Bool columns as UInt8