### PR TITLE
added DEBUG_DEPENDENCIES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ OPTION (WITH_OPENSSL "Use OpenSSL for TLS connections" OFF)
 OPTION (WITH_SYSTEM_ABSEIL "Use system ABSEIL" OFF)
 OPTION (WITH_SYSTEM_LZ4 "Use system LZ4" OFF)
 OPTION (WITH_SYSTEM_CITYHASH "Use system cityhash" OFF)
+OPTION (DEBUG_DEPENDENCIES "Print debug info about dependencies duting build" ON)
 
 PROJECT (CLICKHOUSE-CLIENT)
 
@@ -99,3 +100,36 @@ PROJECT (CLICKHOUSE-CLIENT)
             ut
         )
     ENDIF (BUILD_TESTS)
+
+    if(DEBUG_DEPENDENCIES)
+        function(print_target_properties target)
+            MESSAGE("${target} properties:")
+            set(properties "${ARGN}")
+            foreach(property_name ${properties})
+                get_target_property(PROPERTY ${target} ${property_name})
+                MESSAGE(NOTICE "\t${property_name} : ${PROPERTY}")
+            endforeach()
+
+            # Can't get path to the target file at configure time,
+            # so have to create a target to fetch that info at generate time.
+            string(REPLACE ":" "_" target_plain_name ${target})
+            add_custom_target(${target_plain_name}_print_debug_info COMMAND ${CMAKE_COMMAND} -E echo "${target} : $<TARGET_FILE:${target}>")
+            add_dependencies(clickhouse-cpp-lib ${target_plain_name}_print_debug_info)
+        endfunction()
+
+        function(print_target_debug_info target)
+            print_target_properties(${target}
+                INCLUDE_DIRECTORIES
+                BINARY_DIR
+                INTERFACE_INCLUDE_DIRECTORIES
+                INTERFACE_LINK_LIBRARIES
+                LINK_LIBRARIES
+                LINK_LIBRARIES_ONLY_TARGETS
+                IMPORTED_LOCATION
+            )
+        endfunction()
+
+        print_target_debug_info(absl::int128)
+        print_target_debug_info(cityhash::cityhash)
+        print_target_debug_info(lz4::lz4)
+    endif()

--- a/cmake/Findlz4.cmake
+++ b/cmake/Findlz4.cmake
@@ -32,6 +32,7 @@ if (lz4_FOUND)
   if (NOT TARGET lz4::lz4)
     add_library(lz4::lz4 UNKNOWN IMPORTED)
     set_target_properties(lz4::lz4 PROPERTIES
+      INCLUDE_DIRECTORIES ${lz4_INCLUDE_DIRS}
       IMPORTED_LOCATION "${lz4_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${lz4_INCLUDE_DIR}")
   endif ()


### PR DESCRIPTION
That prints some info about dependencies both at configure and at compile time.
Shouldn't affect produced binaries, just a little utility to help debugging third-party issues.