### PR TITLE
Add rvalue vector ctors for ColumnDate, ColumnDate32 and ColumnIPv4

### DIFF
--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -9,6 +9,12 @@ ColumnDate::ColumnDate()
 {
 }
 
+ColumnDate::ColumnDate(std::vector<uint16_t>&& data)
+    : Column(Type::CreateDate())
+    , data_(std::make_shared<ColumnUInt16>(std::move(data)))
+{
+}
+
 void ColumnDate::Append(const std::time_t& value) {
     /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
     data_->Append(static_cast<uint16_t>(value / std::time_t(86400)));
@@ -75,6 +81,12 @@ ItemView ColumnDate::GetItem(size_t index) const {
 ColumnDate32::ColumnDate32()
     : Column(Type::CreateDate32())
     , data_(std::make_shared<ColumnInt32>())
+{
+}
+
+ColumnDate32::ColumnDate32(std::vector<int32_t>&& data)
+    : Column(Type::CreateDate32())
+    , data_(std::make_shared<ColumnInt32>(std::move(data)))
 {
 }
 

--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -164,6 +164,16 @@ ColumnDateTime::ColumnDateTime(std::string timezone)
 {
 }
 
+ColumnDateTime::ColumnDateTime(std::vector<uint32_t>&& data)
+    : Column(Type::CreateDateTime())
+    , data_(std::make_shared<ColumnUInt32>(std::move(data))) {
+}
+
+ColumnDateTime::ColumnDateTime(std::string timezone, std::vector<uint32_t>&& data)
+    : Column(Type::CreateDateTime(std::move(timezone)))
+    , data_(std::make_shared<ColumnUInt32>(std::move(data))) {
+}
+
 void ColumnDateTime::Append(const std::time_t& value) {
     data_->Append(static_cast<uint32_t>(value));
 }

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -13,6 +13,7 @@ public:
     using ValueType = std::time_t;
 
     ColumnDate();
+    explicit ColumnDate(std::vector<uint16_t>&& data);
 
     /// Appends one element to the end of column.
     /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.
@@ -59,6 +60,7 @@ public:
     using ValueType = std::time_t;
 
     ColumnDate32();
+    explicit ColumnDate32(std::vector<int32_t>&& data);
 
     /// Appends one element to the end of column.
     /// The implementation is fundamentally wrong, ignores timezones, leap years and daylight saving.

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -109,7 +109,10 @@ public:
     using ValueType = std::time_t;
 
     ColumnDateTime();
+    explicit ColumnDateTime(std::vector<uint32_t>&& data);
+
     explicit ColumnDateTime(std::string timezone);
+    ColumnDateTime(std::string timezone, std::vector<uint32_t>&& data);
 
     /// Appends one element to the end of column.
     void Append(const std::time_t& value);

--- a/clickhouse/columns/ip4.cpp
+++ b/clickhouse/columns/ip4.cpp
@@ -19,6 +19,15 @@ ColumnIPv4::ColumnIPv4(ColumnRef data)
         throw ValidationError("Expecting ColumnUInt32, got " + (data ? data->GetType().GetName() : "null"));
 }
 
+ColumnIPv4::ColumnIPv4(std::vector<uint32_t>&& data)
+    : Column(Type::CreateIPv4())
+{
+    for (auto& addr : data) {
+        addr = htonl(addr);
+    }
+    data_ = std::make_shared<ColumnUInt32>(std::move(data));
+}
+
 void ColumnIPv4::Append(const std::string& str) {
     uint32_t address;
     if (inet_pton(AF_INET, str.c_str(), &address) != 1)

--- a/clickhouse/columns/ip4.h
+++ b/clickhouse/columns/ip4.h
@@ -19,6 +19,8 @@ public:
      */
     explicit ColumnIPv4(ColumnRef data);
 
+    explicit ColumnIPv4(std::vector<uint32_t>&& data);
+
     /// Appends one element to the column.
     void Append(const std::string& ip);
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -199,6 +199,17 @@ TEST(ColumnsCase, Date32_Int32_interface) {
     ASSERT_EQ(col1->RawAt(2), -1234);
 }
 
+TEST(ColumnsCase, DateTime_construct_from_rvalue_data) {
+    auto const expected = MakeNumbers<uint32_t>();
+
+    auto data = expected;
+    auto col1 = std::make_shared<ColumnDateTime>(std::move(data));
+
+    ASSERT_EQ(col1->Size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_EQ(col1->At(i), static_cast<std::time_t>(expected[i]));
+    }
+}
 
 TEST(ColumnsCase, DateTime64_0) {
     auto column = std::make_shared<ColumnDateTime64>(0ul);

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -228,10 +228,7 @@ TEST(ColumnsCase, DateTime_construct_from_rvalue_data) {
     auto data = expected;
     auto col1 = std::make_shared<ColumnDateTime>(std::move(data));
 
-    ASSERT_EQ(col1->Size(), expected.size());
-    for (size_t i = 0; i < expected.size(); ++i) {
-        ASSERT_EQ(col1->At(i), static_cast<std::time_t>(expected[i]));
-    }
+    EXPECT_TRUE(CompareRecursive(*col1, expected));
 }
 
 TEST(ColumnsCase, DateTime64_0) {
@@ -576,7 +573,7 @@ TEST(ColumnsCase, ColumnIPv4_construct_from_rvalue_data) {
     };
 
     auto col = ColumnIPv4(std::move(data));
-    ASSERT_EQ(col.Size(), expected.size());
+    EXPECT_TRUE(CompareRecursive(col, expected));
 }
 
 TEST(ColumnsCase, ColumnIPv6)

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -185,6 +185,17 @@ TEST(ColumnsCase, Date_UInt16_interface) {
     ASSERT_EQ(col1->RawAt(1), 1234u);
 }
 
+TEST(ColumnsCase, Date_UInt16_construct_from_rvalue_data) {
+    auto const expected = MakeNumbers<uint16_t>();
+
+    auto data = expected;
+    auto col1 = std::make_shared<ColumnDate>(std::move(data));
+
+    ASSERT_EQ(col1->Size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_EQ(col1->RawAt(i), expected[i]);
+    }
+}
 
 TEST(ColumnsCase, Date32_Int32_interface) {
     auto col1 = std::make_shared<ColumnDate32>();
@@ -197,6 +208,18 @@ TEST(ColumnsCase, Date32_Int32_interface) {
     ASSERT_EQ(col1->RawAt(0), 1);
     ASSERT_EQ(col1->RawAt(1), 1234);
     ASSERT_EQ(col1->RawAt(2), -1234);
+}
+
+TEST(ColumnsCase, Date32_construct_from_rvalue_data) {
+    auto const expected = MakeNumbers<int32_t>();
+
+    auto data = expected;
+    auto col1 = std::make_shared<ColumnDate32>(std::move(data));
+
+    ASSERT_EQ(col1->Size(), expected.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        ASSERT_EQ(col1->RawAt(i), expected[i]);
+    }
 }
 
 TEST(ColumnsCase, DateTime_construct_from_rvalue_data) {
@@ -537,6 +560,23 @@ TEST(ColumnsCase, ColumnIPv4_construct_from_data)
 
     EXPECT_ANY_THROW(ColumnIPv4(ColumnRef(std::make_shared<ColumnInt128>())));
     EXPECT_ANY_THROW(ColumnIPv4(ColumnRef(std::make_shared<ColumnString>())));
+}
+
+TEST(ColumnsCase, ColumnIPv4_construct_from_rvalue_data) {
+    std::vector<uint32_t> data = {
+        0x12345678,
+        0x0,
+        0x0100007f,
+    };
+
+    const auto expected = {
+        MakeIPv4(data[0]),
+        MakeIPv4(data[1]),
+        MakeIPv4(data[2]),
+    };
+
+    auto col = ColumnIPv4(std::move(data));
+    ASSERT_EQ(col.Size(), expected.size());
 }
 
 TEST(ColumnsCase, ColumnIPv6)


### PR DESCRIPTION
These constructors can be valuable for enhancing performance in scenarios where a user knows the row count and can preallocate memory.

I also considered adding a similar constructor for `ColumnDateTime`, but its public interface exclusively utilizes `time_t`, while `uint32_t` is an implementation detail. I'm unsure if extending the interface with implementation details would be a good idea.