### PR TITLE
Add Tuple field names and Bool Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,3 +278,6 @@ BUCKAROO_DEPS
 # Vim
 *.swp
 *.swo
+
+# clangd cache
+/.cache/clangd

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ C++ client for [ClickHouse](https://clickhouse.com/).
 ## Supported data types
 
 * Array(T)
+* Bool
 * Date
 * DateTime, DateTime64
 * DateTime([timezone]), DateTime64(N, [timezone])
@@ -256,5 +257,3 @@ client.Insert("default.test", block);
 ```sql
 ALTER USER insert_account SETTINGS async_insert=1,wait_for_async_insert=1,async_insert_use_adaptive_busy_timeout=0,async_insert_busy_timeout_ms=5000,async_insert_max_data_size=104857600
 ```
-
-

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -162,16 +162,26 @@ static ColumnRef CreateColumnFromAst(const TypeAst& ast, CreateColumnByTypeSetti
 
         case TypeAst::Tuple: {
             std::vector<ColumnRef> columns;
+            std::vector<std::string> names;
 
             columns.reserve(ast.elements.size());
+            names.reserve(ast.elements.size());
+            bool any_named = false;
             for (const auto& elem : ast.elements) {
                 if (auto col = CreateColumnFromAst(elem, settings)) {
                     columns.push_back(col);
+                    names.push_back(elem.element_name);
+                    if (!elem.element_name.empty()) {
+                        any_named = true;
+                    }
                 } else {
                     return nullptr;
                 }
             }
 
+            if (any_named) {
+                return std::make_shared<ColumnTuple>(columns, std::move(names));
+            }
             return std::make_shared<ColumnTuple>(columns);
         }
 

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -49,6 +49,8 @@ static ColumnRef CreateTerminalColumn(const TypeAst& ast) {
     case Type::Void:
         return std::make_shared<ColumnNothing>();
 
+    case Type::Bool:
+        return std::make_shared<ColumnBool>();
     case Type::UInt8:
         return std::make_shared<ColumnUInt8>();
     case Type::UInt16:

--- a/clickhouse/columns/itemview.cpp
+++ b/clickhouse/columns/itemview.cpp
@@ -44,6 +44,7 @@ void ItemView::ValidateData(Type::Code type, DataType data) {
         case Type::Code::Int8:
         case Type::Code::UInt8:
         case Type::Code::Enum8:
+        case Type::Code::Bool:
             return AssertSize({1});
 
         case Type::Code::Int16:

--- a/clickhouse/columns/itemview.h
+++ b/clickhouse/columns/itemview.h
@@ -28,7 +28,10 @@ private:
     inline auto ConvertToStorageValue(const T& t) {
         if constexpr (std::is_same_v<std::string_view, T> || std::is_same_v<std::string, T>) {
             return std::string_view{t};
-        } else if constexpr (std::is_fundamental_v<T> || std::is_same_v<Int128, std::decay_t<T>> || std::is_same_v<UInt128, std::decay_t<T>>) {
+        } else if constexpr (std::is_fundamental_v<T>
+                          || std::is_same_v<Bool, std::decay_t<T>>
+                          || std::is_same_v<Int128, std::decay_t<T>>
+                          || std::is_same_v<UInt128, std::decay_t<T>>) {
             return std::string_view{reinterpret_cast<const char*>(&t), sizeof(T)};
         } else {
             static_assert(!std::is_same_v<T, T>, "Unknown type, which can't be stored in ItemView");
@@ -65,7 +68,10 @@ public:
         using ValueType = std::remove_cv_t<std::decay_t<T>>;
         if constexpr (std::is_same_v<std::string_view, ValueType> || std::is_same_v<std::string, ValueType>) {
             return data;
-        } else if constexpr (std::is_fundamental_v<ValueType> || std::is_same_v<Int128, ValueType> || std::is_same_v<UInt128, ValueType>) {
+        } else if constexpr (std::is_fundamental_v<ValueType>
+                          || std::is_same_v<Bool, ValueType>
+                          || std::is_same_v<Int128, ValueType>
+                          || std::is_same_v<UInt128, ValueType>) {
             if (sizeof(ValueType) == data.size()) {
                 return *reinterpret_cast<const T*>(data.data());
             } else {

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -113,6 +113,7 @@ template class ColumnVector<int16_t>;
 template class ColumnVector<int32_t>;
 template class ColumnVector<int64_t>;
 
+template class ColumnVector<Bool>;
 template class ColumnVector<uint8_t>;
 template class ColumnVector<uint16_t>;
 template class ColumnVector<uint32_t>;

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -70,6 +70,7 @@ using Int128 = absl::int128;
 using UInt128 = absl::uint128;
 using Int64 = int64_t;
 
+using ColumnBool    = ColumnVector<Bool>;
 using ColumnUInt8   = ColumnVector<uint8_t>;
 using ColumnUInt16  = ColumnVector<uint16_t>;
 using ColumnUInt32  = ColumnVector<uint32_t>;

--- a/clickhouse/columns/tuple.cpp
+++ b/clickhouse/columns/tuple.cpp
@@ -16,6 +16,13 @@ ColumnTuple::ColumnTuple(const std::vector<ColumnRef>& columns)
 {
 }
 
+ColumnTuple::ColumnTuple(const std::vector<ColumnRef>& columns,
+                         std::vector<std::string> names)
+    : Column(Type::CreateTuple(CollectTypes(columns), std::move(names)))
+    , columns_(columns)
+{
+}
+
 size_t ColumnTuple::TupleSize() const {
     return columns_.size();
 }
@@ -48,7 +55,11 @@ ColumnRef ColumnTuple::Slice(size_t begin, size_t len) const {
         sliced_columns.push_back(column->Slice(begin, len));
     }
 
-    return std::make_shared<ColumnTuple>(sliced_columns);
+    const auto& names = this->Type()->As<TupleType>()->GetItemNames();
+    if (names.empty()) {
+        return std::make_shared<ColumnTuple>(sliced_columns);
+    }
+    return std::make_shared<ColumnTuple>(sliced_columns, names);
 }
 
 ColumnRef ColumnTuple::CloneEmpty() const {
@@ -59,7 +70,11 @@ ColumnRef ColumnTuple::CloneEmpty() const {
         result_columns.push_back(column->CloneEmpty());
     }
 
-    return std::make_shared<ColumnTuple>(result_columns);
+    const auto& names = this->Type()->As<TupleType>()->GetItemNames();
+    if (names.empty()) {
+        return std::make_shared<ColumnTuple>(result_columns);
+    }
+    return std::make_shared<ColumnTuple>(result_columns, names);
 }
 
 bool ColumnTuple::LoadPrefix(InputStream* input, size_t rows) {

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -13,6 +13,8 @@ namespace clickhouse {
 class ColumnTuple : public Column {
 public:
     ColumnTuple(const std::vector<ColumnRef>& columns);
+    ColumnTuple(const std::vector<ColumnRef>& columns,
+                std::vector<std::string> names);
 
     /// Returns count of columns in the tuple.
     size_t TupleSize() const;

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -22,7 +22,9 @@ bool TypeAst::operator==(const TypeAst & other) const {
     return meta == other.meta
         && code == other.code
         && name == other.name
+        && element_name == other.element_name
         && value == other.value
+        && value_string == other.value_string
         && std::equal(elements.begin(), elements.end(), other.elements.begin(), other.elements.end());
 }
 
@@ -167,6 +169,12 @@ bool TypeParser::Parse(TypeAst* type) {
                 break;
             }
             case Token::Name:
+                if (!type_->name.empty()) {
+                    // A second Name token on the same element means the
+                    // previous one was a field name in a named-tuple element
+                    // (e.g. "a" in "Tuple(a Int32, …)").
+                    type_->element_name = std::move(type_->name);
+                }
                 type_->meta = GetTypeMeta(token.value);
                 type_->name = token.value.to_string();
                 type_->code = GetTypeCode(type_->name);

--- a/clickhouse/types/type_parser.cpp
+++ b/clickhouse/types/type_parser.cpp
@@ -34,7 +34,7 @@ static const std::unordered_map<std::string, Type::Code> kTypeCode = {
     { "Int16",       Type::Int16 },
     { "Int32",       Type::Int32 },
     { "Int64",       Type::Int64 },
-    { "Bool",        Type::UInt8 },
+    { "Bool",        Type::Bool },
     { "UInt8",       Type::UInt8 },
     { "UInt16",      Type::UInt16 },
     { "UInt32",      Type::UInt32 },

--- a/clickhouse/types/type_parser.h
+++ b/clickhouse/types/type_parser.h
@@ -31,6 +31,9 @@ struct TypeAst {
     /// Type's name.
     /// Need to cache TypeAst, so can't use StringView for name.
     std::string name;
+    /// Name of this element inside its parent (e.g. field name inside a named
+    /// Tuple). Empty for unnamed elements.
+    std::string element_name;
     /// Value associated with the node,
     /// used for fixed-width types and enum values.
     int64_t value = 0;

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -243,6 +243,11 @@ TypeRef Type::CreateTuple(const std::vector<TypeRef>& item_types) {
     return TypeRef(new TupleType(item_types));
 }
 
+TypeRef Type::CreateTuple(const std::vector<TypeRef>& item_types,
+                          std::vector<std::string> item_names) {
+    return TypeRef(new TupleType(item_types, std::move(item_names)));
+}
+
 TypeRef Type::CreateEnum8(const std::vector<EnumItem>& enum_items) {
     return TypeRef(new EnumType(Type::Enum8, enum_items));
 }
@@ -447,6 +452,11 @@ NullableType::NullableType(TypeRef nested_type) : Type(Nullable), nested_type_(n
 TupleType::TupleType(const std::vector<TypeRef>& item_types) : Type(Tuple), item_types_(item_types) {
 }
 
+TupleType::TupleType(const std::vector<TypeRef>& item_types,
+                     std::vector<std::string> item_names)
+    : Type(Tuple), item_types_(item_types), item_names_(std::move(item_names)) {
+}
+
 /// class LowCardinalityType
 LowCardinalityType::LowCardinalityType(TypeRef nested_type) : Type(LowCardinality), nested_type_(nested_type) {
 }
@@ -456,13 +466,30 @@ LowCardinalityType::~LowCardinalityType() {
 
 std::string TupleType::GetName() const {
     std::string result("Tuple(");
+    bool has_complete_names = item_names_.size() == item_types_.size();
+    if (has_complete_names) {
+        for (const auto& item_name : item_names_) {
+            if (item_name.empty()) {
+                has_complete_names = false;
+                break;
+            }
+        }
+    }
 
     if (!item_types_.empty()) {
-        result += item_types_[0]->GetName();
+        if (has_complete_names) {
+            result += item_names_[0] + " " + item_types_[0]->GetName();
+        } else {
+            result += item_types_[0]->GetName();
+        }
     }
 
     for (size_t i = 1; i < item_types_.size(); ++i) {
-        result += ", " + item_types_[i]->GetName();
+        if (has_complete_names) {
+            result += ", " + item_names_[i] + " " + item_types_[i]->GetName();
+        } else {
+            result += ", " + item_types_[i]->GetName();
+        }
     }
 
     result += ")";

--- a/clickhouse/types/types.cpp
+++ b/clickhouse/types/types.cpp
@@ -54,6 +54,7 @@ const char* Type::TypeName(Type::Code code) {
         case Type::Code::MultiPolygon:   return "MultiPolygon";
         case Type::Code::Time:           return "Time";
         case Type::Code::Time64:         return "Time64";
+        case Type::Code::Bool:           return "Bool";
     }
 
     return "Unknown type";
@@ -85,6 +86,7 @@ std::string Type::GetName() const {
         case Ring:
         case Polygon:
         case MultiPolygon:
+        case Bool:
             return TypeName(code_);
         case Time64:
             return As<Time64Type>()->GetName();
@@ -146,6 +148,7 @@ uint64_t Type::GetTypeUniqueId() const {
         case Ring:
         case Polygon:
         case MultiPolygon:
+        case Bool:
             // For simple types, unique ID is the same as Type::Code
             return code_;
 

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -126,6 +126,9 @@ public:
 
     static TypeRef CreateTuple(const std::vector<TypeRef>& item_types);
 
+    static TypeRef CreateTuple(const std::vector<TypeRef>& item_types,
+                               std::vector<std::string> item_names);
+
     static TypeRef CreateEnum8(const std::vector<EnumItem>& enum_items);
 
     static TypeRef CreateEnum16(const std::vector<EnumItem>& enum_items);
@@ -293,14 +296,21 @@ private:
 class TupleType : public Type {
 public:
     explicit TupleType(const std::vector<TypeRef>& item_types);
+    TupleType(const std::vector<TypeRef>& item_types,
+              std::vector<std::string> item_names);
 
     std::string GetName() const;
 
     /// Type of nested Tuple element type.
     std::vector<TypeRef> GetTupleType() const { return item_types_; }
 
+    /// Field names for named tuples. Same length as GetTupleType() when
+    /// populated, or empty when the tuple has no field names.
+    const std::vector<std::string>& GetItemNames() const { return item_names_; }
+
 private:
     std::vector<TypeRef> item_types_;
+    std::vector<std::string> item_names_;
 };
 
 class LowCardinalityType : public Type {

--- a/clickhouse/types/types.h
+++ b/clickhouse/types/types.h
@@ -15,6 +15,14 @@ using Int128 = absl::int128;
 using UInt128 = absl::uint128;
 using Int64 = int64_t;
 
+/// Distinct type for the ClickHouse Bool type. Backed by `bool` so it has the
+/// same single-byte layout as `uint8_t` without std::vector<bool>'s
+/// bit-packing, while remaining a type distinct from all integer types.
+enum Bool : bool {
+    false_ = false,
+    true_ = true,
+};
+
 using TypeRef = std::shared_ptr<class Type>;
 
 class Type {
@@ -59,6 +67,7 @@ public:
         MultiPolygon,
         Time,
         Time64,
+        Bool,
     };
 
     using EnumItem = std::pair<std::string /* name */, int16_t /* value */>;
@@ -392,6 +401,11 @@ inline TypeRef Type::CreateSimple<uint32_t>() {
 template <>
 inline TypeRef Type::CreateSimple<uint64_t>() {
     return TypeRef(new Type(UInt64));
+}
+
+template <>
+inline TypeRef Type::CreateSimple<Bool>() {
+    return TypeRef(new Type(Bool));
 }
 
 template <>

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -62,7 +62,8 @@ class CreateColumnByTypeWithName : public ::testing::TestWithParam<const char* /
 TEST(CreateColumnByType, Bool) {
     const auto col = CreateColumnByType("Bool");
     ASSERT_NE(nullptr, col);
-    EXPECT_EQ(col->GetType().GetName(), "UInt8");
+    EXPECT_EQ(col->GetType().GetName(), "Bool");
+    EXPECT_NE(nullptr, col->As<ColumnBool>());
 }
 
 TEST_P(CreateColumnByTypeWithName, CreateColumnByType)
@@ -75,6 +76,7 @@ TEST_P(CreateColumnByTypeWithName, CreateColumnByType)
 INSTANTIATE_TEST_SUITE_P(Basic, CreateColumnByTypeWithName, ::testing::Values(
     "Int8", "Int16", "Int32", "Int64",
     "UInt8", "UInt16", "UInt32", "UInt64",
+    "Bool",
     "String", "Date", "DateTime",
     "UUID", "Int128", "UInt128"
 ));

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -400,11 +400,11 @@ TEST_P(ClientCase, Generic) {
 
         auto id = std::make_shared<ColumnUInt64>();
         auto name = std::make_shared<ColumnString>();
-        auto f = std::make_shared<ColumnUInt8> ();
+        auto f = std::make_shared<ColumnBool>();
         for (auto const& td : TEST_DATA) {
             id->Append(td.id);
             name->Append(td.name);
-            f->Append(td.f);
+            f->Append(static_cast<Bool>(td.f));
         }
 
         block.AppendColumn("id"  , id);
@@ -426,7 +426,7 @@ TEST_P(ClientCase, Generic) {
             for (size_t c = 0; c < block.GetRowCount(); ++c, ++row) {
                 EXPECT_EQ(TEST_DATA[row].id, (*block[0]->As<ColumnUInt64>())[c]);
                 EXPECT_EQ(TEST_DATA[row].name, (*block[1]->As<ColumnString>())[c]);
-                EXPECT_EQ(TEST_DATA[row].f, (*block[2]->As<ColumnUInt8>())[c]);
+                EXPECT_EQ(static_cast<Bool>(TEST_DATA[row].f), (*block[2]->As<ColumnBool>())[c]);
             }
         }
     );
@@ -468,13 +468,13 @@ TEST_P(ClientCase, InsertData) {
         // Fetch the derived columns.
         auto id = block[0]->As<ColumnUInt64>();
         auto name = block[1]->As<ColumnString>();
-        auto f = block[2]->As<ColumnUInt8>();
+        auto f = block[2]->As<ColumnBool>();
 
         // Insert some values.
         for (auto const& td : TEST_DATA) {
             id->Append(td.id);
             name->Append(td.name);
-            f->Append(td.f);
+            f->Append(static_cast<Bool>(td.f));
         }
         block.RefreshRowCount();
         client_->SendInsertBlock(block);
@@ -484,7 +484,7 @@ TEST_P(ClientCase, InsertData) {
         for (auto const& td : TEST_DATA2) {
             id->Append(td.id);
             name->Append(td.name);
-            f->Append(td.f);
+            f->Append(static_cast<Bool>(td.f));
         }
         block.RefreshRowCount();
         client_->SendInsertBlock(block);
@@ -509,13 +509,13 @@ TEST_P(ClientCase, InsertData) {
                 for (size_t c = 0; c < block.GetRowCount(); ++c, ++row) {
                     EXPECT_EQ(TEST_DATA[row].id, (*block[0]->As<ColumnUInt64>())[c]);
                     EXPECT_EQ(TEST_DATA[row].name, (*block[1]->As<ColumnString>())[c]);
-                    EXPECT_EQ(TEST_DATA[row].f, (*block[2]->As<ColumnUInt8>())[c]);
+                    EXPECT_EQ(static_cast<Bool>(TEST_DATA[row].f), (*block[2]->As<ColumnBool>())[c]);
                 }
             } else {
                 for (size_t c = 0; c < block.GetRowCount(); ++c, ++row) {
                     EXPECT_EQ(TEST_DATA2[row-block_two_row_num].id, (*block[0]->As<ColumnUInt64>())[c]);
                     EXPECT_EQ(TEST_DATA2[row-block_two_row_num].name, (*block[1]->As<ColumnString>())[c]);
-                    EXPECT_EQ(TEST_DATA2[row-block_two_row_num].f, (*block[2]->As<ColumnUInt8>())[c]);
+                    EXPECT_EQ(static_cast<Bool>(TEST_DATA2[row-block_two_row_num].f), (*block[2]->As<ColumnBool>())[c]);
                 }
             }
         }

--- a/ut/type_parser_ut.cpp
+++ b/ut/type_parser_ut.cpp
@@ -89,8 +89,26 @@ TEST(TypeParserCase, ParseTuple) {
     auto element = ast.elements.begin();
     for (size_t i = 0; i < 2; ++i) {
         ASSERT_EQ(element->name, names[i]);
+        ASSERT_TRUE(element->element_name.empty());
         ++element;
     }
+}
+
+TEST(TypeParserCase, ParseNamedTuple) {
+    TypeAst ast;
+    TypeParser("Tuple(a UInt8, b String)").Parse(&ast);
+    ASSERT_EQ(ast.meta, TypeAst::Tuple);
+    ASSERT_EQ(ast.name, "Tuple");
+    ASSERT_EQ(ast.code, Type::Tuple);
+    ASSERT_EQ(ast.elements.size(), 2u);
+
+    ASSERT_EQ(ast.elements[0].element_name, "a");
+    ASSERT_EQ(ast.elements[0].name, "UInt8");
+    ASSERT_EQ(ast.elements[0].code, Type::UInt8);
+
+    ASSERT_EQ(ast.elements[1].element_name, "b");
+    ASSERT_EQ(ast.elements[1].name, "String");
+    ASSERT_EQ(ast.elements[1].code, Type::String);
 }
 
 TEST(TypeParserCase, ParseDecimal) {
@@ -167,6 +185,20 @@ TEST(TypeParserCase, ParseDateTime_MINSK_TIMEZONE) {
     ASSERT_EQ(ast.elements[0].meta, TypeAst::Terminal);
 }
 
+TEST(TypeParserCase, EqualityIncludesValueString) {
+    TypeAst utc;
+    TypeAst minsk;
+    ASSERT_TRUE(TypeParser("DateTime('UTC')").Parse(&utc));
+    ASSERT_TRUE(TypeParser("DateTime('Europe/Minsk')").Parse(&minsk));
+    ASSERT_NE(utc, minsk);
+
+    TypeAst enum_one;
+    TypeAst enum_two;
+    ASSERT_TRUE(TypeParser("Enum8('ONE' = 1)").Parse(&enum_one));
+    ASSERT_TRUE(TypeParser("Enum8('TWO' = 1)").Parse(&enum_two));
+    ASSERT_NE(enum_one, enum_two);
+}
+
 TEST(TypeParserCase, LowCardinality_String) {
     TypeAst ast;
     ASSERT_TRUE(TypeParser("LowCardinality(String)").Parse(&ast));
@@ -194,7 +226,7 @@ TEST(TypeParserCase, LowCardinality_FixedString) {
     ASSERT_EQ(ast.elements[0].name, "FixedString");
     ASSERT_EQ(ast.elements[0].value, 0);
     ASSERT_EQ(ast.elements[0].elements.size(), 1u);
-    auto param = TypeAst{TypeAst::Number, Type::Void, "", 10, {}, {}};
+    auto param = TypeAst{TypeAst::Number, Type::Void, "", "", 10, {}, {}};
     ASSERT_EQ(ast.elements[0].elements[0], param);
 }
 

--- a/ut/types_ut.cpp
+++ b/ut/types_ut.cpp
@@ -1,5 +1,6 @@
 #include <clickhouse/types/types.h>
 #include <clickhouse/columns/factory.h>
+#include <clickhouse/columns/numeric.h>
 #include <ut/utils.h>
 
 #include <gtest/gtest.h>
@@ -34,6 +35,22 @@ TEST(TypesCase, TypeName) {
     );
 
     ASSERT_EQ(Type::CreateMap(Type::CreateSimple<int32_t>(), Type::CreateString())->GetName(), "Map(Int32, String)");
+
+    ASSERT_EQ(Type::CreateSimple<Bool>()->GetName(), "Bool");
+}
+
+TEST(TypesCase, ColumnBool) {
+    auto col = std::make_shared<ColumnBool>();
+    col->Append(true_);
+    col->Append(false_);
+    col->Append(true_);
+
+    ASSERT_EQ(col->Size(), 3u);
+    ASSERT_EQ(col->At(0), true_);
+    ASSERT_EQ(col->At(1), false_);
+    ASSERT_EQ(col->At(2), true_);
+    ASSERT_EQ(col->GetType().GetName(), "Bool");
+    ASSERT_EQ(col->GetType().GetCode(), Type::Bool);
 }
 
 TEST(TypesCase, NullableType) {

--- a/ut/types_ut.cpp
+++ b/ut/types_ut.cpp
@@ -41,6 +41,66 @@ TEST(TypesCase, NullableType) {
     ASSERT_EQ(Type::CreateNullable(nested)->As<NullableType>()->GetNestedType(), nested);
 }
 
+TEST(TypesCase, TupleTypeItemNames) {
+    auto unnamed = Type::CreateTuple({
+        Type::CreateSimple<int32_t>(),
+        Type::CreateString()});
+    ASSERT_TRUE(unnamed->As<TupleType>()->GetItemNames().empty());
+
+    auto named = Type::CreateTuple(
+        {Type::CreateSimple<int32_t>(), Type::CreateString()},
+        {"a", "b"});
+    const auto& names = named->As<TupleType>()->GetItemNames();
+    ASSERT_EQ(names.size(), 2u);
+    ASSERT_EQ(names[0], "a");
+    ASSERT_EQ(names[1], "b");
+}
+
+TEST(TypesCase, TupleTypeNameIncludesFieldNames) {
+    auto named = Type::CreateTuple(
+        {Type::CreateSimple<uint8_t>(), Type::CreateString()},
+        {"a", "b"});
+    ASSERT_EQ(named->GetName(), "Tuple(a UInt8, b String)");
+
+    auto partially_named = Type::CreateTuple(
+        {Type::CreateSimple<uint8_t>(), Type::CreateString()},
+        {"a", ""});
+    ASSERT_EQ(partially_named->GetName(), "Tuple(UInt8, String)");
+
+    auto mismatched_names = Type::CreateTuple(
+        {Type::CreateSimple<uint8_t>(), Type::CreateString()},
+        {"a"});
+    ASSERT_EQ(mismatched_names->GetName(), "Tuple(UInt8, String)");
+}
+
+TEST(TypesCase, TupleTypeNamesFromFactory) {
+    auto col = CreateColumnByType("Tuple(a UInt8, b String)");
+    ASSERT_NE(col, nullptr);
+    const auto& names = col->Type()->As<TupleType>()->GetItemNames();
+    ASSERT_EQ(names.size(), 2u);
+    ASSERT_EQ(names[0], "a");
+    ASSERT_EQ(names[1], "b");
+
+    auto col_unnamed = CreateColumnByType("Tuple(UInt8, String)");
+    ASSERT_NE(col_unnamed, nullptr);
+    ASSERT_TRUE(col_unnamed->Type()->As<TupleType>()->GetItemNames().empty());
+}
+
+TEST(TypesCase, TupleTypeEqualityIncludesFieldNames) {
+    auto unnamed = Type::CreateTuple(
+        {Type::CreateSimple<uint8_t>(), Type::CreateString()});
+    auto named_ab = Type::CreateTuple(
+        {Type::CreateSimple<uint8_t>(), Type::CreateString()},
+        {"a", "b"});
+    auto named_xy = Type::CreateTuple(
+        {Type::CreateSimple<uint8_t>(), Type::CreateString()},
+        {"x", "y"});
+
+    ASSERT_TRUE(named_ab->IsEqual(named_ab));
+    ASSERT_FALSE(named_ab->IsEqual(unnamed));
+    ASSERT_FALSE(named_ab->IsEqual(named_xy));
+}
+
 TEST(TypesCase, EnumTypes) {
     auto enum8 = Type::CreateEnum8({{"One", 1}, {"Two", 2}});
     ASSERT_EQ(enum8->GetName(), "Enum8('One' = 1, 'Two' = 2)");

--- a/ut/utils.cpp
+++ b/ut/utils.cpp
@@ -361,6 +361,9 @@ std::ostream& operator<<(std::ostream& ostr, const ItemView& item_view) {
         case Type::UInt8:
             ostr << static_cast<unsigned int>(item_view.get<uint8_t>());
             break;
+        case Type::Bool:
+            ostr << (item_view.get<Bool>() ? "true" : "false");
+            break;
         case Type::UInt16:
             ostr << static_cast<unsigned int>(item_view.get<uint16_t>());
             break;


### PR DESCRIPTION
This resolves two issues I just ran into when writing an integration to fetch data from ClickHouse.

* A strong Bool type to make Bool Columns truly distinct from UInt8 columns.
* A way to obtain the names for the fields of a Tuple.

Both changes are rather simple and self-contained in indivudual commits. Each adds a test for the newly added functionality.

- Fixes https://github.com/ClickHouse/clickhouse-cpp/issues/476
- Fixes https://github.com/ClickHouse/clickhouse-cpp/issues/484
