### PR TITLE
Support for CMake

### DIFF
--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -116,7 +116,9 @@ TARGET_LINK_LIBRARIES (clickhouse-cpp-lib
     zstd::zstd
 )
 TARGET_INCLUDE_DIRECTORIES (clickhouse-cpp-lib
-    PUBLIC ${PROJECT_SOURCE_DIR}
+    PUBLIC
+         $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+         $<INSTALL_INTERFACE:include/clickhouse>
 )
 
 IF (NOT BUILD_SHARED_LIBS)
@@ -153,9 +155,28 @@ ENDIF ()
 
 
 INSTALL (TARGETS clickhouse-cpp-lib
+    EXPORT clickhouse-cpp-config
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
 )
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(
+    ../cmake/clickhouse-cpp-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/clickhouse-cpp-config.cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/clickhouse-cpp
+)
+
+INSTALL(EXPORT clickhouse-cpp-config
+    FILE clickhouse-cpp-targets.cmake
+    DESTINATION lib/cmake/clickhouse-cpp
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/clickhouse-cpp-config.cmake DESTINATION lib/cmake/clickhouse-cpp)
+
+install(FILES ../cmake/Findcityhash.cmake DESTINATION lib/cmake/clickhouse-cpp)
+install(FILES ../cmake/Findlz4.cmake DESTINATION lib/cmake/clickhouse-cpp)
+install(FILES ../cmake/Findzstd.cmake DESTINATION lib/cmake/clickhouse-cpp)
 
 # general
 INSTALL(FILES block.h DESTINATION include/clickhouse/)

--- a/clickhouse/CMakeLists.txt
+++ b/clickhouse/CMakeLists.txt
@@ -153,30 +153,40 @@ IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND NOT DISABLE_CLANG_LIBC_WORKAROUND
     ENDIF ()
 ENDIF ()
 
+#special case for all system dependencies
+IF (WITH_SYSTEM_ABSEIL AND WITH_SYSTEM_CITYHASH AND WITH_SYSTEM_LZ4 AND WITH_SYSTEM_ZSTD)
+    INSTALL (TARGETS clickhouse-cpp-lib
+        EXPORT clickhouse-cpp-config
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+    )
 
-INSTALL (TARGETS clickhouse-cpp-lib
-    EXPORT clickhouse-cpp-config
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-)
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ../cmake/clickhouse-cpp-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/clickhouse-cpp-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/clickhouse-cpp
+    )
 
-include(CMakePackageConfigHelpers)
-configure_package_config_file(
-    ../cmake/clickhouse-cpp-config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/clickhouse-cpp-config.cmake
-    INSTALL_DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/cmake/clickhouse-cpp
-)
+    INSTALL(EXPORT clickhouse-cpp-config
+        FILE clickhouse-cpp-targets.cmake
+        DESTINATION lib/cmake/clickhouse-cpp
+    )
 
-INSTALL(EXPORT clickhouse-cpp-config
-    FILE clickhouse-cpp-targets.cmake
-    DESTINATION lib/cmake/clickhouse-cpp
-)
+    INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/clickhouse-cpp-config.cmake
+        DESTINATION lib/cmake/clickhouse-cpp
+    )
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/clickhouse-cpp-config.cmake DESTINATION lib/cmake/clickhouse-cpp)
-
-install(FILES ../cmake/Findcityhash.cmake DESTINATION lib/cmake/clickhouse-cpp)
-install(FILES ../cmake/Findlz4.cmake DESTINATION lib/cmake/clickhouse-cpp)
-install(FILES ../cmake/Findzstd.cmake DESTINATION lib/cmake/clickhouse-cpp)
+    install(FILES ../cmake/Findabsl.cmake DESTINATION lib/cmake/clickhouse-cpp)
+    install(FILES ../cmake/Findcityhash.cmake DESTINATION lib/cmake/clickhouse-cpp)
+    install(FILES ../cmake/Findlz4.cmake DESTINATION lib/cmake/clickhouse-cpp)
+    install(FILES ../cmake/Findzstd.cmake DESTINATION lib/cmake/clickhouse-cpp)
+ELSE ()
+    INSTALL (TARGETS clickhouse-cpp-lib
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+    )
+ENDIF ()
 
 # general
 INSTALL(FILES block.h DESTINATION include/clickhouse/)

