### PR TITLE
Fix Windows build

### DIFF
--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -19,6 +19,7 @@ struct QuerySettingsField {
     {
         IMPORTANT = 0x01,
         CUSTOM = 0x02,
+        OBSOLETE = 0x04,
     };
     std::string value;
     uint64_t flags{0};

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -310,6 +310,25 @@ std::ostream & operator<<(std::ostream & ostr, const ServerInfo & server_info) {
                 << " (" << server_info.revision << ")";
 }
 
+std::ostream & operator<<(std::ostream & ostr, const Profile & profile) {
+    return ostr
+        << "rows : " << profile.rows
+        << " blocks : " << profile.blocks
+        << " bytes : " << profile.bytes
+        << " rows_before_limit : " << profile.rows_before_limit
+        << " applied_limit : " << profile.applied_limit
+        << " calculated_rows_before_limit : " << profile.calculated_rows_before_limit;
+}
+
+std::ostream & operator<<(std::ostream & ostr, const Progress & progress) {
+    return ostr
+        << "rows : " << progress.rows
+        << " bytes : " << progress.bytes
+        << " total_rows : " << progress.total_rows
+        << " written_rows : " << progress.written_rows
+        << " written_bytes : " << progress.written_bytes;
+}
+
 }
 
 uint64_t versionNumber(const ServerInfo & server_info) {

--- a/ut/utils.h
+++ b/ut/utils.h
@@ -3,6 +3,7 @@
 #include <clickhouse/base/platform.h>
 #include <clickhouse/base/uuid.h>
 
+#include "clickhouse/query.h"
 #include "utils_meta.h"
 #include "utils_comparison.h"
 
@@ -24,6 +25,9 @@ namespace clickhouse {
     class Block;
     class Type;
     struct ServerInfo;
+    struct Profile;
+    struct QuerySettingsField;
+    struct Progress;
 }
 
 template <typename ResultType = std::string>
@@ -136,6 +140,8 @@ namespace clickhouse {
 std::ostream& operator<<(std::ostream & ostr, const Block & block);
 std::ostream& operator<<(std::ostream & ostr, const Type & type);
 std::ostream & operator<<(std::ostream & ostr, const ServerInfo & server_info);
+std::ostream & operator<<(std::ostream & ostr, const Profile & profile);
+std::ostream & operator<<(std::ostream & ostr, const Progress & progress);
 }
 
 std::ostream& operator<<(std::ostream & ostr, const PrettyPrintBlock & block);


### PR DESCRIPTION
https://github.com/ClickHouse/clickhouse-cpp/actions/runs/4714567769/jobs/8361003596?pr=298

```
D:\a\clickhouse-cpp\clickhouse-cpp\ut\utils.h(120,16): error C2679: binary '<<': no operator found which takes a right-hand operand of type 'const _Ty' (or there is no acceptable conversion) [D:\a\clickhouse-cpp\clickhouse-cpp\build\ut\clickhouse-cpp-ut.vcxproj]
          with
          [
              _Ty=clickhouse::Profile
          ]
```