### PR TITLE
[Bug fix] Append() in Nullable columns causes nulls_ array to be incorrectly appended to if nested column Append() fails

### DIFF
--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -95,12 +95,13 @@ public:
     }
 
     inline void Append(ValueType value) {
-        ColumnNullable::Append(!value.has_value());
         if (value.has_value()) {
             typed_nested_data_->Append(std::move(*value));
         } else {
             typed_nested_data_->Append(typename ValueType::value_type{});
         }
+        // Must be called after Append to nested column because it might fail
+        ColumnNullable::Append(!value.has_value());
     }
 
     /** Create a ColumnNullableT from a ColumnNullable, without copying data and offsets, but by


### PR DESCRIPTION
If `Append()` of the nested column fails, the `nulls_` column will be incremented despite nothing being appended.

This causes the following issues:
1- The `Size()` reported by the `Nullable<T>` column will be wrong since it depends on the size of `nulls_`.
2- If you try to access this new "fake" element of the `Nullable<T>` column, an error will be thrown because `false` would be appended to `nulls_` indicating that a valid non-null element exists. When `At()` or `[]` is used to access it, the actual nested column does not have this value, which causes the error to be thrown.
3- This is especially the case for columns like `FixedString` which could throw.

This pull request resolves that by moving the appending of `nulls_` to the end of the `Append()` operation of the nested column. If the nested column `Append()` does fail, then the `Append()` to `nulls_` is never called.