### PR TITLE
Add BeginInsert/InsertData/EndInsert flow

### DIFF
--- a/clickhouse/block.h
+++ b/clickhouse/block.h
@@ -85,10 +85,10 @@ public:
         return columns_.at(idx).name;
     }
 
-    /// Convinience method to wipe out all rows from all columns
+    /// Convenience method to wipe out all rows from all columns
     void Clear();
 
-    /// Convinience method to do Reserve() on all columns
+    /// Convenience method to do Reserve() on all columns
     void Reserve(size_t new_cap);
 
     /// Reference to column by index in the block.

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -273,6 +273,17 @@ public:
     void Insert(const std::string& table_name, const Block& block);
     void Insert(const std::string& table_name, const std::string& query_id, const Block& block);
 
+    /// Start an \p INSERT statement, insert batches of data, then finish the insert.
+    Block BeginInsert(const std::string& query);
+    Block BeginInsert(const std::string& query, const std::string& query_id);
+
+    /// Insert data using a \p block returned by \p BeginInsert.
+    void InsertData(const Block& block);
+
+    /// End an \p INSERT session started by \p BeginInsert.
+    void EndInsert();
+    void EndInsert(const Block& block);
+
     /// Ping server for aliveness.
     void Ping();
 


### PR DESCRIPTION
Add a new pattern for "prepared inserts". It works like this:

*   Call `BeginInsert` with an `INSERT` query with optional columns and ending in `VALUES`. No values should be included in the string.
*   It returns a `Block` pre-configured with columns as declared in the `INSERT` statement
*   Add data to the block and periodically call `InsertData` to insert data and clear the block.
*   Call `EndInsert()` or just let the `Client` object go out of scope to signal the server that it's done inserting.

This allows one to send smaller batches of blocks, thereby using less memory, but still in a single ClickHouse `INSERT` operation.

Expected to be useful in the Postgres foreign data wrapper insert API, where multiple rows can be inserted at once but its API handles one-at-a-time insertion. It will also support the FDW COPY API, which can submit huge batches of data to insert, as well.