### PR TITLE
Allow either *char or Query as BeginInsert arg

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -1220,8 +1220,8 @@ void Client::Insert(const std::string& table_name, const std::string& query_id, 
     impl_->Insert(table_name, query_id, block);
 }
 
-Block Client::BeginInsert(const std::string& query) {
-    return impl_->BeginInsert(Query(query));
+Block Client::BeginInsert(const Query& query) {
+    return impl_->BeginInsert(query);
 }
 
 Block Client::BeginInsert(const std::string& query, const std::string& query_id) {

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -274,7 +274,7 @@ public:
     void Insert(const std::string& table_name, const std::string& query_id, const Block& block);
 
     /// Start an \p INSERT statement, insert batches of data, then finish the insert.
-    Block BeginInsert(const std::string& query);
+    Block BeginInsert(const Query& query);
     Block BeginInsert(const std::string& query, const std::string& query_id);
 
     /// Insert data using a \p block returned by \p BeginInsert.


### PR DESCRIPTION
To allow the user to configure other bits of the query, like settings.