### PR TITLE
Fix MinGW Compiling Error

### DIFF
--- a/clickhouse/columns/ip4.cpp
+++ b/clickhouse/columns/ip4.cpp
@@ -61,9 +61,10 @@ in_addr ColumnIPv4::operator [] (size_t n) const {
 
 std::string ColumnIPv4::AsString(size_t n) const {
     const auto& addr = this->At(n);
+    auto tmp_addr = addr;
 
     char buf[INET_ADDRSTRLEN];
-    const char* ip_str = inet_ntop(AF_INET, &addr, buf, INET_ADDRSTRLEN);
+    const char* ip_str = inet_ntop(AF_INET, &tmp_addr, buf, INET_ADDRSTRLEN);
 
     if (ip_str == nullptr) {
         throw std::system_error(

--- a/clickhouse/columns/ip6.cpp
+++ b/clickhouse/columns/ip6.cpp
@@ -44,9 +44,10 @@ void ColumnIPv6::Clear() {
 
 std::string ColumnIPv6::AsString (size_t n) const {
     const auto& addr = this->At(n);
+    auto tmp_addr = addr;
 
     char buf[INET6_ADDRSTRLEN];
-    const char* ip_str = inet_ntop(AF_INET6, &addr, buf, INET6_ADDRSTRLEN);
+    const char* ip_str = inet_ntop(AF_INET6, &tmp_addr, buf, INET6_ADDRSTRLEN);
 
     if (ip_str == nullptr) {
         throw std::system_error(


### PR DESCRIPTION
const auto& addr = this->At(n);
auto tmp_addr = addr;

the line auto tmp_addr = addr; creates a copy of the object referred to by addr. This copy, tmp_addr, is not marked as const even though addr is a constant reference. As a result, the address of tmp_addr (i.e., &tmp_addr) is of a non-const pointer type, which is acceptable for the inet_ntop function.

Passing &tmp_addr to inet_ntop solves the issue of an invalid conversion from const void* to void*, because &tmp_addr is now of the type void* (or can be implicitly converted to it), bypassing the compiler error that would occur if you tried to pass directly &addr.

This approach is valid provided that this->At(n) returns the data in a way that allows creating a copy with auto tmp_addr without any unintended side effects.