### PR TITLE
Set backward_compatibility_lowcardinality_as_wrapped_column default value to false

### DIFF
--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -123,7 +123,7 @@ struct ClientOptions {
     * @see LowCardinalitySerializationAdaptor, CreateColumnByType
     */
     [[deprecated("Makes implementation of LC(X) harder and code uglier. Will be removed in next major release (3.0) ")]]
-    DECLARE_FIELD(backward_compatibility_lowcardinality_as_wrapped_column, bool, SetBakcwardCompatibilityFeatureLowCardinalityAsWrappedColumn, true);
+    DECLARE_FIELD(backward_compatibility_lowcardinality_as_wrapped_column, bool, SetBakcwardCompatibilityFeatureLowCardinalityAsWrappedColumn, false);
 
     /** Set max size data to compress if compression enabled.
      *


### PR DESCRIPTION
This is to reduce number of weird issues popping up with LowCardinality columns. Consider this as a step towards the removal of this deprecated setting.

e.g. see #326 326