### PR TITLE
Minor: Deprecated LowCardinalitySerializationAdaptor

### DIFF
--- a/clickhouse/columns/lowcardinalityadaptor.h
+++ b/clickhouse/columns/lowcardinalityadaptor.h
@@ -22,7 +22,9 @@ class CodedInputStream;
  * @see ClientOptions, CreateColumnByType
  */
 template <typename AdaptedColumnType>
-class LowCardinalitySerializationAdaptor : public AdaptedColumnType
+class
+[[deprecated("Makes implementation of LC(X) harder and code uglier. Will be removed in next major release (3.0) ")]]
+LowCardinalitySerializationAdaptor : public AdaptedColumnType
 {
 public:
     using AdaptedColumnType::AdaptedColumnType;


### PR DESCRIPTION
Should've been deprecated together with [`backward_compatibility_lowcardinality_as_wrapped_column`](https://github.com/ClickHouse/clickhouse-cpp/blob/master/clickhouse/client.h#L106) by #233