### PR TITLE
Using shared_ptr in exception class

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -701,7 +701,7 @@ bool Client::Impl::ReceiveData() {
 }
 
 bool Client::Impl::ReceiveException(bool rethrow) {
-    std::unique_ptr<Exception> e(new Exception);
+    std::shared_ptr<Exception> e(new Exception);
     Exception* current = e.get();
 
     bool exception_received = true;
@@ -742,7 +742,7 @@ bool Client::Impl::ReceiveException(bool rethrow) {
     }
 
     if (rethrow || options_.rethrow_exceptions) {
-        throw ServerError(std::move(e));
+        throw ServerError(e);
     }
 
     return exception_received;

--- a/clickhouse/exceptions.h
+++ b/clickhouse/exceptions.h
@@ -40,9 +40,9 @@ class CompressionError : public Error {
 // Exception received from server.
 class ServerException : public Error {
 public:
-    ServerException(std::unique_ptr<Exception> e)
+    ServerException(std::shared_ptr<Exception> e)
         : Error(std::string())
-        , exception_(std::move(e))
+        , exception_(e)
     {
     }
 
@@ -59,7 +59,7 @@ public:
     }
 
 private:
-    std::unique_ptr<Exception> exception_;
+    std::shared_ptr<Exception> exception_;
 };
 using ServerError = ServerException;
 


### PR DESCRIPTION
By
https://en.cppreference.com/w/cpp/error/exception
Each standard library class T that derives from std::exception has the following publicly accessible member functions, each of them do not exit with an exception(until C++11)having a [non-throwing exception specification](https://en.cppreference.com/w/cpp/language/noexcept_spec)(since C++11): copy_constructor

For copy unique_ptr we must allocate new space and copy object into one. The allocation can throw exception. So we cannot use unique_ptr.

I change it to shared_ptr that works without memory allocation in copy constructor.