### PR TITLE
Add RawAt() for ColumnDateTime

### DIFF
--- a/clickhouse/columns/date.cpp
+++ b/clickhouse/columns/date.cpp
@@ -210,6 +210,10 @@ void ColumnDateTime::AppendRaw(uint32_t value) {
     data_->Append(value);
 }
 
+uint32_t ColumnDateTime::RawAt(size_t n) const {
+	return data_->At(n);
+}
+
 std::string ColumnDateTime::Timezone() const {
     return type_->As<DateTimeType>()->Timezone();
 }

--- a/clickhouse/columns/date.h
+++ b/clickhouse/columns/date.h
@@ -142,6 +142,7 @@ public:
 
     /// Append raw as UNIX epoch seconds in uint32
     void AppendRaw(uint32_t value);
+    uint32_t RawAt(size_t n) const;
 
     /// Timezone associated with a data column.
     std::string Timezone() const;


### PR DESCRIPTION
`AppendRaw()` already exists for `ColumnDateTime`, but `RawAt()` doesn't.