### PR TITLE
Add JSON support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ C++ client for [ClickHouse](https://clickhouse.com/).
 * UUID
 * Map
 * Point, Ring, Polygon, MultiPolygon
+* JSON
 
 ## Dependencies
 In the most basic case one needs only:

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -86,6 +86,8 @@ static ColumnRef CreateTerminalColumn(const TypeAst& ast) {
 
     case Type::String:
         return std::make_shared<ColumnString>();
+    case Type::JSON:
+        return std::make_shared<ColumnJSON>();
     case Type::FixedString:
         return std::make_shared<ColumnFixedString>(GetASTChildElement(ast, 0).value);
 
@@ -201,6 +203,8 @@ static ColumnRef CreateColumnFromAst(const TypeAst& ast, CreateColumnByTypeSetti
                     // TODO (nemkov): update this to maximize code reuse.
                     case Type::String:
                         return std::make_shared<LowCardinalitySerializationAdaptor<ColumnString>>();
+                    case Type::JSON:
+                        return std::make_shared<LowCardinalitySerializationAdaptor<ColumnJSON>>();
                     case Type::FixedString:
                         return std::make_shared<LowCardinalitySerializationAdaptor<ColumnFixedString>>(GetASTChildElement(nested, 0).value);
                     case Type::Nullable:
@@ -214,6 +218,8 @@ static ColumnRef CreateColumnFromAst(const TypeAst& ast, CreateColumnByTypeSetti
                     // TODO (nemkov): update this to maximize code reuse.
                     case Type::String:
                         return std::make_shared<ColumnLowCardinalityT<ColumnString>>();
+                    case Type::JSON:
+                        return std::make_shared<ColumnLowCardinalityT<ColumnJSON>>();
                     case Type::FixedString:
                         return std::make_shared<ColumnLowCardinalityT<ColumnFixedString>>(GetASTChildElement(nested, 0).value);
                     case Type::Nullable:

--- a/clickhouse/columns/itemview.cpp
+++ b/clickhouse/columns/itemview.cpp
@@ -70,6 +70,7 @@ void ItemView::ValidateData(Type::Code type, DataType data) {
 
         case Type::Code::String:
         case Type::Code::FixedString:
+        case Type::Code::JSON:
             // value can be of any size
             return;
 

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -69,7 +69,7 @@ public:
             if (sizeof(ValueType) == data.size()) {
                 return *reinterpret_cast<const T*>(data.data());
             } else {
-                throw AssertionError("Incompatitable value type and size. Requested size: "
+                throw AssertionError("Incompatible value type and size. Requested size: "
                         + std::to_string(sizeof(ValueType)) + " stored size: " + std::to_string(data.size()));
             }
         }

--- a/clickhouse/columns/string.h
+++ b/clickhouse/columns/string.h
@@ -142,4 +142,76 @@ private:
     std::deque<std::string> append_data_;
 };
 
+/**
+ * Represents column of variable-length strings.
+ */
+class ColumnJSON : public Column {
+public:
+    // Type this column takes as argument of Append and returns with At() and operator[]
+    using ValueType = std::string_view;
+
+    ColumnJSON();
+    ~ColumnJSON();
+
+    explicit ColumnJSON(size_t element_count);
+    explicit ColumnJSON(const std::vector<std::string> & data);
+    explicit ColumnJSON(std::vector<std::string>&& data);
+    ColumnJSON& operator=(const ColumnJSON&) = delete;
+    ColumnJSON(const ColumnJSON&) = delete;
+
+    /// Increase the capacity of the column for large block insertion.
+    void Reserve(size_t new_cap) override;
+
+    /// Appends one element to the column.
+    void Append(std::string_view str);
+
+    /// Appends one element to the column.
+    void Append(const char* str);
+
+    /// Appends one element to the column.
+    void Append(std::string&& steal_value);
+
+    /// Appends one element to the column.
+    /// If str lifetime is managed elsewhere and guaranteed to outlive the Block sent to the server
+    void AppendNoManagedLifetime(std::string_view str);
+
+    /// Returns element at given row number.
+    std::string_view At(size_t n) const;
+
+    /// Returns element at given row number.
+    inline std::string_view operator [] (size_t n) const { return At(n); }
+
+public:
+    /// Appends content of given column to the end of current one.
+    void Append(ColumnRef column) override;
+
+    /// Loads column data from input stream.
+    bool LoadBody(InputStream* input, size_t rows) override;
+
+    /// Saves column data to output stream.
+    void SaveBody(OutputStream* output) override;
+
+    /// Clear column data .
+    void Clear() override;
+
+    /// Returns count of rows in the column.
+    size_t Size() const override;
+
+    /// Makes slice of the current column.
+    ColumnRef Slice(size_t begin, size_t len) const override;
+    ColumnRef CloneEmpty() const override;
+    void Swap(Column& other) override;
+    ItemView GetItem(size_t) const override;
+
+private:
+    void AppendUnsafe(std::string_view);
+
+private:
+    struct Block;
+
+    std::vector<std::string_view> items_;
+    std::vector<Block> blocks_;
+    std::deque<std::string> append_data_;
+};
+
 }

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -40,6 +40,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
     { "Float32",     Type::Float32 },
     { "Float64",     Type::Float64 },
     { "String",      Type::String },
+    { "JSON",        Type::JSON },
     { "FixedString", Type::FixedString },
     { "DateTime",    Type::DateTime },
     { "DateTime64",  Type::DateTime64 },
@@ -68,7 +69,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
 };
 
 template <typename L, typename R>
-inline int CompateStringsCaseInsensitive(const L& left, const R& right) {
+inline int CompareStringsCaseInsensitive(const L& left, const R& right) {
     int64_t size_diff = left.size() - right.size();
     if (size_diff != 0)
         return size_diff > 0 ? 1 : -1;
@@ -129,7 +130,7 @@ bool ValidateAST(const TypeAst& ast) {
     // Void terminal that is not actually "void" produced when unknown type is encountered.
     if (ast.meta == TypeAst::Terminal
             && ast.code == Type::Void
-            && CompateStringsCaseInsensitive(ast.name, std::string_view("void")) != 0)
+            && CompareStringsCaseInsensitive(ast.name, std::string_view("void")) != 0)
         //throw UnimplementedError("Unsupported type: " + ast.name);
         return false;
 

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -52,6 +52,7 @@ const char* Type::TypeName(Type::Code code) {
         case Type::Code::Ring:           return "Ring";
         case Type::Code::Polygon:        return "Polygon";
         case Type::Code::MultiPolygon:   return "MultiPolygon";
+        case Type::Code::JSON:           return "JSON";
     }
 
     return "Unknown type";
@@ -82,6 +83,7 @@ std::string Type::GetName() const {
         case Ring:
         case Polygon:
         case MultiPolygon:
+        case JSON:
             return TypeName(code_);
         case FixedString:
             return As<FixedStringType>()->GetName();
@@ -141,6 +143,7 @@ uint64_t Type::GetTypeUniqueId() const {
         case Ring:
         case Polygon:
         case MultiPolygon:
+        case JSON:
             // For simple types, unique ID is the same as Type::Code
             return code_;
 
@@ -222,6 +225,10 @@ TypeRef Type::CreateString() {
 
 TypeRef Type::CreateString(size_t n) {
     return TypeRef(new FixedStringType(n));
+}
+
+TypeRef Type::CreateJSON() {
+    return TypeRef(new Type(Type::JSON));
 }
 
 TypeRef Type::CreateTuple(const std::vector<TypeRef>& item_types) {

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -33,6 +33,7 @@ public:
         Float64,
         String,
         FixedString,
+        JSON,
         DateTime,
         Date,
         Array,
@@ -56,7 +57,7 @@ public:
         Point,
         Ring,
         Polygon,
-        MultiPolygon
+        MultiPolygon,
     };
 
     using EnumItem = std::pair<std::string /* name */, int16_t /* value */>;
@@ -121,6 +122,8 @@ public:
     static TypeRef CreateString();
 
     static TypeRef CreateString(size_t n);
+
+    static TypeRef CreateJSON();
 
     static TypeRef CreateTuple(const std::vector<TypeRef>& item_types);
 

--- a/ut/Column_ut.cpp
+++ b/ut/Column_ut.cpp
@@ -194,6 +194,7 @@ using TestCases = ::testing::Types<
 
     GenericColumnTestCase<ColumnString, &makeColumn<ColumnString>, std::string, &MakeStrings>,
     GenericColumnTestCase<ColumnFixedString, &makeColumn<ColumnFixedString, 12>, std::string, &MakeFixedStrings<12>>,
+    GenericColumnTestCase<ColumnJSON, &makeColumn<ColumnJSON>, std::string, &MakeJSONStrings>,
 
     GenericColumnTestCase<ColumnDate, &makeColumn<ColumnDate>, time_t, &MakeDates<time_t>>,
     GenericColumnTestCase<ColumnDate32, &makeColumn<ColumnDate32>, time_t, &MakeDates<time_t>>,

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -40,6 +40,9 @@ TEST(CreateColumnByType, LowCardinalityAsWrappedColumn) {
 
     ASSERT_EQ(Type::FixedString, CreateColumnByType("LowCardinality(FixedString(10000))", create_column_settings)->GetType().GetCode());
     ASSERT_EQ(Type::FixedString, CreateColumnByType("LowCardinality(FixedString(10000))", create_column_settings)->As<ColumnFixedString>()->GetType().GetCode());
+
+    ASSERT_EQ(Type::JSON, CreateColumnByType("LowCardinality(JSON)", create_column_settings)->GetType().GetCode());
+    ASSERT_EQ(Type::JSON, CreateColumnByType("LowCardinality(JSON)", create_column_settings)->As<ColumnJSON>()->GetType().GetCode());
 }
 
 TEST(CreateColumnByType, DateTime) {

--- a/ut/column_array_ut.cpp
+++ b/ut/column_array_ut.cpp
@@ -227,6 +227,21 @@ TEST(ColumnArrayT, SimpleFixedString) {
     EXPECT_EQ("world\0"sv, (*array)[0][1]);
 }
 
+TEST(ColumnArrayT, JSON) {
+    using namespace std::literals;
+    auto array = std::make_shared<ColumnArrayT<ColumnJSON>>(6);
+    array->Append({"[\"hello\"]", "{\"place\": \"world\"}"});
+
+    EXPECT_EQ("[\"hello\"]"sv, array->At(0).At(0));
+
+    auto row = array->At(0);
+    EXPECT_EQ("[\"hello\"]"sv, row.At(0));
+    EXPECT_EQ(9u, row[0].length());
+    EXPECT_EQ("[\"hel", row[0].substr(0, 5));
+
+    EXPECT_EQ("{\"place\": \"world\"}"sv, (*array)[0][1]);
+}
+
 TEST(ColumnArrayT, SimpleUInt64_2D) {
     // Nested 2D-arrays are supported too:
     auto array = std::make_shared<ColumnArrayT<ColumnArrayT<ColumnUInt64>>>();

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -137,6 +137,29 @@ TEST(ColumnsCase, StringAppend) {
     ASSERT_EQ(col->At(2), "11");
 }
 
+TEST(ColumnsCase, JSONInit) {
+    auto values = MakeJSONStrings();
+    auto col = std::make_shared<ColumnJSON>(values);
+
+    ASSERT_EQ(col->Size(), values.size());
+    ASSERT_EQ(col->At(1), "98.6");
+    ASSERT_EQ(col->At(3), "false");
+}
+
+TEST(ColumnsCase, JSONAppend) {
+    auto col = std::make_shared<ColumnJSON>();
+    const char* expected = "\"ufiudhf3493fyiudferyer3yrifhdflkdjfeuroe\"";
+    std::string data(expected);
+    col->Append(data);
+    col->Append(std::move(data));
+    col->Append("11");
+
+    ASSERT_EQ(col->Size(), 3u);
+    ASSERT_EQ(col->At(0), expected);
+    ASSERT_EQ(col->At(1), expected);
+    ASSERT_EQ(col->At(2), "11");
+}
+
 TEST(ColumnsCase, TupleAppend){
     auto tuple1 = std::make_shared<ColumnTuple>(std::vector<ColumnRef>({
                                 std::make_shared<ColumnUInt64>(),

--- a/ut/itemview_ut.cpp
+++ b/ut/itemview_ut.cpp
@@ -68,6 +68,9 @@ TEST(ItemView, StorableTypes) {
 
     TEST_ITEMVIEW_TYPE_VALUE(Type::Code::FixedString, std::string_view, "");
     TEST_ITEMVIEW_TYPE_VALUE(Type::Code::FixedString, std::string_view, "here is a string");
+
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::JSON, std::string_view, "{}");
+    TEST_ITEMVIEW_TYPE_VALUE(Type::Code::JSON, std::string_view, "{\"x\": \"some JSON\"}");
 }
 
 #define EXPECT_ITEMVIEW_ERROR(TypeCode, NativeType) \

--- a/ut/type_parser_ut.cpp
+++ b/ut/type_parser_ut.cpp
@@ -24,6 +24,15 @@ TEST(TypeParserCase, ParseFixedString) {
     ASSERT_EQ(ast.elements.front().value, 24U);
 }
 
+TEST(TypeParserCase, ParseJSON) {
+    TypeAst ast;
+    TypeParser("JSON").Parse(&ast);
+
+    ASSERT_EQ(ast.meta, TypeAst::Terminal);
+    ASSERT_EQ(ast.name, "JSON");
+    ASSERT_EQ(ast.code, Type::JSON);
+}
+
 TEST(TypeParserCase, ParseArray) {
     TypeAst ast;
     TypeParser("Array(Int32)").Parse(&ast);

--- a/ut/types_ut.cpp
+++ b/ut/types_ut.cpp
@@ -82,6 +82,7 @@ TEST(TypesCase, IsEqual) {
         "Int8",
 //        "UInt128",
         "String",
+        "JSON",
         "FixedString(0)",
         "FixedString(10000)",
         "DateTime('UTC')",

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -60,6 +60,7 @@ bool doPrintValue(const ColumnRef & c, const size_t row, std::ostream & ostr) {
     if (const auto & casted_c = c->As<ColumnType>()) {
         if constexpr (is_container_v<std::decay_t<AsType>>
                 && !std::is_same_v<ColumnType, ColumnString>
+                && !std::is_same_v<ColumnType, ColumnJSON>
                 && !std::is_same_v<ColumnType, ColumnFixedString>) {
             ostr << PrintContainer{static_cast<AsType>(casted_c->At(row))};
         } else {
@@ -166,6 +167,7 @@ std::ostream & printColumnValue(const ColumnRef& c, const size_t row, std::ostre
     const auto r = false
         || doPrintValue<ColumnString>(c, row, ostr)
         || doPrintValue<ColumnFixedString>(c, row, ostr)
+        || doPrintValue<ColumnJSON>(c, row, ostr)
         || doPrintValue<ColumnUInt8, unsigned int>(c, row, ostr)
         || doPrintValue<ColumnUInt32>(c, row, ostr)
         || doPrintValue<ColumnUInt16>(c, row, ostr)
@@ -377,6 +379,7 @@ std::ostream& operator<<(std::ostream& ostr, const ItemView& item_view) {
             ostr << static_cast<double>(item_view.get<double>());
             break;
         case Type::String:
+        case Type::JSON:
         case Type::FixedString:
             ostr << "\"" << item_view.data << "\" (" << item_view.data.size() << " bytes)";
             break;

--- a/ut/utils_ut.cpp
+++ b/ut/utils_ut.cpp
@@ -235,6 +235,7 @@ TEST(ItemView, OutputToOstream_VALID) {
     // Positive cases: output should be generated
     EXPECTED_SERIALIZATION("String : \"string\" (6 bytes)", ColumnString(), "string");
     EXPECTED_SERIALIZATION("FixedString : \"string\" (6 bytes)", ColumnFixedString(6), "string");
+    EXPECTED_SERIALIZATION("JSON : \"98.6\" (4 bytes)", ColumnJSON(), "98.6");
 
     EXPECTED_SERIALIZATION("Int8 : -123", ColumnInt8(), -123);
     EXPECTED_SERIALIZATION("Int16 : -1234", ColumnInt16(), -1234);

--- a/ut/value_generators.cpp
+++ b/ut/value_generators.cpp
@@ -51,6 +51,40 @@ std::vector<std::string> MakeStrings() {
     };
 }
 
+std::vector<std::string> MakeJSONStrings() {
+    return {
+        "1", "98.6", "true", "false", "null", "\"hello\"",
+        "[1, 98.6, true, false, null, \"hello\"]",
+        "{\"num\": 1, \"got\": true}",
+        "{\"widget\": {  \
+            \"debug\": \"on\", \
+            \"window\": { \
+                \"title\": \"Sample Konfabulator Widget\", \
+                \"name\": \"main_window\", \
+                \"width\": 500, \
+                \"height\": 500 \
+            }, \
+            \"image\": {  \
+                \"src\": \"Images/Sun.png\", \
+                \"name\": \"sun1\", \
+                \"hOffset\": 250, \
+                \"vOffset\": 250, \
+                \"alignment\": \"center\" \
+            }, \
+            \"text\": { \
+                \"data\": \"Click Here\", \
+                \"size\": 36, \
+                \"style\": \"bold\", \
+                \"name\": \"text1\", \
+                \"hOffset\": 250, \
+                \"vOffset\": 100, \
+                \"alignment\": \"center\", \
+                \"onMouseUp\": \"sun1.opacity = (sun1.opacity / 100) * 90;\" \
+            } \
+        }}"
+    };
+}
+
 std::vector<UUID> MakeUUIDs() {
     return {
         UUID(0llu, 0llu),

--- a/ut/value_generators.h
+++ b/ut/value_generators.h
@@ -32,6 +32,7 @@ std::vector<uint32_t> MakeNumbers();
 std::vector<uint8_t> MakeBools();
 std::vector<std::string> MakeFixedStrings(size_t string_size);
 std::vector<std::string> MakeStrings();
+std::vector<std::string> MakeJSONStrings();
 std::vector<clickhouse::Int64> MakeDateTime64s(size_t scale, size_t values_size = 200);
 std::vector<int32_t> MakeDates32();
 std::vector<clickhouse::Int64> MakeDateTimes();


### PR DESCRIPTION
Implemented the same as String, which seems to work fine except for round-tripping. I assume it's not actually a string in the protocol so it will need a different format. But hopefully the rest of the infrastructure for it is helpful.

Not a blocker for my project; JSON works fine for now with the HTTP interface.