### PR TITLE
Implemented Append/RawAt/operator[] for ColumnDate and ColumnDate32 that work with uint16_t/int32_t

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -17,7 +17,6 @@ SET ( clickhouse-cpp-lib-src
     columns/ip4.cpp
     columns/ip6.cpp
     columns/lowcardinality.cpp
-    columns/lowcardinalityadaptor.h
     columns/nullable.cpp
     columns/numeric.cpp
     columns/map.cpp
@@ -33,6 +32,55 @@ SET ( clickhouse-cpp-lib-src
     block.cpp
     client.cpp
     query.cpp
+
+    # Headers
+    base/buffer.h
+    base/compressed.h
+    base/endpoints_iterator.h
+    base/input.h
+    base/open_telemetry.h
+    base/output.h
+    base/platform.h
+    base/projected_iterator.h
+    base/singleton.h
+    base/socket.h
+    base/sslsocket.h
+    base/string_utils.h
+    base/string_view.h
+    base/uuid.h
+    base/wire_format.h
+
+    columns/array.h
+    columns/column.h
+    columns/date.h
+    columns/decimal.h
+    columns/enum.h
+    columns/factory.h
+    columns/geo.h
+    columns/ip4.h
+    columns/ip6.h
+    columns/itemview.h
+    columns/lowcardinality.h
+    columns/lowcardinalityadaptor.h
+    columns/map.h
+    columns/nothing.h
+    columns/nullable.h
+    columns/numeric.h
+    columns/string.h
+    columns/tuple.h
+    columns/utils.h
+    columns/uuid.h
+
+    types/type_parser.h
+    types/types.h
+
+    block.h
+    client.h
+    error_codes.h
+    exceptions.h
+    protocol.h
+    query.h
+    server_exception.h
 )
 
 if (MSVC)

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -1,4 +1,5 @@
 #include "date.h"
+#include <cstdint>
 
 namespace clickhouse {
 
@@ -9,7 +10,7 @@ ColumnDate::ColumnDate()
 }
 
 void ColumnDate::Append(const std::time_t& value) {
-    /// TODO: This code is fundamentally wrong.
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     data_->Append(static_cast<uint16_t>(value / std::time_t(86400)));
 }
 
@@ -18,7 +19,21 @@ void ColumnDate::Clear() {
 }
 
 std::time_t ColumnDate::At(size_t n) const {
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     return static_cast<std::time_t>(data_->At(n)) * 86400;
+}
+
+
+void ColumnDate::Append(uint16_t value) {
+    data_->Append(value);
+}
+
+uint16_t ColumnDate::RawAt(size_t n) const {
+    return data_->At(n);
+}
+
+uint16_t ColumnDate::operator [] (size_t n) const {
+    return (*data_)[n];
 }
 
 void ColumnDate::Append(ColumnRef column) {
@@ -70,7 +85,7 @@ ColumnDate32::ColumnDate32()
 }
 
 void ColumnDate32::Append(const std::time_t& value) {
-    /// TODO: This code is fundamentally wrong.
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     data_->Append(static_cast<int32_t>(value / std::time_t(86400)));
 }
 
@@ -79,6 +94,7 @@ void ColumnDate32::Clear() {
 }
 
 std::time_t ColumnDate32::At(size_t n) const {
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     return static_cast<std::time_t>(data_->At(n)) * 86400;
 }
 
@@ -86,6 +102,18 @@ void ColumnDate32::Append(ColumnRef column) {
     if (auto col = column->As<ColumnDate32>()) {
         data_->Append(col->data_);
     }
+}
+
+void ColumnDate32::Append(int32_t value) {
+    data_->Append(value);
+}
+
+int32_t ColumnDate32::RawAt(size_t n) const {
+    return data_->At(n);
+}
+
+int32_t ColumnDate32::operator [] (size_t n) const {
+    return (*data_)[n];
 }
 
 bool ColumnDate32::LoadBody(InputStream* input, size_t rows) {

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -160,10 +160,6 @@ std::time_t ColumnDateTime::At(size_t n) const {
     return data_->At(n);
 }
 
-std::time_t ColumnDateTime::operator[](size_t n) const {
-    return data_->At(n);
-}
-
 std::string ColumnDateTime::Timezone() const {
     return type_->As<DateTimeType>()->Timezone();
 }
@@ -239,10 +235,6 @@ void ColumnDateTime64::Append(const Int64& value) {
 Int64 ColumnDateTime64::At(size_t n) const {
     // make sure to use Absl's Int128 conversion
     return static_cast<Int64>(data_->At(n));
-}
-
-Int64 ColumnDateTime64::operator[](size_t n) const {
-    return this->At(n);
 }
 
 std::string ColumnDateTime64::Timezone() const {

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -23,20 +23,12 @@ std::time_t ColumnDate::At(size_t n) const {
     return static_cast<std::time_t>(data_->At(n)) * 86400;
 }
 
-void ColumnDate::Append(uint16_t value) {
-    data_->Append(value);
-}
-
 void ColumnDate::AppendRaw(uint16_t value) {
     data_->Append(value);
 }
 
 uint16_t ColumnDate::RawAt(size_t n) const {
     return data_->At(n);
-}
-
-uint16_t ColumnDate::operator [] (size_t n) const {
-    return (*data_)[n];
 }
 
 void ColumnDate::Append(ColumnRef column) {
@@ -106,20 +98,12 @@ void ColumnDate32::Append(ColumnRef column) {
     }
 }
 
-void ColumnDate32::Append(int32_t value) {
-    data_->Append(value);
-}
-
 void ColumnDate32::AppendRaw(int32_t value) {
     data_->Append(value);
 }
 
 int32_t ColumnDate32::RawAt(size_t n) const {
     return data_->At(n);
-}
-
-int32_t ColumnDate32::operator [] (size_t n) const {
-    return (*data_)[n];
 }
 
 bool ColumnDate32::LoadBody(InputStream* input, size_t rows) {
@@ -156,7 +140,6 @@ ItemView ColumnDate32::GetItem(size_t index) const {
     return ItemView{Type()->GetCode(), data_->GetItem(index)};
 }
 
-
 ColumnDateTime::ColumnDateTime()
     : Column(Type::CreateDateTime())
     , data_(std::make_shared<ColumnUInt32>())
@@ -174,6 +157,10 @@ void ColumnDateTime::Append(const std::time_t& value) {
 }
 
 std::time_t ColumnDateTime::At(size_t n) const {
+    return data_->At(n);
+}
+
+std::time_t ColumnDateTime::operator[](size_t n) const {
     return data_->At(n);
 }
 
@@ -252,6 +239,10 @@ void ColumnDateTime64::Append(const Int64& value) {
 Int64 ColumnDateTime64::At(size_t n) const {
     // make sure to use Absl's Int128 conversion
     return static_cast<Int64>(data_->At(n));
+}
+
+Int64 ColumnDateTime64::operator[](size_t n) const {
+    return this->At(n);
 }
 
 std::string ColumnDateTime64::Timezone() const {

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -23,8 +23,11 @@ std::time_t ColumnDate::At(size_t n) const {
     return static_cast<std::time_t>(data_->At(n)) * 86400;
 }
 
-
 void ColumnDate::Append(uint16_t value) {
+    data_->Append(value);
+}
+
+void ColumnDate::AppendRaw(uint16_t value) {
     data_->Append(value);
 }
 
@@ -77,7 +80,6 @@ ItemView ColumnDate::GetItem(size_t index) const {
 }
 
 
-
 ColumnDate32::ColumnDate32()
     : Column(Type::CreateDate32())
     , data_(std::make_shared<ColumnInt32>())
@@ -105,6 +107,10 @@ void ColumnDate32::Append(ColumnRef column) {
 }
 
 void ColumnDate32::Append(int32_t value) {
+    data_->Append(value);
+}
+
+void ColumnDate32::AppendRaw(int32_t value) {
     data_->Append(value);
 }
 

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -269,6 +269,7 @@ void ColumnDateTime64::SaveBody(OutputStream* output) {
 void ColumnDateTime64::Clear() {
     data_->Clear();
 }
+
 size_t ColumnDateTime64::Size() const {
     return data_->Size();
 }

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -24,7 +24,7 @@ public:
 
     /// Do data as is -- number of day in Unix epoch, no conversions performed
     void Append(uint16_t value);
-    void AppendRaw(uint16_t value) { Append(value); }
+    void AppendRaw(uint16_t value);
     uint16_t RawAt(size_t n) const;
     uint16_t operator [] (size_t n) const;
 
@@ -74,7 +74,7 @@ public:
 
     /// Do data as is -- number of day in Unix epoch, no conversions performed
     void Append(int32_t value);
-    void AppendRaw(int32_t value) { Append(value); }
+    void AppendRaw(int32_t value);
     int32_t RawAt(size_t n) const;
     int32_t operator [] (size_t n) const;
 

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -21,12 +21,11 @@ public:
     /// Returns element at given row number.
     /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     std::time_t At(size_t n) const;
+    inline std::time_t operator [] (size_t n) const { return this->At(n); }
 
-    /// Do data as is -- number of day in Unix epoch, no conversions performed
-    void Append(uint16_t value);
+    /// Do append data as is -- number of day in Unix epoch, no conversions performed.
     void AppendRaw(uint16_t value);
     uint16_t RawAt(size_t n) const;
-    uint16_t operator [] (size_t n) const;
 
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
@@ -72,11 +71,11 @@ public:
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
 
-    /// Do data as is -- number of day in Unix epoch, no conversions performed
-    void Append(int32_t value);
+    inline auto operator [] (size_t n) const { return this->At(n); }
+
+    /// Do append data as is -- number of day in Unix epoch (32bit signed), no conversions performed.
     void AppendRaw(int32_t value);
     int32_t RawAt(size_t n) const;
-    int32_t operator [] (size_t n) const;
 
     /// Loads column data from input stream.
     bool LoadBody(InputStream* input, size_t rows) override;
@@ -115,6 +114,7 @@ public:
 
     /// Returns element at given row number.
     std::time_t At(size_t n) const;
+    std::time_t operator [] (size_t n) const;
 
     /// Timezone associated with a data column.
     std::string Timezone() const;
@@ -163,6 +163,8 @@ public:
 
     /// Returns element at given row number.
     Int64 At(size_t n) const;
+
+    Int64 operator[](size_t n) const;
 
     /// Timezone associated with a data column.
     std::string Timezone() const;

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -101,7 +101,7 @@ private:
 };
 
 
-/** */
+/** DateTime64 supports date-time values (number of seconds since UNIX epoch), from 1970 up to 2130. */
 class ColumnDateTime : public Column {
 public:
     using ValueType = std::time_t;
@@ -147,7 +147,7 @@ private:
 };
 
 
-/** */
+/** DateTime64 supports date-time values of arbitrary sub-second precision, from 1900 up to 2300. */
 class ColumnDateTime64 : public Column {
 public:
     using ValueType = Int64;

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -15,12 +15,18 @@ public:
     ColumnDate();
 
     /// Appends one element to the end of column.
-    /// TODO: The implementation is fundamentally wrong.
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     void Append(const std::time_t& value);
 
     /// Returns element at given row number.
-    /// TODO: The implementation is fundamentally wrong.
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     std::time_t At(size_t n) const;
+
+    /// Do data as is -- number of day in Unix epoch, no conversions performed
+    void Append(uint16_t value);
+    void AppendRaw(uint16_t value) { Append(value); }
+    uint16_t RawAt(size_t n) const;
+    uint16_t operator [] (size_t n) const;
 
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
@@ -56,15 +62,21 @@ public:
     ColumnDate32();
 
     /// Appends one element to the end of column.
-    /// TODO: The implementation is fundamentally wrong.
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     void Append(const std::time_t& value);
 
     /// Returns element at given row number.
-    /// TODO: The implementation is fundamentally wrong.
+    /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     std::time_t At(size_t n) const;
 
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
+
+    /// Do data as is -- number of day in Unix epoch, no conversions performed
+    void Append(int32_t value);
+    void AppendRaw(int32_t value) { Append(value); }
+    int32_t RawAt(size_t n) const;
+    int32_t operator [] (size_t n) const;
 
     /// Loads column data from input stream.
     bool LoadBody(InputStream* input, size_t rows) override;

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -21,7 +21,7 @@ public:
     /// Returns element at given row number.
     /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     std::time_t At(size_t n) const;
-    inline std::time_t operator [] (size_t n) const { return this->At(n); }
+    inline std::time_t operator [] (size_t n) const { return At(n); }
 
     /// Do append data as is -- number of day in Unix epoch, no conversions performed.
     void AppendRaw(uint16_t value);
@@ -71,7 +71,7 @@ public:
     /// Appends content of given column to the end of current one.
     void Append(ColumnRef column) override;
 
-    inline auto operator [] (size_t n) const { return this->At(n); }
+    inline std::time_t operator [] (size_t n) const { return At(n); }
 
     /// Do append data as is -- number of day in Unix epoch (32bit signed), no conversions performed.
     void AppendRaw(int32_t value);
@@ -114,7 +114,7 @@ public:
 
     /// Returns element at given row number.
     std::time_t At(size_t n) const;
-    std::time_t operator [] (size_t n) const;
+    inline std::time_t operator [] (size_t n) const { return At(n); }
 
     /// Timezone associated with a data column.
     std::string Timezone() const;
@@ -164,7 +164,7 @@ public:
     /// Returns element at given row number.
     Int64 At(size_t n) const;
 
-    Int64 operator[](size_t n) const;
+    inline Int64 operator[](size_t n) const { return At(n); }
 
     /// Timezone associated with a data column.
     std::string Timezone() const;

--- a/clickhouse/columns/decimal.h
+++ b/clickhouse/columns/decimal.h
@@ -18,6 +18,7 @@ public:
     void Append(const std::string& value);
 
     Int128 At(size_t i) const;
+    inline auto operator[](size_t i) const { return At(i); }
 
 public:
     void Append(ColumnRef column) override;

--- a/clickhouse/columns/enum.cpp
+++ b/clickhouse/columns/enum.cpp
@@ -49,11 +49,6 @@ std::string_view ColumnEnum<T>::NameAt(size_t n) const {
 }
 
 template <typename T>
-const T& ColumnEnum<T>::operator[] (size_t n) const {
-    return data_[n];
-}
-
-template <typename T>
 void ColumnEnum<T>::SetAt(size_t n, const T& value, bool checkValue) {
     if (checkValue) {
         // TODO: type_->HasEnumValue(value), "Enum type doesn't have value " + std::to_string(value);

--- a/clickhouse/columns/enum.h
+++ b/clickhouse/columns/enum.h
@@ -22,7 +22,7 @@ public:
     std::string_view NameAt(size_t n) const;
 
     /// Returns element at given row number.
-    const T& operator[] (size_t n) const;
+    inline const T& operator[] (size_t n) const { return At(n); }
 
     /// Set element at given row number.
     void SetAt(size_t n, const T& value, bool checkValue = false);

--- a/clickhouse/columns/geo.cpp
+++ b/clickhouse/columns/geo.cpp
@@ -55,11 +55,6 @@ const typename ColumnGeo<NestedColumnType, type_code>::ValueType ColumnGeo<Neste
 }
 
 template <typename NestedColumnType, Type::Code type_code>
-const typename ColumnGeo<NestedColumnType, type_code>::ValueType ColumnGeo<NestedColumnType, type_code>::operator[](size_t n) const {
-    return data_->At(n);
-}
-
-template <typename NestedColumnType, Type::Code type_code>
 void ColumnGeo<NestedColumnType, type_code>::Append(ColumnRef column) {
     if (auto col = column->template As<ColumnGeo>()) {
         data_->Append(col->data_->template As<Column>());

--- a/clickhouse/columns/geo.h
+++ b/clickhouse/columns/geo.h
@@ -26,7 +26,7 @@ public:
     const ValueType At(size_t n) const;
 
     /// Returns element at given row number.
-    const ValueType operator[](size_t n) const;
+    inline const ValueType operator[](size_t n) const { return At(n); }
 
 public:
     /// Appends content of given column to the end of current one.

--- a/clickhouse/columns/map.h
+++ b/clickhouse/columns/map.h
@@ -212,7 +212,7 @@ public:
 
     inline auto At(size_t index) const { return MapValueView{typed_data_->At(index)}; }
 
-    inline auto operator[](size_t index) const { return MapValueView{typed_data_->At(index)}; }
+    inline auto operator[](size_t index) const { return At(index); }
 
     using ColumnMap::Append;
 

--- a/clickhouse/columns/nothing.h
+++ b/clickhouse/columns/nothing.h
@@ -33,7 +33,7 @@ public:
     std::nullptr_t At(size_t) const { return nullptr; };
 
     /// Returns element at given row number.
-    std::nullptr_t operator [] (size_t) const { return nullptr; };
+    inline std::nullptr_t operator [] (size_t) const { return nullptr; };
 
     /// Makes slice of the current column.
     ColumnRef Slice(size_t, size_t len) const override {

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -49,11 +49,6 @@ const T& ColumnVector<T>::At(size_t n) const {
 }
 
 template <typename T>
-const T& ColumnVector<T>::operator [] (size_t n) const {
-    return data_[n];
-}
-
-template <typename T>
 void ColumnVector<T>::Append(ColumnRef column) {
     if (auto col = column->As<ColumnVector<T>>()) {
         data_.insert(data_.end(), col->data_.begin(), col->data_.end());

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -26,7 +26,7 @@ public:
     const T& At(size_t n) const;
 
     /// Returns element at given row number.
-    const T& operator [] (size_t n) const;
+    inline const T& operator [] (size_t n) const { return At(n); }
 
     void Erase(size_t pos, size_t count = 1);
 

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -58,11 +58,6 @@ std::string_view ColumnFixedString::At(size_t n) const {
     return std::string_view(&data_.at(pos), string_size_);
 }
 
-std::string_view ColumnFixedString::operator [](size_t n) const {
-    const auto pos = n * string_size_;
-    return std::string_view(&data_[pos], string_size_);
-}
-
 size_t ColumnFixedString::FixedSize() const {
        return string_size_;
 }
@@ -230,10 +225,6 @@ void ColumnString::Clear() {
 
 std::string_view ColumnString::At(size_t n) const {
     return items_.at(n);
-}
-
-std::string_view ColumnString::operator [] (size_t n) const {
-    return items_[n];
 }
 
 void ColumnString::Append(ColumnRef column) {

--- a/clickhouse/columns/string.h
+++ b/clickhouse/columns/string.h
@@ -34,7 +34,7 @@ public:
     std::string_view At(size_t n) const;
 
     /// Returns element at given row number.
-    std::string_view operator [] (size_t n) const;
+    inline std::string_view operator [] (size_t n) const { return At(n); }
 
     /// Returns the max size of the fixed string
     size_t FixedSize() const;
@@ -101,7 +101,7 @@ public:
     std::string_view At(size_t n) const;
 
     /// Returns element at given row number.
-    std::string_view operator [] (size_t n) const;
+    inline std::string_view operator [] (size_t n) const { return At(n); }
 
 public:
     /// Appends content of given column to the end of current one.

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -17,11 +17,11 @@ public:
     /// Returns count of columns in the tuple.
     size_t TupleSize() const;
 
-    ColumnRef operator [] (size_t n) const {
+    inline ColumnRef operator [] (size_t n) const {
         return columns_[n];
     }
 
-    ColumnRef At(size_t n) const {
+    inline ColumnRef At(size_t n) const {
         return columns_[n];
     }
 

--- a/clickhouse/columns/uuid.cpp
+++ b/clickhouse/columns/uuid.cpp
@@ -34,10 +34,6 @@ const UUID ColumnUUID::At(size_t n) const {
     return UUID(data_->At(n * 2), data_->At(n * 2 + 1));
 }
 
-const UUID ColumnUUID::operator [] (size_t n) const {
-    return UUID((*data_)[n * 2], (*data_)[n * 2 + 1]);
-}
-
 void ColumnUUID::Append(ColumnRef column) {
     if (auto col = column->As<ColumnUUID>()) {
         data_->Append(col->data_);

--- a/clickhouse/columns/uuid.h
+++ b/clickhouse/columns/uuid.h
@@ -23,7 +23,7 @@ public:
     const UUID At(size_t n) const;
 
     /// Returns element at given row number.
-    const UUID operator [] (size_t n) const;
+    inline const UUID operator [] (size_t n) const { return At(n); }
 
 public:
     /// Appends content of given column to the end of current one.

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -237,8 +237,8 @@ inline auto convertValueForGetItem(const ColumnType& col, ValueType&& t) {
     using T = std::remove_cv_t<std::decay_t<ValueType>>;
 
     if constexpr (std::is_same_v<ColumnType, ColumnDecimal>) {
-            // Since ColumnDecimal can hold 32, 64, 128-bit wide data and there is no way telling at run-time.
-            const ItemView item = col.GetItem(0);
+        // Since ColumnDecimal can hold 32, 64, 128-bit wide data and there is no way telling at run-time.
+        const ItemView item = col.GetItem(0);
         return std::string_view(reinterpret_cast<const char*>(&t), item.data.size());
     } else if constexpr (std::is_same_v<T, clickhouse::UInt128>
             || std::is_same_v<T, clickhouse::Int128>) {

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -66,7 +66,7 @@ public:
         } else if constexpr (std::is_same_v<ColumnType, ColumnFixedString>) {
             return GenerateVector(values_size, FromVectorGenerator{MakeFixedStrings(12)});
         } else if constexpr (std::is_same_v<ColumnType, ColumnDate>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeDates()});
+            return GenerateVector(values_size, FromVectorGenerator{MakeDates<time_t>()});
         } else if constexpr (std::is_same_v<ColumnType, ColumnDateTime>) {
             return GenerateVector(values_size, FromVectorGenerator{MakeDateTimes()});
         } else if constexpr (std::is_same_v<ColumnType, ColumnDateTime64>) {
@@ -142,6 +142,14 @@ using ValueColumns = ::testing::Types<
     , ColumnUUID
 >;
 TYPED_TEST_SUITE(GenericColumnTest, ValueColumns);
+
+//TestCase(TypeCreatorFunc, ValuesGeneratorFunc)
+
+
+//class GenericColumnTestCase
+//{
+//    virutual
+//};
 
 TYPED_TEST(GenericColumnTest, Construct) {
     auto column = this->MakeColumn();

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -43,53 +43,38 @@ std::ostream& operator<<(std::ostream& ostr, const Type::Code& type_code) {
 // 6. Swap: create two instances, populate one with data, swap with second, make sure has data was transferred
 // 7. Load/Save: create, append some data, save to buffer, load from same buffer into new column, make sure columns match.
 
+template <typename ColumnTypeT,
+          typename std::shared_ptr<ColumnTypeT> (*CreatorFunction)(),
+          typename GeneratorValueType,
+          typename std::vector<GeneratorValueType> (*GeneratorFunc)()>
+struct GenericColumnTestCase
+{
+    using ColumnType = ColumnTypeT;
+
+    static auto createColumn()
+    {
+        return CreatorFunction();
+    }
+
+    static auto generateValues()
+    {
+        return GeneratorFunc();
+    }
+};
+
 template <typename T>
 class GenericColumnTest : public testing::Test {
 public:
-    using ColumnType = std::decay_t<T>;
+    using ColumnType = typename T::ColumnType;
 
-    static auto MakeColumn() {
-        if constexpr (std::is_same_v<ColumnType, ColumnFixedString>) {
-            return std::make_shared<ColumnFixedString>(12);
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDateTime64>) {
-                return std::make_shared<ColumnDateTime64>(3);
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDecimal>) {
-                return std::make_shared<ColumnDecimal>(10, 5);
-        } else {
-            return std::make_shared<ColumnType>();
-        }
+    static auto MakeColumn()
+    {
+        return T::createColumn();
     }
 
-    static auto GenerateValues(size_t values_size) {
-        if constexpr (std::is_same_v<ColumnType, ColumnString>) {
-            return GenerateVector(values_size, FooBarGenerator);
-        } else if constexpr (std::is_same_v<ColumnType, ColumnFixedString>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeFixedStrings(12)});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDate>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeDates<time_t>()});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDateTime>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeDateTimes()});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDateTime64>) {
-            return MakeDateTime64s(3u, values_size);
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDate32>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeDates32()});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnIPv4>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeIPv4s()});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnIPv6>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeIPv6s()});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnInt128>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeInt128s()});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnDecimal>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeDecimals(3, 10)});
-        } else if constexpr (std::is_same_v<ColumnType, ColumnUUID>) {
-            return GenerateVector(values_size, FromVectorGenerator{MakeUUIDs()});
-        } else if constexpr (std::is_integral_v<typename ColumnType::ValueType>) {
-            // ColumnUIntX and ColumnIntX
-            return GenerateVector<typename ColumnType::ValueType>(values_size, RandomGenerator<int>());
-        } else if constexpr (std::is_floating_point_v<typename ColumnType::ValueType>) {
-            // OR ColumnFloatX
-            return GenerateVector<typename ColumnType::ValueType>(values_size, RandomGenerator<typename ColumnType::ValueType>());
-        }
+    static auto GenerateValues(size_t values_size)
+    {
+        return GenerateVector(values_size, FromVectorGenerator{T::generateValues()});
     }
 
     template <typename Values>
@@ -130,26 +115,79 @@ public:
     }
 };
 
-using ValueColumns = ::testing::Types<
-    ColumnUInt8, ColumnUInt16, ColumnUInt32, ColumnUInt64
-    , ColumnInt8, ColumnInt16, ColumnInt32, ColumnInt64
-    , ColumnFloat32, ColumnFloat64
-    , ColumnString, ColumnFixedString
-    , ColumnDate, ColumnDateTime, ColumnDateTime64, ColumnDate32
-    , ColumnIPv4, ColumnIPv6
-    , ColumnInt128
-    , ColumnDecimal
-    , ColumnUUID
->;
-TYPED_TEST_SUITE(GenericColumnTest, ValueColumns);
+// Luckily all (non-data copying/moving) constructors have size_t params.
+template <typename ColumnType, size_t ...ConstructorParams>
+auto makeColumn()
+{
+    return std::make_shared<ColumnType>(ConstructorParams...);
+}
 
-//TestCase(TypeCreatorFunc, ValuesGeneratorFunc)
+template <typename ColumnTypeT>
+struct NumberColumnTestCase : public GenericColumnTestCase<ColumnTypeT, &makeColumn<ColumnTypeT>, typename ColumnTypeT::ValueType, &MakeNumbers<typename ColumnTypeT::ValueType>>
+{
+    using Base = GenericColumnTestCase<ColumnTypeT, &makeColumn<ColumnTypeT>, typename ColumnTypeT::ValueType, &MakeNumbers<typename ColumnTypeT::ValueType>>;
 
+    using ColumnType = typename Base::ColumnType;
+    using Base::createColumn;
+    using Base::generateValues;
+};
 
-//class GenericColumnTestCase
-//{
-//    virutual
-//};
+template <typename ColumnTypeT, size_t precision, size_t scale>
+struct DecimalColumnTestCase : public GenericColumnTestCase<ColumnDecimal, &makeColumn<ColumnDecimal, precision, scale>, clickhouse::Int128, &MakeDecimals<precision, scale>>
+{
+    using Base = GenericColumnTestCase<ColumnDecimal, &makeColumn<ColumnDecimal, precision, scale>, clickhouse::Int128, &MakeDecimals<precision, scale>>;
+
+    using ColumnType = typename Base::ColumnType;
+    using Base::createColumn;
+    using Base::generateValues;
+};
+
+using TestCases = ::testing::Types<
+    NumberColumnTestCase<ColumnUInt8>,
+    NumberColumnTestCase<ColumnUInt16>,
+    NumberColumnTestCase<ColumnUInt32>,
+    NumberColumnTestCase<ColumnUInt64>,
+
+    NumberColumnTestCase<ColumnInt8>,
+    NumberColumnTestCase<ColumnInt16>,
+    NumberColumnTestCase<ColumnInt32>,
+    NumberColumnTestCase<ColumnInt64>,
+
+    NumberColumnTestCase<ColumnFloat32>,
+    NumberColumnTestCase<ColumnFloat64>,
+
+    GenericColumnTestCase<ColumnString, &makeColumn<ColumnString>, std::string, &MakeStrings>,
+    GenericColumnTestCase<ColumnFixedString, &makeColumn<ColumnFixedString, 12>, std::string, &MakeFixedStrings<12>>,
+
+    GenericColumnTestCase<ColumnDate, &makeColumn<ColumnDate>, time_t, &MakeDates<time_t>>,
+    GenericColumnTestCase<ColumnDate32, &makeColumn<ColumnDate32>, time_t, &MakeDates<time_t>>,
+    GenericColumnTestCase<ColumnDateTime, &makeColumn<ColumnDateTime>, clickhouse::Int64, &MakeDateTimes>,
+    GenericColumnTestCase<ColumnDateTime64, &makeColumn<ColumnDateTime64, 0>, clickhouse::Int64, &MakeDateTime64s<0>>,
+    GenericColumnTestCase<ColumnDateTime64, &makeColumn<ColumnDateTime64, 3>, clickhouse::Int64, &MakeDateTime64s<3>>,
+    GenericColumnTestCase<ColumnDateTime64, &makeColumn<ColumnDateTime64, 6>, clickhouse::Int64, &MakeDateTime64s<6>>,
+    GenericColumnTestCase<ColumnDateTime64, &makeColumn<ColumnDateTime64, 9>, clickhouse::Int64, &MakeDateTime64s<9>>,
+
+    GenericColumnTestCase<ColumnIPv4, &makeColumn<ColumnIPv4>, in_addr, &MakeIPv4s>,
+    GenericColumnTestCase<ColumnIPv6, &makeColumn<ColumnIPv6>, in6_addr, &MakeIPv6s>,
+
+    GenericColumnTestCase<ColumnInt128, &makeColumn<ColumnInt128>, clickhouse::Int128, &MakeInt128s>,
+    GenericColumnTestCase<ColumnUUID, &makeColumn<ColumnUUID>, clickhouse::UUID, &MakeUUIDs>,
+
+    DecimalColumnTestCase<ColumnDecimal, 18, 0>,
+    DecimalColumnTestCase<ColumnDecimal, 18, 6>,
+    DecimalColumnTestCase<ColumnDecimal, 18, 12>,
+    // there is an arithmetical overflow on some values in the test value generator harness
+    // DecimalColumnTestCase<ColumnDecimal, 18, 15>,
+
+    DecimalColumnTestCase<ColumnDecimal, 12, 0>,
+    DecimalColumnTestCase<ColumnDecimal, 12, 6>,
+    DecimalColumnTestCase<ColumnDecimal, 12, 9>,
+
+    DecimalColumnTestCase<ColumnDecimal, 6, 0>,
+    DecimalColumnTestCase<ColumnDecimal, 6, 3>
+    >;
+
+TYPED_TEST_SUITE(GenericColumnTest, TestCases);
 
 TYPED_TEST(GenericColumnTest, Construct) {
     auto column = this->MakeColumn();
@@ -230,7 +268,8 @@ TYPED_TEST(GenericColumnTest, GetItem) {
         const auto v = convertValueForGetItem(*column, values[i]);
         const ItemView item = column->GetItem(i);
 
-        ASSERT_TRUE(CompareRecursive(item.get<decltype(v)>(), v));
+        ASSERT_TRUE(CompareRecursive(v, item.get<decltype(v)>()))
+            << " On item " << i << " of " << PrintContainer{values};
     }
 }
 
@@ -318,9 +357,11 @@ TYPED_TEST(GenericColumnTest, RoundTrip) {
 }
 
 TYPED_TEST(GenericColumnTest, NulableT_RoundTrip) {
-    using NullableType = ColumnNullableT<TypeParam>;
+    using NullableType = ColumnNullableT<typename TestFixture::ColumnType>;
+
     auto column = std::make_shared<NullableType>(this->MakeColumn());
     auto values = this->GenerateValues(100);
+
     FromVectorGenerator<bool> is_null({true, false});
     for (size_t i = 0; i < values.size(); ++i) {
         if (is_null(i)) {

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -172,6 +172,7 @@ TEST(ColumnsCase, DateAppend) {
     ASSERT_EQ(col2->At(0), (now / 86400) * 86400);
 }
 
+
 TEST(ColumnsCase, Date_UInt16_interface) {
     auto col1 = std::make_shared<ColumnDate>();
 
@@ -182,10 +183,10 @@ TEST(ColumnsCase, Date_UInt16_interface) {
     ASSERT_EQ(col1->RawAt(0), 1u);
     ASSERT_EQ(col1->RawAt(1), 1234u);
 
-
     ASSERT_EQ((*col1)[0], 1u);
     ASSERT_EQ((*col1)[1], 1234u);
 }
+
 
 TEST(ColumnsCase, Date32_Int32_interface) {
     auto col1 = std::make_shared<ColumnDate32>();
@@ -197,12 +198,11 @@ TEST(ColumnsCase, Date32_Int32_interface) {
     ASSERT_EQ(col1->Size(), 3u);
     ASSERT_EQ(col1->RawAt(0), 1);
     ASSERT_EQ(col1->RawAt(1), 1234);
-    ASSERT_EQ(col1->RawAt(1), -1234);
-
+    ASSERT_EQ(col1->RawAt(2), -1234);
 
     ASSERT_EQ((*col1)[0], 1);
     ASSERT_EQ((*col1)[1], 1234);
-    ASSERT_EQ((*col1)[1], -1234);
+    ASSERT_EQ((*col1)[2], -1234);
 }
 
 
@@ -214,6 +214,7 @@ TEST(ColumnsCase, DateTime64_0) {
     ASSERT_EQ(0u, column->GetPrecision());
     ASSERT_EQ(0u, column->Size());
 }
+
 
 TEST(ColumnsCase, DateTime64_6) {
     auto column = std::make_shared<ColumnDateTime64>(6ul);

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -172,6 +172,40 @@ TEST(ColumnsCase, DateAppend) {
     ASSERT_EQ(col2->At(0), (now / 86400) * 86400);
 }
 
+TEST(ColumnsCase, Date_UInt16_interface) {
+    auto col1 = std::make_shared<ColumnDate>();
+
+    col1->AppendRaw(1u);
+    col1->AppendRaw(1234u);
+
+    ASSERT_EQ(col1->Size(), 2u);
+    ASSERT_EQ(col1->RawAt(0), 1u);
+    ASSERT_EQ(col1->RawAt(1), 1234u);
+
+
+    ASSERT_EQ((*col1)[0], 1u);
+    ASSERT_EQ((*col1)[1], 1234u);
+}
+
+TEST(ColumnsCase, Date32_Int32_interface) {
+    auto col1 = std::make_shared<ColumnDate32>();
+
+    col1->AppendRaw(1);
+    col1->AppendRaw(1234);
+    col1->AppendRaw(-1234);
+
+    ASSERT_EQ(col1->Size(), 3u);
+    ASSERT_EQ(col1->RawAt(0), 1);
+    ASSERT_EQ(col1->RawAt(1), 1234);
+    ASSERT_EQ(col1->RawAt(1), -1234);
+
+
+    ASSERT_EQ((*col1)[0], 1);
+    ASSERT_EQ((*col1)[1], 1234);
+    ASSERT_EQ((*col1)[1], -1234);
+}
+
+
 TEST(ColumnsCase, DateTime64_0) {
     auto column = std::make_shared<ColumnDateTime64>(0ul);
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -182,9 +182,6 @@ TEST(ColumnsCase, Date_UInt16_interface) {
     ASSERT_EQ(col1->Size(), 2u);
     ASSERT_EQ(col1->RawAt(0), 1u);
     ASSERT_EQ(col1->RawAt(1), 1234u);
-
-    ASSERT_EQ((*col1)[0], 1u);
-    ASSERT_EQ((*col1)[1], 1234u);
 }
 
 
@@ -199,10 +196,6 @@ TEST(ColumnsCase, Date32_Int32_interface) {
     ASSERT_EQ(col1->RawAt(0), 1);
     ASSERT_EQ(col1->RawAt(1), 1234);
     ASSERT_EQ(col1->RawAt(2), -1234);
-
-    ASSERT_EQ((*col1)[0], 1);
-    ASSERT_EQ((*col1)[1], 1234);
-    ASSERT_EQ((*col1)[2], -1234);
 }
 
 

--- a/ut/performance_tests.cpp
+++ b/ut/performance_tests.cpp
@@ -84,7 +84,7 @@ class ColumnPerformanceTest : public ::testing::Test {
 TYPED_TEST_SUITE_P(ColumnPerformanceTest);
 
 // Turns out this is the easiest way to skip test with current version of gtest
-#ifndef NDEBUG
+#ifdef NDEBUG
 #  define SKIP_IN_DEBUG_BUILDS() (void)(0)
 #else
 #  define SKIP_IN_DEBUG_BUILDS() GTEST_SKIP_("Test skipped for DEBUG build...")

--- a/ut/roundtrip_tests.cpp
+++ b/ut/roundtrip_tests.cpp
@@ -5,6 +5,7 @@
 
 #include <gtest/gtest.h>
 #include <map>
+#include <optional>
 
 using namespace clickhouse;
 
@@ -213,12 +214,16 @@ TEST_P(RoundtripCase, LowCardinalityTString) {
 TEST_P(RoundtripCase, LowCardinalityTNullableString) {
     using TestColumn = ColumnLowCardinalityT<ColumnNullableT<ColumnString>>;
     auto col = std::make_shared<TestColumn>();
+
     col->Append("abc");
     col->Append("def");
     col->Append("abc");
+    col->Append(std::nullopt);
     col->Append("abc");
     col->Append(std::nullopt);
     col->Append(std::nullopt);
+    col->Append("foobar");
+
     auto result_typed = WrapColumn<TestColumn>(RoundtripColumnValues(*client_, col));
     EXPECT_TRUE(CompareRecursive(*col, *result_typed));
 }

--- a/ut/utils_comparison.h
+++ b/ut/utils_comparison.h
@@ -8,6 +8,7 @@
 
 #include <string_view>
 #include <cstring>
+#include <cmath>
 
 namespace clickhouse {
     class Block;
@@ -153,10 +154,17 @@ template <typename Left, typename Right>
             return result << "\nExpected container: " << PrintContainer{l}
                           << "\nActual container  : " << PrintContainer{r};
     } else {
-        if (left != right)
+        if (left != right) {
+
+            if constexpr (std::is_floating_point_v<Left> && std::is_floating_point_v<Right>) {
+                if (std::isnan(left) && std::isnan(right))
+                    return ::testing::AssertionSuccess();
+            }
+
             return ::testing::AssertionFailure()
                     << "\nExpected value: " << left
                     << "\nActual value  : " << right;
+        }
 
         return ::testing::AssertionSuccess();
     }

--- a/ut/utils_meta.h
+++ b/ut/utils_meta.h
@@ -39,3 +39,10 @@ using my_result_of_t =
     std::result_of_t<F(ArgTypes...)>;
 #endif
 
+// https://stackoverflow.com/a/11251408
+template < template <typename...> class Template, typename T >
+struct is_instantiation_of : std::false_type {};
+
+template < template <typename...> class Template, typename... Args >
+struct is_instantiation_of< Template, Template<Args...> > : std::true_type {};
+

--- a/ut/utils_ut.cpp
+++ b/ut/utils_ut.cpp
@@ -1,9 +1,22 @@
 #include <gtest/gtest.h>
 #include "utils.h"
 
+#include <limits>
+#include <optional>
 #include <vector>
 
-TEST(TestCompareContainer, ComparePlain) {
+TEST(CompareRecursive, CompareValues) {
+    EXPECT_TRUE(CompareRecursive(1, 1));
+    EXPECT_TRUE(CompareRecursive(1.0f, 1.0f));
+    EXPECT_TRUE(CompareRecursive(1.0, 1.0));
+    EXPECT_TRUE(CompareRecursive(1.0L, 1.0L));
+
+    EXPECT_TRUE(CompareRecursive("1.0L", "1.0L"));
+    EXPECT_TRUE(CompareRecursive(std::string{"1.0L"}, std::string{"1.0L"}));
+    EXPECT_TRUE(CompareRecursive(std::string_view{"1.0L"}, std::string_view{"1.0L"}));
+}
+
+TEST(CompareRecursive, CompareContainers) {
     EXPECT_TRUE(CompareRecursive(std::vector<int>{1, 2, 3}, std::vector<int>{1, 2, 3}));
     EXPECT_TRUE(CompareRecursive(std::vector<int>{}, std::vector<int>{}));
 
@@ -15,7 +28,7 @@ TEST(TestCompareContainer, ComparePlain) {
 }
 
 
-TEST(TestCompareContainer, CompareNested) {
+TEST(CompareRecursive, CompareNestedContainers) {
     EXPECT_TRUE(CompareRecursive(
         std::vector<std::vector<int>>{{{1, 2, 3}, {4, 5, 6}}},
         std::vector<std::vector<int>>{{{1, 2, 3}, {4, 5, 6}}}));
@@ -38,4 +51,65 @@ TEST(StringUtils, UUID) {
     const clickhouse::UUID& uuid{0x0102030405060708, 0x090a0b0c0d0e0f10};
     const std::string uuid_string = "01020304-0506-0708-090a-0b0c0d0e0f10";
     EXPECT_EQ(ToString(uuid), uuid_string);
+}
+
+TEST(CompareRecursive, Nan) {
+    /// Even though NaN == NaN is FALSE, CompareRecursive must compare those as TRUE.
+
+    const auto NaNf = std::numeric_limits<float>::quiet_NaN();
+    const auto NaNd = std::numeric_limits<double>::quiet_NaN();
+
+    EXPECT_TRUE(CompareRecursive(NaNf, NaNf));
+    EXPECT_TRUE(CompareRecursive(NaNd, NaNd));
+
+    EXPECT_TRUE(CompareRecursive(NaNf, NaNd));
+    EXPECT_TRUE(CompareRecursive(NaNd, NaNf));
+
+    // 1.0 is arbitrary here
+    EXPECT_FALSE(CompareRecursive(NaNf, 1.0));
+    EXPECT_FALSE(CompareRecursive(NaNf, 1.0));
+    EXPECT_FALSE(CompareRecursive(1.0, NaNd));
+    EXPECT_FALSE(CompareRecursive(1.0, NaNd));
+}
+
+TEST(CompareRecursive, Optional) {
+    EXPECT_TRUE(CompareRecursive(1, std::optional{1}));
+    EXPECT_TRUE(CompareRecursive(std::optional{1}, 1));
+    EXPECT_TRUE(CompareRecursive(std::optional{1}, std::optional{1}));
+
+    EXPECT_FALSE(CompareRecursive(2, std::optional{1}));
+    EXPECT_FALSE(CompareRecursive(std::optional{1}, 2));
+    EXPECT_FALSE(CompareRecursive(std::optional{2}, std::optional{1}));
+    EXPECT_FALSE(CompareRecursive(std::optional{1}, std::optional{2}));
+}
+
+TEST(CompareRecursive, OptionalNan) {
+    // Special case for optional comparison:
+    // NaNs should be considered as equal (compare by unpacking value of optional)
+
+    const auto NaNf = std::numeric_limits<float>::quiet_NaN();
+    const auto NaNd = std::numeric_limits<double>::quiet_NaN();
+
+    const auto NaNfo = std::optional{NaNf};
+    const auto NaNdo = std::optional{NaNd};
+
+    EXPECT_TRUE(CompareRecursive(NaNf, NaNf));
+    EXPECT_TRUE(CompareRecursive(NaNf, NaNfo));
+    EXPECT_TRUE(CompareRecursive(NaNfo, NaNf));
+    EXPECT_TRUE(CompareRecursive(NaNfo, NaNfo));
+
+    EXPECT_TRUE(CompareRecursive(NaNd, NaNd));
+    EXPECT_TRUE(CompareRecursive(NaNd, NaNdo));
+    EXPECT_TRUE(CompareRecursive(NaNdo, NaNd));
+    EXPECT_TRUE(CompareRecursive(NaNdo, NaNdo));
+
+    EXPECT_FALSE(CompareRecursive(NaNdo, std::optional<double>{}));
+    EXPECT_FALSE(CompareRecursive(NaNfo, std::optional<float>{}));
+    EXPECT_FALSE(CompareRecursive(std::optional<double>{}, NaNdo));
+    EXPECT_FALSE(CompareRecursive(std::optional<float>{}, NaNfo));
+
+    // Too lazy to comparison code against std::nullopt, but this shouldn't be a problem in real life
+    // following will produce compile time error:
+//    EXPECT_FALSE(CompareRecursive(NaNdo, std::nullopt));
+//    EXPECT_FALSE(CompareRecursive(NaNfo, std::nullopt));
 }

--- a/ut/value_generators.cpp
+++ b/ut/value_generators.cpp
@@ -1,6 +1,7 @@
 #include "value_generators.h"
 
 #include <algorithm>
+#include <type_traits>
 #include <math.h>
 
 namespace {
@@ -53,25 +54,13 @@ std::vector<Int64> MakeDateTime64s(size_t scale, size_t values_size) {
         });
 }
 
-std::vector<clickhouse::Int64> MakeDates() {
-    // in CH Date internally a UInt16 and stores a day number
-    // ColumnDate expects values to be seconds, which is then
-    // converted to day number internally, hence the `* 86400`.
-    std::vector<clickhouse::Int64> result {0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536 - 1};
-    std::for_each(result.begin(), result.end(), [](auto& value) {
-        value *= 86400;
-    });
-
-    return result;
-}
-
-std::vector<clickhouse::Int64> MakeDates32() {
+std::vector<int32_t> MakeDates32() {
     // in CH Date32 internally a UInt32 and stores a day number
     // ColumnDate expects values to be seconds, which is then
     // converted to day number internally, hence the `* 86400`.
     // 114634 * 86400 is 2282-11-10, last integer that fits into DateTime32 range
     // (max is 2283-11-11)
-    std::vector<clickhouse::Int64> result  = MakeDates();
+    std::vector<int32_t> result = MakeDates<int32_t>();
 
     // add corresponding negative values, since pre-epoch date are supported too.
     const auto size = result.size();

--- a/ut/value_generators.cpp
+++ b/ut/value_generators.cpp
@@ -92,7 +92,7 @@ std::vector<clickhouse::Int128> MakeInt128s() {
 
 std::vector<clickhouse::Int128> MakeDecimals(size_t /*precision*/, size_t scale) {
     const auto scale_multiplier = static_cast<size_t>(std::pow(10, scale));
-    const auto rhs_value = 12345678910;
+    const long long int rhs_value = 12345678910;
 
     const std::vector<long long int> vals {0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536 - 1};
 

--- a/ut/value_generators.h
+++ b/ut/value_generators.h
@@ -33,14 +33,30 @@ std::vector<uint8_t> MakeBools();
 std::vector<std::string> MakeFixedStrings(size_t string_size);
 std::vector<std::string> MakeStrings();
 std::vector<clickhouse::Int64> MakeDateTime64s(size_t scale, size_t values_size = 200);
-std::vector<clickhouse::Int64> MakeDates();
-std::vector<clickhouse::Int64> MakeDates32();
+std::vector<int32_t> MakeDates32();
 std::vector<clickhouse::Int64> MakeDateTimes();
 std::vector<in_addr> MakeIPv4s();
 std::vector<in6_addr> MakeIPv6s();
 std::vector<clickhouse::UUID> MakeUUIDs();
 std::vector<clickhouse::Int128> MakeInt128s();
 std::vector<clickhouse::Int128> MakeDecimals(size_t precision, size_t scale);
+
+template <typename ResultType>
+std::vector<ResultType> MakeDates() {
+    std::vector<ResultType> result {0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536 - 1};
+
+    if constexpr (std::is_same_v<time_t, ResultType>) {
+        // in CH Date internally a UInt16 and stores a day number
+        // ColumnDate expects values to be seconds, which is then
+        // converted to day number internally, hence the `* 86400`.
+        std::for_each(result.begin(), result.end(), [](auto& value) {
+            value *= 86400;
+        });
+    }
+
+    return result;
+}
+
 
 std::string FooBarGenerator(size_t i);
 

--- a/ut/value_generators.h
+++ b/ut/value_generators.h
@@ -79,7 +79,7 @@ inline std::vector<T> MakeNumbers() {
     const auto min_value = std::pow(10, std::numeric_limits<T>::min_exponent10);
 
     // cover most of the precision ranges
-    for (T i = std::numeric_limits<T>::max(); i >= /*std::numeric_limits<T>::epsilon()*/ min_value * step; i /= step)
+    for (T i = std::numeric_limits<T>::max(); i >= min_value * step; i /= step)
     {
         result.push_back(i);
         result.push_back(-1 * i);


### PR DESCRIPTION
Provide an interface for writing/reading immediate values for `Date` and `Date32` columns without conversion.

Closes: #318