### PR TITLE
Add move semantics for ColumnEnum

### DIFF
--- a/clickhouse/columns/enum.cpp
+++ b/clickhouse/columns/enum.cpp
@@ -21,6 +21,13 @@ ColumnEnum<T>::ColumnEnum(TypeRef type, const std::vector<T>& data)
 }
 
 template <typename T>
+ColumnEnum<T>::ColumnEnum(TypeRef type, std::vector<T>&& data)
+    : Column(type)
+    , data_(std::move(data))
+{
+}
+
+template <typename T>
 void ColumnEnum<T>::Append(const T& value, bool checkValue) {
     if  (checkValue) {
         // TODO: type_->HasEnumValue(value), "Enum type doesn't have value " + std::to_string(value);

--- a/clickhouse/columns/enum.h
+++ b/clickhouse/columns/enum.h
@@ -12,6 +12,7 @@ public:
 
     ColumnEnum(TypeRef type);
     ColumnEnum(TypeRef type, const std::vector<T>& data);
+    ColumnEnum(TypeRef type, std::vector<T>&& data);
 
     /// Appends one element to the end of column.
     void Append(const T& value, bool checkValue = false);


### PR DESCRIPTION
The `ColumnEnum<T>` can be initialized with `std::vector<T>` by moving the vector instead of copying.