### PR TITLE
Fix UB in ColumnStringBlock::AppendUnsafe when appending empty string_view

### DIFF
--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -136,8 +136,13 @@ struct ColumnString::Block
     std::string_view AppendUnsafe(std::string_view str) {
         const auto pos = &data_[size];
 
-        memcpy(pos, str.data(), str.size());
-        size += str.size();
+        // memcpy's source pointer is declared nonnull regardless of the
+        // size argument, so an empty string_view backed by std::string()
+        // (where data() may be null) trips UBSan on every empty append.
+        if (str.size() > 0) {
+            memcpy(pos, str.data(), str.size());
+            size += str.size();
+        }
 
         return std::string_view(pos, str.size());
     }


### PR DESCRIPTION
## Summary

`ColumnStringBlock::AppendUnsafe` calls `memcpy(pos, str.data(), str.size())` without short-circuiting on `str.size() == 0`. When the input `string_view` was built from an empty `std::string`, `str.data()` can be `nullptr`, and glibc declares `memcpy`'s source pointer with `__attribute__((nonnull))` regardless of the size argument. UBSan flags every empty-string append:

```
runtime error: null pointer passed as argument 2, which is declared to never be null
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior clickhouse/columns/string.cpp:139:21
```

The bug is benign in practice because libc no-ops `memcpy(_, NULL, 0)`, but the false positive fires on any workload that round-trips empty values through `String` or `LowCardinality(String)` columns. That makes `-fsanitize=undefined` builds noisy and hides real findings.

## Patch

One-line guard around the `memcpy`. Behavior is unchanged for non-empty inputs, and the return value matches the previous shape: a `string_view` pointing at `pos` with length 0 for empty inputs.

## Repro

I hit this in a downstream PHP extension that wraps the library ([iliaal/php_clickhouse](https://github.com/iliaal/php_clickhouse)). Inserting an empty value into a `LowCardinality(String)` column under `-fsanitize=address,undefined` reproduces it on every read path. Happy to add a unit test in `ut/` if you'd prefer it gated by `make test` rather than relying on existing coverage.