### PR TITLE
Less flaky tests when executing against remote server (not docker)

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,5 +67,5 @@ jobs:
         # It is impossible to start CH server in docker on macOS due to github actions limitations,
         # so we use remote server to execute tests, some do not allow some features for anonymoust/free users:
         # - system.query_log used by 'Client/ClientCase.Query_ID'
-        GTEST_FILTER: "-Client/ClientCase.Query_ID*"
+        GTEST_FILTER: "-Client/ClientCase.Query_ID*:Client/ClientCase.TracingContext/*"
       run: ./clickhouse-cpp-ut ${GTEST_FILTER}

--- a/.github/workflows/windows_mingw.yml
+++ b/.github/workflows/windows_mingw.yml
@@ -85,7 +85,7 @@ jobs:
         # It is impossible to start CH server in docker on Windows due to github actions limitations,
         # so we use remote server to execute tests, some do not allow some features for anonymoust/free users:
         # - system.query_log used by 'Client/ClientCase.Query_ID'
-        GTEST_FILTER: "-Client/ClientCase.Query_ID*"
+        GTEST_FILTER: "-Client/ClientCase.Query_ID*:Client/ClientCase.TracingContext/*"
       run: ./build/ut/clickhouse-cpp-ut.exe ${GTEST_FILTER}
 
     - name: Test (simple)

--- a/.github/workflows/windows_msvc.yml
+++ b/.github/workflows/windows_msvc.yml
@@ -61,6 +61,6 @@ jobs:
         # It is impossible to start CH server in docker on Windows due to github actions limitations,
         # so we use remote server to execute tests, some do not allow some features for anonymoust/free users:
         # - system.query_log used by 'Client/ClientCase.Query_ID'
-        GTEST_FILTER: "-Client/ClientCase.Query_ID*"
+        GTEST_FILTER: "-Client/ClientCase.Query_ID*:Client/ClientCase.TracingContext/*"
       working-directory: ${{github.workspace}}/build/ut
       run: Release\clickhouse-cpp-ut.exe "${{env.GTEST_FILTER}}"


### PR DESCRIPTION
Disabled tests that rely on some privileges that might be unavailable on a remote server:
- Client/ClientCase.Query_ID
- Client/ClientCase.TracingContext