### PR TITLE
Ignore exceptions in ~Client

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -289,8 +289,10 @@ Client::Impl::Impl(const ClientOptions& opts,
 }
 
 Client::Impl::~Impl() {
-    // Wrap up an insert if one is in progress.
-    EndInsert();
+    try {
+        EndInsert();
+    } catch (...) {
+    }
 }
 
 void Client::Impl::ExecuteQuery(Query query) {


### PR DESCRIPTION
`~Client` can throw producing all sorts for problems. To avoid that, we ignore exceptions in the destructor, similar to how it is done in std::fstream.

Addresses https://github.com/ClickHouse/clickhouse-cpp/pull/443#discussion_r2601655461