### PR TITLE
Fix abnormal column names in gcc7.3.1

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -609,9 +609,9 @@ bool Client::Impl::ReadBlock(InputStream& input, Block* block) {
     CreateColumnByTypeSettings create_column_settings;
     create_column_settings.low_cardinality_as_wrapped_column = options_.backward_compatibility_lowcardinality_as_wrapped_column;
 
-    std::string name;
-    std::string type;
     for (size_t i = 0; i < num_columns; ++i) {
+        std::string name;
+        std::string type;
         if (!WireFormat::ReadString(input, &name)) {
             return false;
         }

--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -15,6 +15,7 @@ SET ( clickhouse-cpp-ut-src
     performance_tests.cpp
     tcp_server.cpp
     readonly_client_test.cpp
+    abnormal_column_names_test.cpp
     connection_failed_client_test.cpp
     array_of_low_cardinality_tests.cpp
     CreateColumnByType_ut.cpp

--- a/ut/abnormal_column_names_test.cpp
+++ b/ut/abnormal_column_names_test.cpp
@@ -1,0 +1,47 @@
+#include "abnormal_column_names_test.h"
+#include "utils.h"
+
+#include <clickhouse/columns/column.h>
+#include <clickhouse/block.h>
+#include <unordered_set>
+#include <iostream>
+
+namespace {
+    using namespace clickhouse;
+}
+
+void AbnormalColumnNamesTest::SetUp() {
+    client_ = std::make_unique<Client>(std::get<0>(GetParam()));
+}
+
+void AbnormalColumnNamesTest::TearDown() {
+    client_.reset();
+}
+
+// Sometimes gtest fails to detect that this test is instantiated elsewhere, suppress the error explicitly.
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(AbnormalColumnNamesTest);
+TEST_P(AbnormalColumnNamesTest, Select) {
+
+    const auto & queries = std::get<1>(GetParam());
+    for (const auto & query : queries) {
+        std::unordered_set<std::string> names;
+        size_t count = 0;
+        client_->Select(query,
+            [& query,& names, & count](const Block& block) {
+                if (block.GetRowCount() == 0 || block.GetColumnCount() == 0)
+                    return;
+
+                std::cout << "query => " << query <<"\n" << PrettyPrintBlock{block}; 
+                for (size_t i = 0; i < block.GetColumnCount(); ++i)
+                {
+                    count++;
+                    names.insert(block.GetColumnName(i));
+                }
+            }
+        );
+        EXPECT_EQ(count, names.size());
+        for(auto& name: names) {
+            std::cout << name << ", count=" << count<< std::endl;
+        }
+    }
+}

--- a/ut/abnormal_column_names_test.h
+++ b/ut/abnormal_column_names_test.h
@@ -8,7 +8,7 @@
 #include <tuple>
 #include <vector>
 
-class AbnormalColumnNamesTest : public testing::TestWithParam<
+class AbnormalColumnNamesClientTest : public testing::TestWithParam<
         std::tuple<clickhouse::ClientOptions, std::vector<std::string> > /*queries*/> {
 protected:
     void SetUp() override;

--- a/ut/abnormal_column_names_test.h
+++ b/ut/abnormal_column_names_test.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <clickhouse/client.h>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+class AbnormalColumnNamesTest : public testing::TestWithParam<
+        std::tuple<clickhouse::ClientOptions, std::vector<std::string> > /*queries*/> {
+protected:
+    void SetUp() override;
+    void TearDown() override;
+
+    std::unique_ptr<clickhouse::Client> client_;
+};

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1,7 +1,6 @@
 #include <clickhouse/client.h>
 
 #include "readonly_client_test.h"
-#include "abnormal_column_names_test.h"
 #include "connection_failed_client_test.h"
 #include "utils.h"
 
@@ -1194,21 +1193,6 @@ INSTANTIATE_TEST_SUITE_P(ClientLocalReadonly, ReadonlyClientTest,
             .SetPingBeforeQuery(true)
             .SetCompressionMethod(CompressionMethod::None),
         QUERIES
-    }
-));
-
-INSTANTIATE_TEST_SUITE_P(ColumnNames, AbnormalColumnNamesTest,
-    ::testing::Values(AbnormalColumnNamesTest::ParamType{
-        ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
-            .SetPort(           getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
-            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
-            .SetSendRetries(1)
-            .SetPingBeforeQuery(true)
-            .SetCompressionMethod(CompressionMethod::None),
-            {"select 123,231,113", "select 'ABC','AAA','BBB','CCC'"}
     }
 ));
 

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1,6 +1,7 @@
 #include <clickhouse/client.h>
 
 #include "readonly_client_test.h"
+#include "abnormal_column_names_test.h"
 #include "connection_failed_client_test.h"
 #include "utils.h"
 
@@ -1195,6 +1196,22 @@ INSTANTIATE_TEST_SUITE_P(ClientLocalReadonly, ReadonlyClientTest,
         QUERIES
     }
 ));
+
+INSTANTIATE_TEST_SUITE_P(ColumnNames, AbnormalColumnNamesTest,
+    ::testing::Values(AbnormalColumnNamesTest::ParamType{
+        ClientOptions()
+            .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
+            .SetPort(           getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))
+            .SetUser(           getEnvOrDefault("CLICKHOUSE_USER",     "default"))
+            .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
+            .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"))
+            .SetSendRetries(1)
+            .SetPingBeforeQuery(true)
+            .SetCompressionMethod(CompressionMethod::None),
+            {"select 123,231,113", "select 'ABC','AAA','BBB','CCC'"}
+    }
+));
+
 
 INSTANTIATE_TEST_SUITE_P(ClientLocalFailed, ConnectionFailedClientTest,
     ::testing::Values(ConnectionFailedClientTest::ParamType{


### PR DESCRIPTION
Fix abnormal column names in gcc7.3.1

example: "select 123,231,113"

on gcc7.3.1 output:
name:113, type:UInt8
name:113, type:UInt8
name:113, type:UInt8

on gcc9.3.1 output:
name:123, type:UInt8
name:231, type:UInt8
name:113, type:UInt8