### PR TITLE
Fixed issue #335 by making at least one connection attempt

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -385,14 +385,15 @@ void Client::Impl::ResetConnectionEndpoint() {
 }
 
 void Client::Impl::CreateConnection() {
-    for (size_t i = 0; i < options_.send_retries;)
+    // i <= 1 to try at least once
+    for (size_t i = 0; i <= 1 || i < options_.send_retries;)
     {
         try
         {
             ResetConnectionEndpoint();
             return;
         } catch (const std::system_error&) {
-            if (++i == options_.send_retries)
+            if (++i >= options_.send_retries)
             {
                 throw;
             }

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -385,15 +385,17 @@ void Client::Impl::ResetConnectionEndpoint() {
 }
 
 void Client::Impl::CreateConnection() {
-    // i <= 1 to try at least once
-    for (size_t i = 0; i <= 1 || i < options_.send_retries;)
+    // make sure to try to connect to each endpoint at least once even if `options_.send_retries` is 0
+    const size_t max_attempts = (options_.send_retries ? options_.send_retries : 1);
+    for (size_t i = 0; i < max_attempts;)
     {
         try
         {
+            // Try to connect to each endpoint before throwing exception.
             ResetConnectionEndpoint();
             return;
         } catch (const std::system_error&) {
-            if (++i >= options_.send_retries)
+            if (++i >= max_attempts)
             {
                 throw;
             }

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -173,7 +173,7 @@ ColumnString::ColumnString(const std::vector<std::string>& data)
     for (const auto & s : data) {
         AppendUnsafe(s);
     }
-};
+}
 
 ColumnString::ColumnString(std::vector<std::string>&& data)
     : ColumnString()

--- a/ut/roundtrip_column.h
+++ b/ut/roundtrip_column.h
@@ -1,9 +1,16 @@
 #pragma once
 
 #include <clickhouse/columns/column.h>
+#include <memory>
 
 namespace clickhouse {
     class Client;
 }
 
 clickhouse::ColumnRef RoundtripColumnValues(clickhouse::Client& client, clickhouse::ColumnRef expected);
+
+template <typename T>
+auto RoundtripColumnValuesTyped(clickhouse::Client& client, std::shared_ptr<T> expected_col)
+{
+    return RoundtripColumnValues(client, expected_col)->template As<T>();
+}


### PR DESCRIPTION
Due to setting `ClientOptions.SetSendRetries(0)`, Client made no attempts to connect to a server, which resulted in uninitialized streams and hence the crash.

Closes: #335