### PR TITLE
Added `GetSize()` const method for FixedStringType

### DIFF
--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -251,6 +251,8 @@ public:
 
     std::string GetName() const { return std::string("FixedString(") + std::to_string(size_) + ")"; }
 
+    inline size_t GetSize() const { return size_; }
+
 private:
     size_t size_;
 };


### PR DESCRIPTION
By using ColumnLowCardinalityT<ColumnFixedString>, you lose the ability to conveniently know the fixed size parameter of ColumnFixedString. Adding this method fixes this issue.