### PR TITLE
Start adding Bool type

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ C++ client for [ClickHouse](https://clickhouse.com/).
 * String
 * LowCardinality(String) or LowCardinality(FixedString(N))
 * Tuple
-* UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64
+* UInt8, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64, Bool
 * UInt128, Int128
 * UUID
 * Map

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -48,6 +48,8 @@ static ColumnRef CreateTerminalColumn(const TypeAst& ast) {
     case Type::Void:
         return std::make_shared<ColumnNothing>();
 
+    case Type::Bool:
+        return std::make_shared<ColumnBool>();
     case Type::UInt8:
         return std::make_shared<ColumnUInt8>();
     case Type::UInt16:

--- a/clickhouse/columns/itemview.cpp
+++ b/clickhouse/columns/itemview.cpp
@@ -41,6 +41,7 @@ void ItemView::ValidateData(Type::Code type, DataType data) {
         case Type::Code::Void:
             return AssertSize({0});
 
+        case Type::Code::Bool:
         case Type::Code::Int8:
         case Type::Code::UInt8:
         case Type::Code::Enum8:

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -69,7 +69,7 @@ public:
             if (sizeof(ValueType) == data.size()) {
                 return *reinterpret_cast<const T*>(data.data());
             } else {
-                throw AssertionError("Incompatitable value type and size. Requested size: "
+                throw AssertionError("Incompatible value type and size. Requested size: "
                         + std::to_string(sizeof(ValueType)) + " stored size: " + std::to_string(data.size()));
             }
         }

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -70,6 +70,7 @@ using Int128 = absl::int128;
 using UInt128 = absl::uint128;
 using Int64 = int64_t;
 
+using ColumnBool    = ColumnVector<uint8_t>;
 using ColumnUInt8   = ColumnVector<uint8_t>;
 using ColumnUInt16  = ColumnVector<uint16_t>;
 using ColumnUInt32  = ColumnVector<uint32_t>;

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -32,7 +32,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
     { "Int16",       Type::Int16 },
     { "Int32",       Type::Int32 },
     { "Int64",       Type::Int64 },
-    { "Bool",        Type::UInt8 },
+    { "Bool",        Type::Bool },
     { "UInt8",       Type::UInt8 },
     { "UInt16",      Type::UInt16 },
     { "UInt32",      Type::UInt32 },

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -20,6 +20,7 @@ const char* Type::TypeName(Type::Code code) {
         case Type::Code::Int16:          return "Int16";
         case Type::Code::Int32:          return "Int32";
         case Type::Code::Int64:          return "Int64";
+        case Type::Code::Bool:           return "Bool";
         case Type::Code::UInt8:          return "UInt8";
         case Type::Code::UInt16:         return "UInt16";
         case Type::Code::UInt32:         return "UInt32";
@@ -65,6 +66,7 @@ std::string Type::GetName() const {
         case Int32:
         case Int64:
         case Int128:
+        case Bool:
         case UInt8:
         case UInt16:
         case UInt32:
@@ -124,6 +126,7 @@ uint64_t Type::GetTypeUniqueId() const {
         case Int32:
         case Int64:
         case Int128:
+        case Bool:
         case UInt8:
         case UInt16:
         case UInt32:

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -25,6 +25,7 @@ public:
         Int16,
         Int32,
         Int64,
+        Bool,
         UInt8,
         UInt16,
         UInt32,
@@ -344,6 +345,11 @@ inline TypeRef Type::CreateSimple<Int128>() {
 template <>
 inline TypeRef Type::CreateSimple<UInt128>() {
     return TypeRef(new Type(UInt128));
+}
+
+template <>
+inline TypeRef Type::CreateSimple<bool>() {
+    return TypeRef(new Type(Bool));
 }
 
 template <>

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -62,7 +62,7 @@ class CreateColumnByTypeWithName : public ::testing::TestWithParam<const char* /
 TEST(CreateColumnByType, Bool) {
     const auto col = CreateColumnByType("Bool");
     ASSERT_NE(nullptr, col);
-    EXPECT_EQ(col->GetType().GetName(), "UInt8");
+    EXPECT_EQ(col->GetType().GetName(), "Bool");
 }
 
 TEST_P(CreateColumnByTypeWithName, CreateColumnByType)
@@ -74,7 +74,7 @@ TEST_P(CreateColumnByTypeWithName, CreateColumnByType)
 
 INSTANTIATE_TEST_SUITE_P(Basic, CreateColumnByTypeWithName, ::testing::Values(
     "Int8", "Int16", "Int32", "Int64",
-    "UInt8", "UInt16", "UInt32", "UInt64",
+    "UInt8", "UInt16", "UInt32", "UInt64", "Bool",
     "String", "Date", "DateTime",
     "UUID", "Int128", "UInt128"
 ));

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -358,6 +358,9 @@ std::ostream& operator<<(std::ostream& ostr, const ItemView& item_view) {
         case Type::Int64:
             ostr << item_view.get<int64_t>();
             break;
+        case Type::Bool:
+            ostr << static_cast<bool>(item_view.get<bool>());
+            break;
         case Type::UInt8:
             ostr << static_cast<unsigned int>(item_view.get<uint8_t>());
             break;


### PR DESCRIPTION
Try implementing it as a number, just like `UInt8`. One test fails:

```
/Users/david/dev/clickhouse/clickhouse-cpp/ut/CreateColumnByType_ut.cpp:72: Failure
Expected equality of these values:
  col->GetType().GetName()
    Which is: "UInt8"
  GetParam()
    Which is: "Bool"
```

It looks as though `CreateColumnByType`, even though passed a `Bool`, creates a `UInt8`. I tried instead configuring it with

```patch
--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -108,6 +108,7 @@ ItemView ColumnVector<T>::GetItem(size_t index) const  {
     return ItemView{type_->GetCode(), data_[index]};
 }
 
+template class ColumnVector<bool>;
 template class ColumnVector<int8_t>;
 template class ColumnVector<int16_t>;
 template class ColumnVector<int32_t>;
--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -70,7 +70,7 @@ using Int128 = absl::int128;
 using UInt128 = absl::uint128;
 using Int64 = int64_t;
 
-using ColumnBool    = ColumnVector<uint8_t>;
+using ColumnBool    = ColumnVector<bool>;
 using ColumnUInt8   = ColumnVector<uint8_t>;
 using ColumnUInt16  = ColumnVector<uint16_t>;
 using ColumnUInt32  = ColumnVector<uint32_t>;
```

But that won't even compile, presumably because a vector of bools is a whole different thing than a vector of numbers.

Not a blocker for my project, as the old mapping to UInt8 seems to work well enough.