### PR TITLE
CI/CD fix

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,33 +22,43 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
-        compiler: [clang-11, clang-12, gcc-8, gcc-9, gcc-10, gcc-12]
+        compiler: [clang-11, clang-14, clang-18, gcc-9, gcc-12, gcc-14]
         ssl: [ssl_ON, ssl_OFF]
         dependencies: [dependencies_BUILT_IN]
 
         include:
+        - compiler: clang-11
+          os: ubuntu-22.04
+          COMPILER_INSTALL: clang-11 libc++-11-dev
+          C_COMPILER: clang-11
+          CXX_COMPILER: clang++-11
+
         - compiler: clang-14
+          os: ubuntu-24.04
           COMPILER_INSTALL: clang-14 libc++-14-dev
           C_COMPILER: clang-14
-          CXX_COMPILER: clang++14
+          CXX_COMPILER: clang++-14
 
         - compiler: clang-18
+          os: ubuntu-24.04
           COMPILER_INSTALL: clang-18 libc++-18-dev
           C_COMPILER: clang-18
           CXX_COMPILER: clang++-18
 
         - compiler: gcc-9
+          os: ubuntu-22.04
           COMPILER_INSTALL: gcc-9 g++-9
           C_COMPILER: gcc-9
           CXX_COMPILER: g++-9
 
         - compiler: gcc-12
+          os: ubuntu-24.04
           COMPILER_INSTALL: gcc-12 g++-12
           C_COMPILER: gcc-12
           CXX_COMPILER: g++-12
 
         - compiler: gcc-14
+          os: ubuntu-24.04
           COMPILER_INSTALL: gcc-14 g++-14
           C_COMPILER: gcc-14
           CXX_COMPILER: g++-14
@@ -77,9 +87,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update && \
+          sudo apt-get update
           sudo apt-get install -y \
-            docker \
             cmake \
             ${{matrix.COMPILER_INSTALL}} \
             ${{matrix.DEPENDENCIES_INSTALL}}
@@ -92,6 +101,7 @@ jobs:
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt update -q
           sudo apt install docker-ce docker-ce-cli containerd.io
+          sudo docker run hello-world
 
       - name: Configure project
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,35 +23,35 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04]
-        compiler: [clang-6, clang-10-libc++, gcc-7, gcc-8, gcc-9]
+        compiler: [clang-11, clang-12, gcc-8, gcc-9, gcc-10, gcc-12]
         ssl: [ssl_ON, ssl_OFF]
         dependencies: [dependencies_BUILT_IN]
 
         include:
-        - compiler: clang-6
-          COMPILER_INSTALL: clang-6.0 libc++-dev
-          C_COMPILER: clang-6.0
-          CXX_COMPILER: clang++-6.0
+        - compiler: clang-14
+          COMPILER_INSTALL: clang-14 libc++-14-dev
+          C_COMPILER: clang-14
+          CXX_COMPILER: clang++14
 
-        - compiler: clang-10-libc++
-          COMPILER_INSTALL: clang-10 libc++-dev
-          C_COMPILER: clang-10
-          CXX_COMPILER: clang++-10
-
-        - compiler: gcc-7
-          COMPILER_INSTALL: gcc-7 g++-7
-          C_COMPILER: gcc-7
-          CXX_COMPILER: g++-7
-
-        - compiler: gcc-8
-          COMPILER_INSTALL: gcc-8 g++-8
-          C_COMPILER: gcc-8
-          CXX_COMPILER: g++-8
+        - compiler: clang-18
+          COMPILER_INSTALL: clang-18 libc++-18-dev
+          C_COMPILER: clang-18
+          CXX_COMPILER: clang++-18
 
         - compiler: gcc-9
           COMPILER_INSTALL: gcc-9 g++-9
           C_COMPILER: gcc-9
           CXX_COMPILER: g++-9
+
+        - compiler: gcc-12
+          COMPILER_INSTALL: gcc-12 g++-12
+          C_COMPILER: gcc-12
+          CXX_COMPILER: g++-12
+
+        - compiler: gcc-14
+          COMPILER_INSTALL: gcc-14 g++-14
+          C_COMPILER: gcc-14
+          CXX_COMPILER: g++-14
 
         - ssl: ssl_ON
           SSL_CMAKE_OPTION: -D WITH_OPENSSL=ON

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         compiler: [clang-6, clang-10-libc++, gcc-7, gcc-8, gcc-9]
         ssl: [ssl_ON, ssl_OFF]
         dependencies: [dependencies_BUILT_IN]
@@ -58,7 +58,7 @@ jobs:
 
         - dependencies: dependencies_SYSTEM
           compiler: compiler_SYSTEM
