### PR TITLE
fix deprecated-enum-enum-conversion warning in ColumnLowCardinality::SaveBody

### DIFF
--- a/clickhouse/columns/lowcardinality.cpp
+++ b/clickhouse/columns/lowcardinality.cpp
@@ -396,7 +396,8 @@ void ColumnLowCardinality::SavePrefix(OutputStream* output) {
 }
 
 void ColumnLowCardinality::SaveBody(OutputStream* output) {
-    const uint64_t index_serialization_type = indexTypeFromIndexColumn(*index_column_) | IndexFlag::HasAdditionalKeysBit;
+    const uint64_t index_serialization_type =
+        static_cast<uint64_t>(indexTypeFromIndexColumn(*index_column_)) | IndexFlag::HasAdditionalKeysBit;
     WireFormat::WriteFixed(*output, index_serialization_type);
 
     const uint64_t number_of_keys = dictionary_column_->Size();


### PR DESCRIPTION
A trivial `static_cast` to make compiler happy. It solves #452 .