### PR TITLE
Install contrib libraries

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -156,6 +156,32 @@ INSTALL (TARGETS clickhouse-cpp-lib
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
 )
+IF (NOT BUILD_SHARED_LIBS)
+    IF (NOT WITH_SYSTEM_CITYHASH)
+        INSTALL (TARGETS cityhash
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+        )
+    ENDIF()
+    IF (NOT WITH_SYSTEM_LZ4)
+        INSTALL (TARGETS lz4
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+        )
+    ENDIF()
+    IF (NOT WITH_SYSTEM_ZSTD)
+        INSTALL (TARGETS zstdstatic
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+        )
+    ENDIF()
+    IF (NOT WITH_SYSTEM_ABSEIL)
+        INSTALL (TARGETS absl_int128
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib
+        )
+    ENDIF()
+ENDIF()
 
 # general
 INSTALL(FILES block.h DESTINATION include/clickhouse/)


### PR DESCRIPTION
Resolves #408 

To check:
```shell
$ cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr/local
$ cmake --build build
$ cmake --install install
```

It installs:
```
-- Install configuration: "RelWithDebInfo"
-- Installing: /usr/local/lib/libclickhouse-cpp-lib.a
-- Installing: /usr/local/lib/libcityhash.a
-- Installing: /usr/local/lib/liblz4.a
-- Installing: /usr/local/lib/libzstdstatic.a
-- Installing: /usr/local/lib/libabsl_int128.a
```