### PR TITLE
Interactive API for Selecting Data

### DIFF
--- a/clickhouse/block.cpp
+++ b/clickhouse/block.cpp
@@ -115,7 +115,7 @@ void Block::Reserve(size_t new_cap) {
 
 
 
-ColumnRef Block::operator [] (size_t idx) const {
+ColumnRef Block::At(size_t idx) const {
     if (idx < columns_.size()) {
         return columns_[idx].column;
     }

--- a/clickhouse/block.h
+++ b/clickhouse/block.h
@@ -92,7 +92,8 @@ public:
     void Reserve(size_t new_cap);
 
     /// Reference to column by index in the block.
-    ColumnRef operator [] (size_t idx) const;
+    ColumnRef At(size_t idx) const;
+    ColumnRef operator [] (size_t idx) const { return At(idx); }
 
     Iterator begin() const;
     Iterator end() const;

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -8,10 +8,12 @@
 
 #include "columns/factory.h"
 
-#include <assert.h>
-#include <system_error>
-#include <vector>
+#include <cassert>
+#include <optional>
 #include <sstream>
+#include <system_error>
+#include <variant>
+#include <vector>
 
 #if defined(WITH_OPENSSL)
 #include "base/sslsocket.h"
@@ -125,6 +127,48 @@ ClientOptions& ClientOptions::SetSSLOptions(ClientOptions::SSLOptions options)
 
 namespace {
 
+// Compared to std::visit this is a more convenient way to unpack std::variant values. The
+// `VariantIndex` trait allows to get index of the variant by type. This way, the variant can be
+// unpacked using the old and simple `switch` statement. While the standard way of doing do is
+// std::visit, using it is very inconvenient, it's semantics are often unclear and it lead to
+// bizarre and hard to parse errors.
+template <typename T>
+struct VariantIndexTag {};
+template <typename T, typename V>
+struct VariantIndex;
+template <typename T, typename... Ts>
+struct VariantIndex<T, std::variant<Ts...>>
+    : std::integral_constant<size_t, std::variant<VariantIndexTag<Ts>...>{VariantIndexTag<T>{}}.index()>
+{
+};
+
+struct Pong {
+};
+struct Hello {
+};
+struct Log {
+    Block block;
+};
+struct TableColumns {
+};
+struct ProfileEvents {
+    Block block;
+};
+struct EndOfStream {
+};
+using DecodedPacket = std::variant<
+    std::monostate,
+    Block,
+    ServerException,
+    Profile,
+    Progress,
+    Pong,
+    Hello,
+    Log,
+    TableColumns,
+    ProfileEvents,
+    EndOfStream>;
+
 std::unique_ptr<SocketFactory> GetSocketFactory(const ClientOptions& opts) {
     (void)opts;
 #if defined(WITH_OPENSSL)
@@ -144,7 +188,7 @@ std::unique_ptr<EndpointsIteratorBase> GetEndpointsIterator(const ClientOptions&
     return std::make_unique<RoundRobinEndpointsIterator>(opts.endpoints);
 }
 
-}
+} // anonymous namespace
 
 class Client::Impl {
 public:
@@ -154,10 +198,18 @@ public:
     ~Impl();
 
     void ExecuteQuery(Query query);
+    void BeginExecuteQuery(const Query& query, bool finalize = true);
+    
+    // Note, next block returns the block, but also notifies `query.OnData()` if it is set.
+    std::optional<Block> NextBlock();
 
     void SelectWithExternalData(Query query, const ExternalTables& external_tables);
 
     void SendCancel();
+
+    void Cancel();
+
+    bool IsSelecting() const { return state_ == State::Selecting; }
 
     void Insert(const std::string& table_name, const std::string& query_id, const Block& block);
 
@@ -166,6 +218,8 @@ public:
     void SendInsertBlock(const Block& block);
 
     void EndInsert();
+
+    bool IsInserting() const { return state_ == State::Inserting; }
 
     void Ping();
 
@@ -180,7 +234,9 @@ public:
 private:
     bool Handshake();
 
-    bool ReceivePacket(uint64_t* server_packet = nullptr);
+    DecodedPacket ReceivePacket(uint64_t* server_packet = nullptr);
+    bool ProcessPacket(uint64_t* server_packet = nullptr);
+    void ResetState();
 
     void SendQuery(const Query& query, bool finalize = true);
     void FinalizeQuery();
@@ -197,10 +253,10 @@ private:
     bool ReceiveHello();
 
     /// Reads data packet form input stream.
-    bool ReceiveData();
+    bool ReceiveData(Block & block);
 
     /// Reads exception packet form input stream.
-    bool ReceiveException(bool rethrow = false);
+    bool ReceiveException(bool rethrow = false, ServerError * error = nullptr);
 
     void WriteBlock(const Block& block, OutputStream& output);
 
@@ -221,6 +277,12 @@ private:
     void RetryConnectToTheEndpoint(std::function<void()>& func);
 
 private:
+    enum class State : uint8_t {
+        Idle = 0,
+        Selecting = 1,
+        Inserting = 2,
+    };
+
     class EnsureNull {
     public:
         inline EnsureNull(QueryEvents* ev, QueryEvents** ptr)
@@ -244,6 +306,7 @@ private:
 
 
     const ClientOptions options_;
+    Query query_;
     QueryEvents* events_;
     int compression_ = CompressionState::Disable;
 
@@ -258,7 +321,7 @@ private:
 
     ServerInfo server_info_;
 
-    bool inserting_;
+    State state_ = State::Idle;
 };
 
 ClientOptions modifyClientOptions(ClientOptions opts)
@@ -290,50 +353,91 @@ Client::Impl::Impl(const ClientOptions& opts,
 
 Client::Impl::~Impl() {
     try {
-        EndInsert();
+        if (state_ == State::Inserting) {
+            EndInsert();
+        }
     } catch (...) {
     }
 }
 
-void Client::Impl::ExecuteQuery(Query query) {
-    if (inserting_) {
-        throw ValidationError("cannot execute query while inserting");
+void Client::Impl::BeginExecuteQuery(const Query& query, bool finalize) {
+    if (state_ != State::Idle) {
+        throw ValidationError("cannot execute query while executing another operation");
     }
-
-    EnsureNull en(static_cast<QueryEvents*>(&query), &events_);
 
     if (options_.ping_before_query) {
         RetryGuard([this]() { Ping(); });
     }
 
-    SendQuery(query);
+    query_ = query;
+    events_ = static_cast<QueryEvents*>(&query_);
+    state_ = State::Selecting;
 
-    while (ReceivePacket()) {
+    try {
+        SendQuery(query_, finalize);
+    }
+    catch (...) {
+        ResetState();
+        throw;
+    }
+}
+
+std::optional<Block> Client::Impl::NextBlock() {
+    if (state_ != State::Selecting) {
+        throw ValidationError("cannot execute NextBlock while not selecting");
+    }
+
+    try {
+        while (true) {
+            auto packet = ReceivePacket();
+            switch (packet.index()) {
+            case VariantIndex<Block, decltype(packet)>(): {
+                Block & block = std::get<Block>(packet);
+                if (block.GetColumnCount() == 0) {
+                    continue;
+                }
+                return {std::move(block)};
+            }
+            case VariantIndex<ServerError, decltype(packet)>():
+            case VariantIndex<std::monostate, decltype(packet)>():
+            case VariantIndex<EndOfStream, decltype(packet)>():
+                ResetState();
+                return std::nullopt;
+            default:
+                continue;
+            }
+        }
+    }
+    catch (...) {
+        ResetState();
+        throw;
+    }
+}
+
+void Client::Impl::ExecuteQuery(Query query) {
+    BeginExecuteQuery(query);
+    while (NextBlock().has_value()) {
         ;
     }
 }
 
 
 void Client::Impl::SelectWithExternalData(Query query, const ExternalTables& external_tables) {
-    if (inserting_) {
-        throw ValidationError("cannot execute query while inserting");
-    }
-
     if (server_info_.revision < DBMS_MIN_REVISION_WITH_TEMPORARY_TABLES) {
        throw UnimplementedError("This version of ClickHouse server doesn't support temporary tables");
     }
 
-    EnsureNull en(static_cast<QueryEvents*>(&query), &events_);
-
-    if (options_.ping_before_query) {
-        RetryGuard([this]() { Ping(); });
+    BeginExecuteQuery(query, /*finalize=*/ false);
+    try {
+        SendExternalData(external_tables);
+        FinalizeQuery();
+    }
+    catch (...) {
+        ResetState();
+        throw;
     }
 
-    SendQuery(query, false);
-    SendExternalData(external_tables);
-    FinalizeQuery();
-
-    while (ReceivePacket()) {
+    while (NextBlock().has_value()) {
         ;
     }
 }
@@ -382,15 +486,18 @@ std::string NameToQueryString(const std::string &input)
 }
 
 void Client::Impl::Insert(const std::string& table_name, const std::string& query_id, const Block& block) {
-    if (inserting_) {
+    if (state_ == State::Inserting) {
         throw ValidationError("cannot execute query while inserting, use SendInsertData instead");
+    }
+    if (state_ != State::Idle) {
+        throw ValidationError("cannot execute query while executing another operation");
     }
 
     if (options_.ping_before_query) {
         RetryGuard([this]() { Ping(); });
     }
 
-    inserting_ = true;
+    state_ = State::Inserting;
 
     std::stringstream fields_section;
     const auto num_columns = block.GetColumnCount();
@@ -408,7 +515,7 @@ void Client::Impl::Insert(const std::string& table_name, const std::string& quer
 
     // Wait for a data packet and return
     uint64_t server_packet = 0;
-    while (ReceivePacket(&server_packet)) {
+    while (ProcessPacket(&server_packet)) {
         if (server_packet == ServerCodes::Data) {
             SendData(block);
             EndInsert();
@@ -420,8 +527,8 @@ void Client::Impl::Insert(const std::string& table_name, const std::string& quer
 }
 
 Block Client::Impl::BeginInsert(Query query) {
-    if (inserting_) {
-        throw ValidationError("cannot execute query while inserting");
+    if (state_ != State::Idle) {
+        throw ValidationError("cannot execute query while executing another operation");
     }
 
     EnsureNull en(static_cast<QueryEvents*>(&query), &events_);
@@ -430,7 +537,7 @@ Block Client::Impl::BeginInsert(Query query) {
         RetryGuard([this]() { Ping(); });
     }
 
-    inserting_ = true;
+    state_ = State::Inserting;
 
     // Create a callback to extract the block with the proper query columns.
     Block block;
@@ -443,7 +550,7 @@ Block Client::Impl::BeginInsert(Query query) {
 
     // Wait for a data packet and return
     uint64_t server_packet = 0;
-    while (ReceivePacket(&server_packet)) {
+    while (ProcessPacket(&server_packet)) {
         if (server_packet == ServerCodes::Data) {
             return block;
         }
@@ -453,15 +560,15 @@ Block Client::Impl::BeginInsert(Query query) {
 }
 
 void Client::Impl::SendInsertBlock(const Block& block) {
-    if (!inserting_) {
-        throw ValidationError("illegal call to InsertData without first calling BeginInsert");
+    if (state_ != State::Inserting) {
+        throw ValidationError("illegal to send insert data without first calling BeginInsert");
     }
 
     SendData(block);
 }
 
 void Client::Impl::EndInsert() {
-    if (!inserting_) {
+    if (state_ != State::Inserting) {
         return;
     }
 
@@ -470,7 +577,7 @@ void Client::Impl::EndInsert() {
 
     // Wait for EOS.
     uint64_t eos_packet{0};
-    while (ReceivePacket(&eos_packet)) {
+    while (ProcessPacket(&eos_packet)) {
         ;
     }
 
@@ -479,19 +586,19 @@ void Client::Impl::EndInsert() {
         throw ProtocolError(std::string{"unexpected packet from server while receiving end of query, expected (expected Exception, EndOfStream or Log, got: "}
                             + (eos_packet ? std::to_string(eos_packet) : "nothing") + ")");
     }
-    inserting_ = false;
+    state_ = State::Idle;
 }
 
 void Client::Impl::Ping() {
-    if (inserting_) {
-        throw ValidationError("cannot execute query while inserting");
+    if (state_ != State::Idle) {
+        throw ValidationError("cannot execute query while executing another operation");
     }
 
     WireFormat::WriteUInt64(*output_, ClientCodes::Ping);
     output_->Flush();
 
     uint64_t server_packet;
-    const bool ret = ReceivePacket(&server_packet);
+    const bool ret = ProcessPacket(&server_packet);
 
     if (!ret || server_packet != ServerCodes::Pong) {
         throw ProtocolError("fail to ping server");
@@ -500,7 +607,7 @@ void Client::Impl::Ping() {
 
 void Client::Impl::ResetConnection() {
     InitializeStreams(socket_factory_->connect(options_, current_endpoint_.value()));
-    inserting_ = false;
+    state_ = State::Idle;
 
     if (!Handshake()) {
         throw ProtocolError("fail to connect to " + options_.host);
@@ -569,11 +676,11 @@ bool Client::Impl::Handshake() {
     return true;
 }
 
-bool Client::Impl::ReceivePacket(uint64_t* server_packet) {
+DecodedPacket Client::Impl::ReceivePacket(uint64_t* server_packet) {
     uint64_t packet_type = 0;
 
     if (!WireFormat::ReadVarint64(*input_, &packet_type)) {
-        return false;
+        return {};
     }
     if (server_packet) {
         *server_packet = packet_type;
@@ -581,143 +688,166 @@ bool Client::Impl::ReceivePacket(uint64_t* server_packet) {
 
     switch (packet_type) {
     case ServerCodes::Data: {
-        if (!ReceiveData()) {
+        Block ret{};
+        if (!ReceiveData(ret)) {
             throw ProtocolError("can't read data packet from input stream");
         }
-        return true;
+        return ret;
     }
 
     case ServerCodes::Exception: {
-        ReceiveException();
-        return false;
+        ServerError ret{std::make_shared<Exception>()};
+        if (!ReceiveException(false, &ret)) {
+            throw ProtocolError("can't read exception packet from input stream");
+        }
+        return ret;
     }
 
     case ServerCodes::ProfileInfo: {
-        Profile profile;
+        Profile ret{};
 
-        if (!WireFormat::ReadUInt64(*input_, &profile.rows)) {
-            return false;
+        if (!WireFormat::ReadUInt64(*input_, &ret.rows)) {
+            return {};
         }
-        if (!WireFormat::ReadUInt64(*input_, &profile.blocks)) {
-            return false;
+        if (!WireFormat::ReadUInt64(*input_, &ret.blocks)) {
+            return {};
         }
-        if (!WireFormat::ReadUInt64(*input_, &profile.bytes)) {
-            return false;
+        if (!WireFormat::ReadUInt64(*input_, &ret.bytes)) {
+            return {};
         }
-        if (!WireFormat::ReadFixed(*input_, &profile.applied_limit)) {
-            return false;
+        if (!WireFormat::ReadFixed(*input_, &ret.applied_limit)) {
+            return {};
         }
-        if (!WireFormat::ReadUInt64(*input_, &profile.rows_before_limit)) {
-            return false;
+        if (!WireFormat::ReadUInt64(*input_, &ret.rows_before_limit)) {
+            return {};
         }
-        if (!WireFormat::ReadFixed(*input_, &profile.calculated_rows_before_limit)) {
-            return false;
+        if (!WireFormat::ReadFixed(*input_, &ret.calculated_rows_before_limit)) {
+            return {};
         }
 
         if (events_) {
-            events_->OnProfile(profile);
+            events_->OnProfile(ret);
         }
 
-        return true;
+        return ret;
     }
 
     case ServerCodes::Progress: {
-        Progress info;
+        Progress ret{};
 
-        if (!WireFormat::ReadUInt64(*input_, &info.rows)) {
-            return false;
+        if (!WireFormat::ReadUInt64(*input_, &ret.rows)) {
+            return {};
         }
-        if (!WireFormat::ReadUInt64(*input_, &info.bytes)) {
-            return false;
+        if (!WireFormat::ReadUInt64(*input_, &ret.bytes)) {
+            return {};
         }
         if constexpr(DMBS_PROTOCOL_REVISION >= DBMS_MIN_REVISION_WITH_TOTAL_ROWS_IN_PROGRESS) {
-            if (!WireFormat::ReadUInt64(*input_, &info.total_rows)) {
-                return false;
+            if (!WireFormat::ReadUInt64(*input_, &ret.total_rows)) {
+                return {};
             }
         }
         if (server_info_.revision >= DBMS_MIN_REVISION_WITH_CLIENT_WRITE_INFO)
         {
-            if (!WireFormat::ReadUInt64(*input_, &info.written_rows)) {
-                return false;
+            if (!WireFormat::ReadUInt64(*input_, &ret.written_rows)) {
+                return {};
             }
-            if (!WireFormat::ReadUInt64(*input_, &info.written_bytes)) {
-                return false;
+            if (!WireFormat::ReadUInt64(*input_, &ret.written_bytes)) {
+                return {};
             }
         }
 
         if (events_) {
-            events_->OnProgress(info);
+            events_->OnProgress(ret);
         }
 
-        return true;
+        return ret;
     }
 
     case ServerCodes::Pong: {
-        return true;
+        return Pong{};
     }
 
     case ServerCodes::Hello: {
-        return true;
+        return Hello{};
     }
 
     case ServerCodes::EndOfStream: {
         if (events_) {
             events_->OnFinish();
         }
-        return false;
+        return EndOfStream{};
     }
 
     case ServerCodes::Log: {
         // log tag
         if (!WireFormat::SkipString(*input_)) {
-            return false;
+            return {};
         }
-        Block block;
+        Log ret;
 
         // Use uncompressed stream since log blocks usually contain only one row
-        if (!ReadBlock(*input_, &block)) {
-            return false;
+        if (!ReadBlock(*input_, &ret.block)) {
+            return {};
         }
 
         if (events_) {
-            events_->OnServerLog(block);
+            events_->OnServerLog(ret.block);
         }
-        return true;
+        return ret;
     }
 
     case ServerCodes::TableColumns: {
         // external table name
         if (!WireFormat::SkipString(*input_)) {
-            return false;
+            return {};
         }
 
         //  columns metadata
         if (!WireFormat::SkipString(*input_)) {
-            return false;
+            return {};
         }
-        return true;
+        return TableColumns{};
     }
 
     case ServerCodes::ProfileEvents: {
         if (!WireFormat::SkipString(*input_)) {
-            return false;
+            return {};
         }
 
-        Block block;
-        if (!ReadBlock(*input_, &block)) {
-            return false;
+        ProfileEvents ret;
+        if (!ReadBlock(*input_, &ret.block)) {
+            return {};
         }
 
         if (events_) {
-            events_->OnProfileEvents(block);
+            events_->OnProfileEvents(ret.block);
         }
-        return true;
+        return ret;
     }
 
     default:
         throw UnimplementedError("unimplemented " + std::to_string((int)packet_type));
         break;
     }
+}
+
+bool Client::Impl::ProcessPacket(uint64_t* server_packet) {
+    auto packet = ReceivePacket(server_packet);
+    switch (packet.index()) {
+    case VariantIndex<ServerError, decltype(packet)>():
+    case VariantIndex<std::monostate, decltype(packet)>():
+    case VariantIndex<EndOfStream, decltype(packet)>():
+        return false;
+    default:
+        return true;
+    }
+}
+
+void Client::Impl::ResetState()
+{
+    state_ = State::Idle;
+    query_ = {};
+    events_ = nullptr;
 }
 
 bool Client::Impl::ReadBlock(InputStream& input, Block* block) {
@@ -793,8 +923,7 @@ bool Client::Impl::ReadBlock(InputStream& input, Block* block) {
     return true;
 }
 
-bool Client::Impl::ReceiveData() {
-    Block block;
+bool Client::Impl::ReceiveData(Block & block) {
 
     if (server_info_.revision >= DBMS_MIN_REVISION_WITH_TEMPORARY_TABLES) {
         if (!WireFormat::SkipString(*input_)) {
@@ -823,7 +952,7 @@ bool Client::Impl::ReceiveData() {
     return true;
 }
 
-bool Client::Impl::ReceiveException(bool rethrow) {
+bool Client::Impl::ReceiveException(bool rethrow, ServerError * error) {
     std::shared_ptr<Exception> e(new Exception);
     Exception* current = e.get();
 
@@ -868,12 +997,25 @@ bool Client::Impl::ReceiveException(bool rethrow) {
         throw ServerError(e);
     }
 
+    if (exception_received && error != nullptr) {
+        *error = ServerError(e);
+    }
     return exception_received;
 }
 
 void Client::Impl::SendCancel() {
     WireFormat::WriteUInt64(*output_, ClientCodes::Cancel);
     output_->Flush();
+}
+
+void Client::Impl::Cancel() {
+    if (state_ != State::Selecting) {
+        throw ValidationError("cannot cancel while not executing a query");
+    }
+    SendCancel();
+    while (NextBlock().has_value()) {
+        ;
+    }
 }
 
 void Client::Impl::SendQuery(const Query& query, bool finalize) {
@@ -1176,6 +1318,10 @@ void Client::Execute(const Query& query) {
     impl_->ExecuteQuery(query);
 }
 
+void Client::Select(const Query& query) {
+    Execute(query);
+}
+
 void Client::Select(const std::string& query, SelectCallback cb) {
     Execute(Query(query).OnData(std::move(cb)));
 }
@@ -1192,10 +1338,6 @@ void Client::SelectCancelable(const std::string& query, const std::string& query
     Execute(Query(query, query_id).OnDataCancelable(std::move(cb)));
 }
 
-void Client::Select(const Query& query) {
-    Execute(query);
-}
-
 void Client::SelectWithExternalData(const std::string& query, const ExternalTables& external_tables, SelectCallback cb) {
     impl_->SelectWithExternalData(Query(query).OnData(std::move(cb)), external_tables);
 }
@@ -1210,6 +1352,43 @@ void Client::SelectWithExternalDataCancelable(const std::string& query, const Ex
 
 void Client::SelectWithExternalDataCancelable(const std::string& query, const std::string& query_id, const ExternalTables& external_tables, SelectCancelableCallback cb) {
     impl_->SelectWithExternalData(Query(query, query_id).OnDataCancelable(std::move(cb)), external_tables);
+}
+
+void Client::BeginExecute(const Query& query) {
+    impl_->BeginExecuteQuery(query);
+}
+
+void Client::BeginSelect(const Query& query) {
+    impl_->BeginExecuteQuery(query);
+}
+
+void Client::BeginSelect(const char* query)
+{
+    BeginExecute(Query(query));
+}
+
+void Client::BeginSelect(const std::string& query)
+{
+    BeginExecute(Query(query));
+}
+
+void Client::BeginSelect(const std::string& query, const std::string& query_id)
+{
+    BeginExecute(Query(query, query_id));
+}
+
+std::optional<Block> Client::NextBlock() {
+    return impl_->NextBlock();
+}
+
+void Client::Cancel()
+{
+    impl_->Cancel();
+}
+
+bool Client::IsSelecting() const
+{
+    return impl_->IsSelecting();
 }
 
 void Client::Insert(const std::string& table_name, const Block& block) {
@@ -1234,6 +1413,10 @@ void Client::SendInsertBlock(const Block& block) {
 
 void Client::EndInsert() {
     impl_->EndInsert();
+}
+
+bool Client::IsInserting() const {
+    return impl_->IsInserting();
 }
 
 void Client::Ping() {

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -247,6 +247,9 @@ public:
     /// Intends for execute arbitrary queries.
     void Execute(const Query& query);
 
+    /// Alias for Execute.
+    void Select(const Query& query);
+
     /// Intends for execute select queries.  Data will be returned with
     /// one or more call of \p cb.
     void Select(const std::string& query, SelectCallback cb);
@@ -267,8 +270,30 @@ public:
     void SelectWithExternalDataCancelable(const std::string& query, const ExternalTables& external_tables, SelectCancelableCallback cb);
     void SelectWithExternalDataCancelable(const std::string& query, const std::string& query_id, const ExternalTables& external_tables, SelectCancelableCallback cb);
 
-    /// Alias for Execute.
-    void Select(const Query& query);
+    /// EXPERIMENTAL. Intends for execute arbitrary queries while reading the data interactively with
+    /// NextBlock().
+    void BeginExecute(const Query& query);
+
+    /// EXPERIMENTAL. Alias for BeginExecute.
+    void BeginSelect(const Query& query);
+
+    /// EXPERIMENTAL. Interactive version of select, data will be returned on consequent calls
+    /// to NextBlock().
+    void BeginSelect(const char* query);
+    void BeginSelect(const std::string& query);
+    void BeginSelect(const std::string& query, const std::string& query_id);
+
+    /// Returns the next block in the dataset after using BeginSelect family of functions
+    /// functions.
+    std::optional<Block> NextBlock();
+
+    // EXPERIMENTAL. Cancels current execution of BeginSelect and drains all in-flight data.
+    // Consecutive calls to NextBlock() after Cancel() will throw an exception.
+    void Cancel();
+
+    // EXPERIMENTAL. Returns true if the client is still in data-receiving mode and more future
+    // calls to NextBlock().
+    bool IsSelecting() const;
 
     /// Intends for insert block of data into a table \p table_name.
     void Insert(const std::string& table_name, const Block& block);
@@ -283,6 +308,8 @@ public:
 
     /// End an \p INSERT session started by \p BeginInsert.
     void EndInsert();
+
+    bool IsInserting() const;
 
     /// Ping server for aliveness.
     void Ping();

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -229,8 +229,8 @@ private:
     }
 
 private:
-    const std::string query_;
-    const std::string query_id_;
+    std::string query_;
+    std::string query_id_;
     std::optional<open_telemetry::TracingContext> tracing_context_;
     QuerySettings query_settings_;
     QueryParams query_params_;

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1385,6 +1385,190 @@ TEST_P(ClientCase, SelectAggregateFunction) {
 }
 
 
+// ============================================================================
+// Interactive (pull-based) Select API tests
+// ============================================================================
+
+TEST_P(ClientCase, InteractiveSelect_Basic) {
+    client_->Execute("CREATE TEMPORARY TABLE IF NOT EXISTS test_interactive_basic (id UInt64)");
+
+    {
+        Block block;
+        auto id = std::make_shared<ColumnUInt64>();
+        id->Append(1);
+        id->Append(2);
+        id->Append(3);
+        block.AppendColumn("id", id);
+        client_->Insert("test_interactive_basic", block);
+    }
+
+    // Initially not selecting.
+    EXPECT_FALSE(client_->IsSelecting());
+
+    client_->BeginSelect("SELECT id FROM test_interactive_basic ORDER BY id");
+    EXPECT_TRUE(client_->IsSelecting());
+
+    std::vector<uint64_t> values;
+    while (auto block = client_->NextBlock()) {
+        if (block->GetRowCount() == 0) continue;
+        auto col = block->At(0)->AsStrict<ColumnUInt64>();
+        for (size_t i = 0; i < block->GetRowCount(); ++i) {
+            values.push_back(col->At(i));
+        }
+    }
+
+    EXPECT_FALSE(client_->IsSelecting());
+    ASSERT_EQ(3u, values.size());
+    EXPECT_EQ(1u, values[0]);
+    EXPECT_EQ(2u, values[1]);
+    EXPECT_EQ(3u, values[2]);
+
+    // Client is reusable after drain.
+    client_->BeginSelect("SELECT CAST(42, 'UInt64') AS val");
+    {
+        uint64_t val = 0;
+        size_t rows = 0;
+        while (auto b = client_->NextBlock()) {
+            for (size_t i = 0; i < b->GetRowCount(); ++i) {
+                val = b->At(0)->AsStrict<ColumnUInt64>()->At(i);
+                rows++;
+            }
+        }
+        EXPECT_EQ(1u, rows);
+        EXPECT_EQ(42u, val);
+    }
+    EXPECT_FALSE(client_->IsSelecting());
+}
+
+TEST_P(ClientCase, InteractiveSelect_MultipleBlocks) {
+    Query query("SELECT number FROM system.numbers LIMIT 10");
+    query.SetSetting("max_block_size", {"2"});
+
+    client_->BeginSelect(query);
+
+    size_t block_count = 0;
+    std::vector<uint64_t> values;
+    while (auto block = client_->NextBlock()) {
+        if (block->GetRowCount() == 0) continue;
+        EXPECT_LE(block->GetRowCount(), 2u);
+        block_count++;
+        auto col = block->At(0)->AsStrict<ColumnUInt64>();
+        for (size_t i = 0; i < block->GetRowCount(); ++i) {
+            values.push_back(col->At(i));
+        }
+    }
+
+    EXPECT_EQ(10u, values.size());
+    EXPECT_GE(block_count, 2u);
+    for (size_t i = 0; i < values.size(); ++i) {
+        EXPECT_EQ(i, values[i]);
+    }
+}
+
+TEST_P(ClientCase, InteractiveSelect_Cancel) {
+    // Cancel mid-stream on a large result set with small blocks to ensure
+    // we don't receive all data in a single block.
+    Query query("SELECT number FROM system.numbers LIMIT 100000");
+    query.SetSetting("max_block_size", {"100"});
+
+    client_->BeginSelect(query);
+    // Consume one block of data, skipping any blocks with 0 rows.
+    size_t rows_before_cancel = 0;
+    while (auto b = client_->NextBlock()) {
+        if (b->GetRowCount() == 0) continue;
+        rows_before_cancel = b->GetRowCount();
+        break;
+    }
+    ASSERT_GT(rows_before_cancel, 0u);
+    ASSERT_LT(rows_before_cancel, 100000u);
+    EXPECT_TRUE(client_->IsSelecting());
+
+    EXPECT_NO_THROW(client_->Cancel());
+    EXPECT_FALSE(client_->IsSelecting());
+
+    // Client is reusable after cancel.
+    client_->BeginSelect("SELECT 99 AS val");
+    {
+        size_t rows = 0;
+        while (auto b = client_->NextBlock()) {
+            for (size_t i = 0; i < b->GetRowCount(); ++i) {
+                EXPECT_EQ(99u, b->At(0)->AsStrict<ColumnUInt8>()->At(i));
+                rows++;
+            }
+        }
+        EXPECT_EQ(1u, rows);
+    }
+
+}
+
+TEST_P(ClientCase, InteractiveSelect_StateErrors) {
+    // NextBlock while idle.
+    EXPECT_THROW(client_->NextBlock(), ValidationError);
+
+    // Cancel while idle.
+    EXPECT_THROW(client_->Cancel(), ValidationError);
+
+    // Double BeginSelect.
+    client_->BeginSelect("SELECT 1");
+    EXPECT_THROW(client_->BeginSelect("SELECT 2"), ValidationError);
+    client_->Cancel();
+
+    // Server error (non-existent table) resets state back to Idle.
+    client_->BeginSelect("SELECT * FROM non_existent_table_xyz_clickhouse_cpp_test");
+    EXPECT_THROW(client_->NextBlock(), ServerException);
+    EXPECT_FALSE(client_->IsSelecting());
+
+    // Client is usable after server error.
+    client_->BeginSelect("SELECT 1 AS val");
+    {
+        size_t rows = 0;
+        while (auto b = client_->NextBlock()) {
+            for (size_t i = 0; i < b->GetRowCount(); ++i) {
+                EXPECT_EQ(1u, b->At(0)->AsStrict<ColumnUInt8>()->At(i));
+                rows++;
+            }
+        }
+        EXPECT_EQ(1u, rows);
+    }
+}
+
+TEST_P(ClientCase, InteractiveSelect_WithCallbacks) {
+    client_->Execute("CREATE TEMPORARY TABLE IF NOT EXISTS test_interactive_cb (id UInt64)");
+
+    {
+        Block block;
+        auto id = std::make_shared<ColumnUInt64>();
+        for (uint64_t i = 0; i < 100; ++i) {
+            id->Append(i);
+        }
+        block.AppendColumn("id", id);
+        client_->Insert("test_interactive_cb", block);
+    }
+
+    size_t callback_rows = 0;
+    bool progress_received = false;
+
+    Query query("SELECT id FROM test_interactive_cb");
+    query.OnData([&](const Block& block) {
+        callback_rows += block.GetRowCount();
+    });
+    query.OnProgress([&](const Progress&) {
+        progress_received = true;
+    });
+
+    client_->BeginSelect(query);
+
+    size_t nextblock_rows = 0;
+    while (auto block = client_->NextBlock()) {
+        nextblock_rows += block->GetRowCount();
+    }
+
+    EXPECT_EQ(100u, nextblock_rows);
+    // OnData fires for non-empty blocks too — both methods see the data.
+    EXPECT_GT(callback_rows, 0u);
+    EXPECT_TRUE(progress_received);
+}
+
 const auto LocalHostEndpoint = ClientOptions()
         .SetHost(           getEnvOrDefault("CLICKHOUSE_HOST",     "localhost"))
         .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_PORT",     "9000"))


### PR DESCRIPTION

Previously, SELECT results could only be consumed via a callback (`Query::OnData`). This commit adds an interactive (pull-based) alternative, where the caller drives the loop using the `NextBlock()` function.

```cpp
client.BeginSelect("SELECT ...");
while (auto block = client.NextBlock()) {
    // process block
}
```

As before, the interactive API allows passing a Query object with callbacks. In this case, the callbacks will be invoked as data arrives. Be aware that if you set up a callback while using the interactive API, you will receive the same data twice: once via the callback and once as the result of the `NextBlock()` call.

> [!IMPORTANT]
> This is an experimental API and is subject to change.

New functions:

- `BeginExecute(const Query&)` - Starts executing a `SELECT` query without blocking until all results arrive. It sends the query to the server and returns immediately. Data can then be retrieved by calling `NextBlock()`.
- `NextBlock()` - Returns the next block of results as `std::optional<clickhouse::Block>`. It returns `std::nullopt` when the query is finished. This allows callers to pull data one block at a time in a loop.
- `Cancel()` - Cancels the current query, sends a cancel message to the server, and drains all in-flight data.
- `IsSelecting()` - Returns `true` if the client is still in data-receiving mode and more future calls to NextBlock().

Additionally, there are convenience functions built on top of `BeginExecute`:
- `BeginSelect(const Query&)`
- `void BeginSelect(const char* query)`
- `BeginSelect(const std::string& query)`
- `BeginSelect(const std::string& query, const std::string& query_id)`

A little example:

```cpp
size_t total_rows = 0;

// Use one of BeginSelect function overloads to query data in the interactive mode.
client.BeginSelect("SELECT read_rows, query FROM system.query_log");

// Keep calling NextBlock until it returns std::nullopt
while (auto block = client.NextBlock()) {
    auto col = block->At(0)->AsStrict<clickhouse::ColumnUInt64>();
    for (size_t i = 0; i < block->GetRowCount(); ++i) {
        total_rows += col->At(i);
    }
    if (total_rows > 1000) {
        // Call Cancel when you do not need the rest of the data.
        client.Cancel();
        // Do not forget to exit the loop after calling Cancel(). The client no longer excepts
        // any data after the Cancel call and the consecutive call to NextBlock will throw an
        // exception.
        break;
    }
}
```