### PR TITLE
Fix `ColumnArrayT<ColumnLowCardinalityT<ColumnString>>::Append`

### DIFF
--- a/clickhouse/columns/array.cpp
+++ b/clickhouse/columns/array.cpp
@@ -25,14 +25,9 @@ ColumnArray::ColumnArray(ColumnArray&& other)
 }
 
 void ColumnArray::AppendAsColumn(ColumnRef array) {
-    if (!data_->Type()->IsEqual(array->Type())) {
-        throw ValidationError(
-            "can't append column of type " + array->Type()->GetName() + " "
-            "to column type " + data_->Type()->GetName());
-    }
-
-    AddOffset(array->Size());
+    // appending data may throw (i.e. due to ype check failure), so do it first to avoid partly modified state.
     data_->Append(array);
+    AddOffset(array->Size());
 }
 
 ColumnRef ColumnArray::GetAsColumn(size_t n) const {
@@ -59,10 +54,6 @@ ColumnRef ColumnArray::CloneEmpty() const {
 
 void ColumnArray::Append(ColumnRef column) {
     if (auto col = column->As<ColumnArray>()) {
-        if (!col->data_->Type()->IsEqual(data_->Type())) {
-            return;
-        }
-
         for (size_t i = 0; i < col->Size(); ++i) {
             AppendAsColumn(col->GetAsColumn(i));
         }

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -16,6 +16,9 @@
 #include <clickhouse/client.h>
 
 #include <gtest/gtest.h>
+#include <initializer_list>
+#include <memory>
+#include <type_traits>
 
 #include "utils.h"
 #include "roundtrip_column.h"
@@ -46,10 +49,12 @@ std::ostream& operator<<(std::ostream& ostr, const Type::Code& type_code) {
 template <typename ColumnTypeT,
           typename std::shared_ptr<ColumnTypeT> (*CreatorFunction)(),
           typename GeneratorValueType,
-          typename std::vector<GeneratorValueType> (*GeneratorFunc)()>
+          typename std::vector<GeneratorValueType> (*GeneratorFunction)()>
 struct GenericColumnTestCase
 {
     using ColumnType = ColumnTypeT;
+    static constexpr auto Creator = CreatorFunction;
+    static constexpr auto Generator = GeneratorFunction;
 
     static auto createColumn()
     {
@@ -58,7 +63,7 @@ struct GenericColumnTestCase
 
     static auto generateValues()
     {
-        return GeneratorFunc();
+        return GeneratorFunction();
     }
 };
 
@@ -92,7 +97,7 @@ public:
         return std::tuple{column, values};
     }
 
-    static std::optional<std::string> SkipTest(clickhouse::Client& client) {
+    static std::optional<std::string> CheckIfShouldSkipTest(clickhouse::Client& client) {
         if constexpr (std::is_same_v<ColumnType, ColumnDate32>) {
             // Date32 first appeared in v21.9.2.17-stable
             const auto server_info = client.GetServerInfo();
@@ -112,6 +117,33 @@ public:
             }
         }
         return std::nullopt;
+    }
+
+    template <typename ColumnType>
+    static void TestColumnRoundtrip(const std::shared_ptr<ColumnType> & column, const ClientOptions & client_options)
+    {
+        SCOPED_TRACE(::testing::Message("Column type: ") << column->GetType().GetName());
+        SCOPED_TRACE(::testing::Message("Client options: ") << client_options);
+
+        clickhouse::Client client(client_options);
+
+        if (auto message = CheckIfShouldSkipTest(client)) {
+            GTEST_SKIP() << *message;
+        }
+
+        auto result_typed = RoundtripColumnValues(client, column)->template AsStrict<ColumnType>();
+        EXPECT_TRUE(CompareRecursive(*column, *result_typed));
+    }
+
+
+    template <typename ColumnType, typename CompressionMethods>
+    static void TestColumnRoundtrip(const ColumnType & column, const ClientOptions & client_options, CompressionMethods && compression_methods)
+    {
+        for (auto compressionMethod : compression_methods)
+        {
+            ClientOptions new_options = ClientOptions(client_options).SetCompressionMethod(compressionMethod);
+            TestColumnRoundtrip(column, new_options);
+        }
     }
 };
 
@@ -184,7 +216,17 @@ using TestCases = ::testing::Types<
     DecimalColumnTestCase<ColumnDecimal, 12, 9>,
 
     DecimalColumnTestCase<ColumnDecimal, 6, 0>,
-    DecimalColumnTestCase<ColumnDecimal, 6, 3>
+    DecimalColumnTestCase<ColumnDecimal, 6, 3>,
+
+    GenericColumnTestCase<ColumnLowCardinalityT<ColumnString>, &makeColumn<ColumnLowCardinalityT<ColumnString>>, std::string, &MakeStrings>
+
+    // Array(String)
+//    GenericColumnTestCase<ColumnArrayT<ColumnString>, &makeColumn<ColumnArrayT<ColumnString>>, std::vector<std::string>, &MakeArrays<std::string, &MakeStrings>>
+
+//    // Array(Array(String))
+//    GenericColumnTestCase<ColumnArrayT<ColumnArrayT<ColumnString>>, &makeColumn<ColumnArrayT<ColumnArrayT<ColumnString>>>,
+//            std::vector<std::vector<std::string>>,
+//            &MakeArrays<std::vector<std::string>, &MakeArrays<std::string, &MakeStrings>>>
     >;
 
 TYPED_TEST_SUITE(GenericColumnTest, TestCases);
@@ -262,7 +304,14 @@ TYPED_TEST(GenericColumnTest, GetItem) {
     auto [column, values] = this->MakeColumnWithValues(100);
 
     ASSERT_EQ(values.size(), column->Size());
-    ASSERT_EQ(column->GetItem(0).type, column->GetType().GetCode());
+    const auto wrapping_types = std::set<Type::Code>{
+        Type::Code::LowCardinality, Type::Code::Array, Type::Code::Nullable
+    };
+
+    // For wrapping types, type of ItemView can be different from type of column
+    if (wrapping_types.find(column->GetType().GetCode()) == wrapping_types.end() ) {
+        EXPECT_EQ(column->GetItem(0).type, column->GetType().GetCode());
+    }
 
     for (size_t i = 0; i < values.size(); ++i) {
         const auto v = convertValueForGetItem(*column, values[i]);
@@ -318,7 +367,8 @@ TYPED_TEST(GenericColumnTest, Swap) {
 TYPED_TEST(GenericColumnTest, LoadAndSave) {
     auto [column_A, values] = this->MakeColumnWithValues(100);
 
-    char buffer[4096] = {'\0'};
+    // large buffer since we have pretty big values for String column
+    char buffer[1024*1024] = {'\0'};
     {
         ArrayOutput output(buffer, sizeof(buffer));
         // Save
@@ -342,24 +392,39 @@ const auto LocalHostEndpoint = ClientOptions()
         .SetPassword(       getEnvOrDefault("CLICKHOUSE_PASSWORD", ""))
         .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_DB",       "default"));
 
+const auto AllCompressionMethods = {
+    clickhouse::CompressionMethod::None,
+    clickhouse::CompressionMethod::LZ4
+};
+
 TYPED_TEST(GenericColumnTest, RoundTrip) {
     auto [column, values] = this->MakeColumnWithValues(100);
     EXPECT_EQ(values.size(), column->Size());
 
-    clickhouse::Client client(LocalHostEndpoint);
+    this->TestColumnRoundtrip(column, LocalHostEndpoint, AllCompressionMethods);
+//    for (auto compressionMethod : AllCompressionMethods)
+//    {
+//        clickhouse::Client client(ClientOptions(LocalHostEndpoint)
+//                .SetCompressionMethod(compressionMethod));
 
-    if (auto message = this->SkipTest(client)) {
-        GTEST_SKIP() << *message;
-    }
+//        if (auto message = this->CheckIfShouldSkipTest(client)) {
+//            GTEST_SKIP() << *message;
+//        }
 
-    auto result_typed = RoundtripColumnValues(client, column)->template AsStrict<typename TestFixture::ColumnType>();
-    EXPECT_TRUE(CompareRecursive(*column, *result_typed));
+//        auto result_typed = RoundtripColumnValues(client, column)->template AsStrict<typename TestFixture::ColumnType>();
+//        EXPECT_TRUE(CompareRecursive(*column, *result_typed));
+//    }
 }
 
-TYPED_TEST(GenericColumnTest, NulableT_RoundTrip) {
+TYPED_TEST(GenericColumnTest, NullableT_RoundTrip) {
     using NullableType = ColumnNullableT<typename TestFixture::ColumnType>;
 
-    auto column = std::make_shared<NullableType>(this->MakeColumn());
+    auto non_nullable_column = this->MakeColumn();
+    if (non_nullable_column->GetType().GetCode() == Type::Code::LowCardinality)
+        // TODO (vnemkov): wrap as ColumnLowCardinalityT<ColumnNullableT<NestedColumn>> instead of ColumnNullableT<ColumnLowCardinalityT<NestedColumn>>
+        GTEST_SKIP() << "Can't wrap " << non_nullable_column->GetType().GetName() << " into Nullable";
+
+    auto column = std::make_shared<NullableType>(std::move(non_nullable_column));
     auto values = this->GenerateValues(100);
 
     FromVectorGenerator<bool> is_null({true, false});
@@ -371,12 +436,53 @@ TYPED_TEST(GenericColumnTest, NulableT_RoundTrip) {
         }
     }
 
-    clickhouse::Client client(LocalHostEndpoint);
+    this->TestColumnRoundtrip(column, LocalHostEndpoint, AllCompressionMethods);
+//    for (auto compressionMethod : AllCompressionMethods)
+//    {
+//        clickhouse::Client client(ClientOptions(LocalHostEndpoint)
+//                .SetCompressionMethod(compressionMethod));
 
-    if (auto message = this->SkipTest(client)) {
-        GTEST_SKIP() << *message;
-    }
+//        if (auto message = this->CheckIfShouldSkipTest(client)) {
+//            GTEST_SKIP() << *message;
+//        }
 
-    auto result_typed = WrapColumn<NullableType>(RoundtripColumnValues(client, column));
-    EXPECT_TRUE(CompareRecursive(*column, *result_typed));
+//        auto result_typed = WrapColumn<NullableType>(RoundtripColumnValues(client, column));
+//        EXPECT_TRUE(CompareRecursive(*column, *result_typed));
+//    }
 }
+
+TYPED_TEST(GenericColumnTest, ArrayT_RoundTrip) {
+    using ColumnArrayType = ColumnArrayT<typename TestFixture::ColumnType>;
+
+    auto [nested_column, values] = this->MakeColumnWithValues(10);
+
+    auto column = std::make_shared<ColumnArrayType>(nested_column->CloneEmpty()->template As<typename TestFixture::ColumnType>());
+    for (size_t i = 0; i < values.size(); ++i)
+    {
+        const std::vector<std::decay_t<decltype(values[0])>> row{values.begin(), values.begin() + i};
+        column->Append(values.begin(), values.begin() + i);
+
+        EXPECT_TRUE(CompareRecursive(row, (*column)[column->Size() - 1]));
+    }
+    EXPECT_EQ(values.size(), column->Size());
+
+    this->TestColumnRoundtrip(column, LocalHostEndpoint, AllCompressionMethods);
+
+//    SCOPED_TRACE(::testing::Message("Column type: ") << column->GetType().GetName());
+
+//    for (auto compressionMethod : AllCompressionMethods)
+//    {
+//        const ClientOptions client_options = ClientOptions(LocalHostEndpoint).SetCompressionMethod(compressionMethod);
+//        SCOPED_TRACE(::testing::Message("Client options: ") << client_options);
+
+//        clickhouse::Client client(client_options);
+
+//        if (auto message = this->CheckIfShouldSkipTest(client)) {
+//            GTEST_SKIP() << *message;
+//        }
+
+//        auto result_typed = RoundtripColumnValues(client, column)->template AsStrict<ColumnArrayType>();
+//        EXPECT_TRUE(CompareRecursive(*column, *result_typed));
+//    }
+}
+

--- a/ut/utils.h
+++ b/ut/utils.h
@@ -167,7 +167,10 @@ std::ostream& operator<<(std::ostream & ostr, const PrintContainer<T>& print_con
     for (auto i = std::begin(container); i != std::end(container); /*intentionally no ++i*/) {
         const auto & elem = *i;
 
-        if constexpr (is_container_v<std::decay_t<decltype(elem)>>) {
+        if constexpr (is_string_v<decltype(elem)>) {
+            ostr << '"' << elem << '"';
+        }
+        else if constexpr (is_container_v<std::decay_t<decltype(elem)>>) {
             ostr << PrintContainer{elem};
         } else {
             ostr << elem;

--- a/ut/utils_comparison.h
+++ b/ut/utils_comparison.h
@@ -143,7 +143,8 @@ struct PrintContainer;
 
 template <typename Left, typename Right>
 ::testing::AssertionResult CompareRecursive(const Left & left, const Right & right) {
-    if constexpr ((is_container_v<Left> || std::is_base_of_v<clickhouse::Column, std::decay_t<Left>>)
+    if constexpr (!is_string_v<Left> && !is_string_v<Right>
+            && (is_container_v<Left> || std::is_base_of_v<clickhouse::Column, std::decay_t<Left>>)
             && (is_container_v<Right> || std::is_base_of_v<clickhouse::Column, std::decay_t<Right>>) ) {
 
         const auto & l = maybeWrapColumnAsContainer(left);

--- a/ut/utils_meta.h
+++ b/ut/utils_meta.h
@@ -2,6 +2,8 @@
 
 #include <type_traits>
 #include <array> // for std::begin
+#include <string>
+#include <string_view>
 
 // based on https://stackoverflow.com/a/31207079
 template <typename T, typename _ = void>
@@ -46,3 +48,6 @@ struct is_instantiation_of : std::false_type {};
 template < template <typename...> class Template, typename... Args >
 struct is_instantiation_of< Template, Template<Args...> > : std::true_type {};
 
+
+template <typename T>
+inline constexpr bool is_string_v = std::is_same_v<std::string, std::decay_t<T>> || std::is_same_v<std::string_view, std::decay_t<T>>;

--- a/ut/utils_ut.cpp
+++ b/ut/utils_ut.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "ut/value_generators.h"
 #include "utils.h"
 
 #include <limits>
@@ -112,4 +113,10 @@ TEST(CompareRecursive, OptionalNan) {
     // following will produce compile time error:
 //    EXPECT_FALSE(CompareRecursive(NaNdo, std::nullopt));
 //    EXPECT_FALSE(CompareRecursive(NaNfo, std::nullopt));
+}
+
+
+TEST(Generators, MakeArrays) {
+    auto arrays = MakeArrays<std::string, MakeStrings>();
+    ASSERT_LT(0u, arrays.size());
 }

--- a/ut/value_generators.cpp
+++ b/ut/value_generators.cpp
@@ -17,7 +17,7 @@ std::vector<uint8_t> MakeBools() {
 }
 
 std::vector<std::string> MakeFixedStrings(size_t string_size) {
-    std::vector<std::string> result {"aaa", "bbb", "ccc", "ddd"};
+    std::vector<std::string> result = MakeStrings();
 
     std::for_each(result.begin(), result.end(), [string_size](auto& value) {
         value.resize(string_size, '\0');
@@ -27,7 +27,28 @@ std::vector<std::string> MakeFixedStrings(size_t string_size) {
 }
 
 std::vector<std::string> MakeStrings() {
-    return {"a", "ab", "abc", "abcd"};
+    return {
+        "a", "ab", "abc", "abcd",
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+        "long string to test how those are handled. Here goes more text. "
+    };
 }
 
 std::vector<UUID> MakeUUIDs() {

--- a/ut/value_generators.h
+++ b/ut/value_generators.h
@@ -122,6 +122,20 @@ inline auto MakeDates() {
     return result;
 }
 
+template <typename ValueType, std::vector<ValueType> (*Generator)()>
+inline auto MakeArrays() {
+    const auto nested_values = Generator();
+    std::vector<std::vector<ValueType>> result;
+    result.reserve(nested_values.size());
+
+    for (size_t i = 0; i < nested_values.size(); ++i)
+    {
+        result.emplace_back(nested_values.begin(), nested_values.begin() + i);
+    }
+
+    return result;
+}
+
 
 std::string FooBarGenerator(size_t i);
 


### PR DESCRIPTION
Also allow `ColumnLowCardinalityT<ColumnString>::Append` to take ColumnString instance instead of `ColumnLowCardinalityT<ColumnString>`

This allows for better testing