### PR TITLE
Disabled LowCardinalityOfNullable.ThrowOnBackwardsCompatibleLCColumn

### DIFF
--- a/ut/low_cardinality_nullable_tests.cpp
+++ b/ut/low_cardinality_nullable_tests.cpp
@@ -134,7 +134,7 @@ TEST(LowCardinalityOfNullable, InsertAndQueryEmpty) {
     });
 }
 
-TEST(LowCardinalityOfNullable, ThrowOnBackwardsCompatibleLCColumn) {
+TEST(LowCardinalityOfNullable, DISABLED_ThrowOnBackwardsCompatibleLCColumn) {
     auto column = buildTestColumn({}, {});
 
     Block block;


### PR DESCRIPTION
Test for a deprecated feature, which is going to be removed anyway