-          os: ubuntu-22.04
+          os: ubuntu-24.04
           COMPILER_INSTALL: gcc g++
           C_COMPILER: gcc
           CXX_COMPILER: g++

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
   release:

--- a/.github/workflows/windows_mingw.yml
+++ b/.github/workflows/windows_mingw.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/windows_msvc.yml
+++ b/.github/workflows/windows_msvc.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   push:
-    branches: [ master ]
+    branches: [ '*' ]
   pull_request:
     branches: [ master ]
 

--- a/ut/utils_comparison.h
+++ b/ut/utils_comparison.h
@@ -141,11 +141,15 @@ template <typename LeftContainer, typename RightContainer>
 template <typename Container>
 struct PrintContainer;
 
+
 template <typename Left, typename Right>
 ::testing::AssertionResult CompareRecursive(const Left & left, const Right & right) {
-    if constexpr (!is_string_v<Left> && !is_string_v<Right>
-            && (is_container_v<Left> || std::is_base_of_v<clickhouse::Column, std::decay_t<Left>>)
-            && (is_container_v<Right> || std::is_base_of_v<clickhouse::Column, std::decay_t<Right>>) ) {
+    using L = std::decay_t<Left>;
+    using R = std::decay_t<Right>;
+
+    if constexpr (!is_string_v<L> && !is_string_v<R>
+            && (is_container_v<L> || std::is_base_of_v<clickhouse::Column, L>)
+            && (is_container_v<R> || std::is_base_of_v<clickhouse::Column, R>) ) {
 
         const auto & l = maybeWrapColumnAsContainer(left);
         const auto & r = maybeWrapColumnAsContainer(right);
@@ -155,24 +159,29 @@ template <typename Left, typename Right>
         else
             return result << "\nExpected container: " << PrintContainer{l}
                           << "\nActual container  : " << PrintContainer{r};
+    }
+    else if constexpr (std::is_same_v<char const *, L> || std::is_same_v<char *, L>) {
+        return CompareRecursive(std::string_view(left), right);
+    }
+    else if constexpr (std::is_same_v<char const *, R> || std::is_same_v<char *, R>) {
+        return CompareRecursive(left, std::string_view(right));
     } else {
         if (left != right) {
-
             // Handle std::optional<float>(nan)
-            // I'm too lazy to code comparison against std::nullopt, but this shpudn't be a problem in real life.
-            // RN comparing against std::nullopt, you'll receive an compilation error.
-            if constexpr (is_instantiation_of<std::optional, Left>::value && is_instantiation_of<std::optional, Right>::value)
+            // I'm too lazy to code comparison against std::nullopt, but this shouldn't be a problem in real life.
+            // RN comparing against std::nullopt, you'll get a compilation error.
+            if constexpr (is_instantiation_of<std::optional, L>::value && is_instantiation_of<std::optional, R>::value)
             {
                 if (left.has_value() && right.has_value())
                     return CompareRecursive(*left, *right);
             }
-            else if constexpr (is_instantiation_of<std::optional, Left>::value) {
+            else if constexpr (is_instantiation_of<std::optional, L>::value) {
                 if (left)
                     return CompareRecursive(*left, right);
-            } else if constexpr (is_instantiation_of<std::optional, Right>::value) {
+            } else if constexpr (is_instantiation_of<std::optional, R>::value) {
                 if (right)
                     return CompareRecursive(left, *right);
-            } else if constexpr (std::is_floating_point_v<Left> && std::is_floating_point_v<Right>) {
+            } else if constexpr (std::is_floating_point_v<L> && std::is_floating_point_v<R>) {
                 if (std::isnan(left) && std::isnan(right))
                     return ::testing::AssertionSuccess();
             }

--- a/ut/utils_meta.h
+++ b/ut/utils_meta.h
@@ -52,6 +52,7 @@ struct is_instantiation_of< Template, Template<Args...> > : std::true_type {};
 template <typename T>
 inline constexpr bool is_string_v = std::is_same_v<std::string, std::decay_t<T>> || std::is_same_v<std::string_view, std::decay_t<T>>;
 
+
 // https://stackoverflow.com/a/34111095
 template <typename...>
 struct is_one_of {

--- a/ut/utils_ut.cpp
+++ b/ut/utils_ut.cpp
@@ -12,9 +12,84 @@ TEST(CompareRecursive, CompareValues) {
     EXPECT_TRUE(CompareRecursive(1.0, 1.0));
     EXPECT_TRUE(CompareRecursive(1.0L, 1.0L));
 
+    EXPECT_TRUE(CompareRecursive('a', 'a'));
+}
+
+TEST(CompareRecursive, CompareStrings) {
+    // literals
     EXPECT_TRUE(CompareRecursive("1.0L", "1.0L"));
-    EXPECT_TRUE(CompareRecursive(std::string{"1.0L"}, std::string{"1.0L"}));
+    EXPECT_TRUE(CompareRecursive("1.0L", std::string("1.0L")));
+    EXPECT_TRUE(CompareRecursive(std::string("1.0L"), "1.0L"));
+    EXPECT_TRUE(CompareRecursive("1.0L", std::string_view("1.0L")));
+    EXPECT_TRUE(CompareRecursive(std::string_view("1.0L"), "1.0L"));
+
+    // array
+    const char str[] = "1.0L";
+    EXPECT_TRUE(CompareRecursive("1.0L", str));
+    EXPECT_TRUE(CompareRecursive(str, "1.0L"));
+    EXPECT_TRUE(CompareRecursive(str, str));
+    EXPECT_TRUE(CompareRecursive(str, std::string("1.0L")));
+    EXPECT_TRUE(CompareRecursive(std::string("1.0L"), str));
+    EXPECT_TRUE(CompareRecursive(str, std::string_view("1.0L")));
+    EXPECT_TRUE(CompareRecursive(std::string_view("1.0L"), str));
+
+    // pointer
+    const char *str2 = "1.0L";
+    EXPECT_TRUE(CompareRecursive("1.0L", str2));
+    EXPECT_TRUE(CompareRecursive(str2, "1.0L"));
+    EXPECT_TRUE(CompareRecursive(str2, str2));
+    EXPECT_TRUE(CompareRecursive(str2, str));
+    EXPECT_TRUE(CompareRecursive(str, str2));
+    EXPECT_TRUE(CompareRecursive(str2, std::string("1.0L")));
+    EXPECT_TRUE(CompareRecursive(std::string("1.0L"), str2));
+    EXPECT_TRUE(CompareRecursive(str2, std::string_view("1.0L")));
+    EXPECT_TRUE(CompareRecursive(std::string_view("1.0L"), str2));
+
+    // string & string_view
+    EXPECT_TRUE(CompareRecursive(std::string{"1.0L"},      std::string{"1.0L"}));
     EXPECT_TRUE(CompareRecursive(std::string_view{"1.0L"}, std::string_view{"1.0L"}));
+    EXPECT_TRUE(CompareRecursive(std::string{"1.0L"},      std::string_view{"1.0L"}));
+    EXPECT_TRUE(CompareRecursive(std::string_view{"1.0L"}, std::string{"1.0L"}));
+}
+
+TEST(CompareRecursive, CompareContainerOfStrings) {
+    const std::vector<const char*> vector_of_cstrings = {
+        "abc",
+        "cde",
+        "ghi"
+    };
+
+    const std::vector<std::string> vector_of_strings = {
+        "abc",
+        "cde",
+        "ghi"
+    };
+
+    const std::vector<std::string_view> vector_of_string_views = {
+        "abc",
+        "cde",
+        "ghi"
+    };
+
+    {
+        // same values, but different pointers
+        const std::vector<const char*> vector_of_cstrings2 = {
+            vector_of_strings[0].data(),
+            vector_of_strings[1].data(),
+            vector_of_strings[2].data(),
+        };
+        EXPECT_TRUE(CompareRecursive(vector_of_cstrings, vector_of_cstrings2));
+    }
+
+    EXPECT_TRUE(CompareRecursive(vector_of_strings, vector_of_strings));
+    EXPECT_TRUE(CompareRecursive(vector_of_strings, vector_of_cstrings));
+    EXPECT_TRUE(CompareRecursive(vector_of_cstrings, vector_of_strings));
+
+    EXPECT_TRUE(CompareRecursive(vector_of_string_views, vector_of_string_views));
+    EXPECT_TRUE(CompareRecursive(vector_of_strings, vector_of_string_views));
+    EXPECT_TRUE(CompareRecursive(vector_of_string_views, vector_of_strings));
+    EXPECT_TRUE(CompareRecursive(vector_of_strings, vector_of_string_views));
+    EXPECT_TRUE(CompareRecursive(vector_of_string_views, vector_of_strings));
 }
 
 TEST(CompareRecursive, CompareContainers) {


### PR DESCRIPTION
Mostly focused on fixing CI/CD on Linux
- Using Ubuntu 22.04 and Ubuntu 24.04
- corresponding supported compilers
- Properly installing docker
- CompareRecursive fix for GCC-12 (fixes #425)

Closes #415 (supersedes)