--- a/cmake/Findabsl.cmake
+++ b/cmake/Findabsl.cmake
@@ -1,0 +1,30 @@
+find_path(absl_INCLUDE_DIR
+  NAMES absl/base/config.h
+  DOC "absl include directory"
+  REQUIRED
+)
+mark_as_advanced(absl_INCLUDE_DIR)
+find_library(absl_LIBRARY
+  NAMES absl_int128 libabsl_int128
+  DOC "absl library"
+  REQUIRED
+)
+mark_as_advanced(absl_LIBRARY)
+
+# Unlike lz4, absl's version information does not seem to be available.
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(absl
+  REQUIRED_VARS absl_LIBRARY absl_INCLUDE_DIR)
+
+if (absl_FOUND)
+  set(absl_INCLUDE_DIRS "${absl_INCLUDE_DIR}")
+  set(absl_LIBRARIES "${absl_LIBRARY}")
+
+  if (NOT TARGET absl::int128)
+    add_library(absl::int128 UNKNOWN IMPORTED)
+    set_target_properties(absl::int128 PROPERTIES
+      IMPORTED_LOCATION "${absl_LIBRARY}"
+      INTERFACE_INCLUDE_DIRECTORIES "${absl_INCLUDE_DIR}")
+  endif ()
+endif ()

--- a/cmake/Findcityhash.cmake
+++ b/cmake/Findcityhash.cmake
@@ -1,10 +1,14 @@
 find_path(cityhash_INCLUDE_DIR
   NAMES city.h
-  DOC "cityhash include directory")
+  DOC "cityhash include directory"
+  REQUIRED
+)
 mark_as_advanced(cityhash_INCLUDE_DIR)
 find_library(cityhash_LIBRARY
   NAMES cityhash libcityhash
-  DOC "cityhash library")
+  DOC "cityhash library"
+  REQUIRED
+)
 mark_as_advanced(cityhash_LIBRARY)
 
 # Unlike lz4, cityhash's version information does not seem to be available.

--- a/cmake/Findlz4.cmake
+++ b/cmake/Findlz4.cmake
@@ -1,10 +1,14 @@
 find_path(lz4_INCLUDE_DIR
   NAMES lz4.h
-  DOC "lz4 include directory")
+  DOC "lz4 include directory"
+  REQUIRED
+)
 mark_as_advanced(lz4_INCLUDE_DIR)
 find_library(lz4_LIBRARY
   NAMES lz4 liblz4
-  DOC "lz4 library")
+  DOC "lz4 library"
+  REQUIRED
+)
 mark_as_advanced(lz4_LIBRARY)
 
 if (lz4_INCLUDE_DIR)

--- a/cmake/Findzstd.cmake
+++ b/cmake/Findzstd.cmake
@@ -1,10 +1,14 @@
 find_path(zstd_INCLUDE_DIR
   NAMES zstd.h
-  DOC "zstd include directory")
+  DOC "zstd include directory"
+  REQUIRED
+)
 mark_as_advanced(zstd_INCLUDE_DIR)
 find_library(zstd_LIBRARY
   NAMES zstd libzstd
-  DOC "zstd library")
+  DOC "zstd library"
+  REQUIRED
+)
 mark_as_advanced(zstd_LIBRARY)
 
 if (zstd_INCLUDE_DIR)

--- a/cmake/clickhouse-cpp-config.cmake.in
+++ b/cmake/clickhouse-cpp-config.cmake.in
@@ -2,9 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-find_dependency(absl)
-find_dependency(cityhash)
-find_dependency(lz4)
-find_dependency(zstd)
+find_dependency(cityhash REQUIRED)
+find_dependency(lz4 REQUIRED)
+find_dependency(zstd REQUIRED)
+find_dependency(absl REQUIRED)
 
 include(clickhouse-cpp-targets)

--- a/cmake/clickhouse-cpp-config.cmake.in
+++ b/cmake/clickhouse-cpp-config.cmake.in
@@ -1,0 +1,10 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+find_dependency(absl)
+find_dependency(cityhash)
+find_dependency(lz4)
+find_dependency(zstd)
+
+include(clickhouse-cpp-targets)


### PR DESCRIPTION
Normal support for using library clickhouse-cpp with CMake and vcpkg added. Also some errors fixed.

Current usage of library in projects requires writing many lines of code, sush as
find_library, find_package, include_directories, target_link_libraries for all dependencies.
It's very annoying and error prune.
```
find_library(CLICKHOUSE_CPP libclickhouse-cpp-lib.a REQUIRED)
find_package(zstd CONFIG REQUIRED)
find_package(lz4 CONFIG REQUIRED)
find_package(cityhash CONFIG REQUIRED)
find_package(abseil CONFIG REQUIRED)

target_link_libraries(${PROJECT_NAME}
  PRIVATE
    ${CLICKHOUSE_CPP}
    zstd::libzstd_static
    lz4::lz4
    cityhash
    abseil
)
```

With my corrections all we need is:
```
find_package(clickhouse-cpp CONFIG REQUIRED)
target_link_libraries(${PROJECT_NAME} PRIVATE clickhouse-cpp-lib)
```
