### PR TITLE
Fixed deprecation warning

### DIFF
--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -45,12 +45,13 @@ enum class CompressionMethod {
 };
 
 struct ClientOptions {
+    // Setter goes first, so it is possible to apply 'deprecated' annotation safely.
 #define DECLARE_FIELD(name, type, setter, default_value) \
-    type name = default_value; \
     inline auto & setter(const type& value) { \
         name = value; \
         return *this; \
-    }
+    } \
+    type name = default_value
 
     /// Hostname of the server.
     DECLARE_FIELD(host, std::string, SetHost, std::string());


### PR DESCRIPTION
Client's that do not even call any deprecated APIs were getting warning/error: 'backward_compatibility_lowcardinality_as_wrapped_column' is deprecated

Closes: #274