### PR TITLE
Run ClickHouse server locally instead of using cloud instances for tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,10 +15,6 @@ on:
 
 env:
   BUILD_TYPE: Release
-  CLICKHOUSE_SERVER_IMAGE: "clickhouse/clickhouse-server:25.10"
-  CLICKHOUSE_SECURE_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
-  CLICKHOUSE_SECURE_USER: default
-  CLICKHOUSE_SECURE_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
 
 jobs:
   build:
@@ -83,7 +79,7 @@ jobs:
     runs-on: ${{matrix.os}}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
           fetch-tags: true
@@ -95,16 +91,6 @@ jobs:
             cmake \
             ${{matrix.COMPILER_INSTALL}} \
             ${{matrix.DEPENDENCIES_INSTALL}}
-
-      - name: Install dependencies - Docker
-        run: |
-          sudo apt remove -y docker docker-engine docker.io containerd runc
-          sudo apt install -y apt-transport-https ca-certificates curl gnupg lsb-release
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt update -q
-          sudo apt install docker-ce docker-ce-cli containerd.io
-          sudo docker run hello-world
 
       - name: Configure project
         run: |
@@ -125,15 +111,24 @@ jobs:
             --config ${{env.BUILD_TYPE}} \
             --target all
 
-      - name: Test - Start ClickHouse server in background
-        run: |
-          docker pull ${CLICKHOUSE_SERVER_IMAGE}
-          docker run -d --name clickhouse -p 9000:9000 -e CLICKHOUSE_SKIP_USER_SETUP=1 ${CLICKHOUSE_SERVER_IMAGE}
-          docker ps -a
-          docker stats -a --no-stream
-          ## Check and wait until CH is ready to accept connections
-          docker exec clickhouse bash -c 'for i in {1..10}; do echo checking if clickhouse server is started  attempt \#$i; if ( grep -q "<Information> Application: Ready for connections." /var/log/clickhouse-server/clickhouse-server.log ); then echo seems like clickhouse server is started; exit 0; fi; sleep 1; done; exit -1'
+      - name: Start ClickHouse in Docker
+        uses: hoverkraft-tech/compose-action@v2.0.1
+        with:
+          compose-file: ci/docker-compose.yml
+          down-flags: --volumes
 
+      - name: Check if ClickHouse is available
+        run: |
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8123/ > /dev/null; then
+              echo "ClickHouse is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ClickHouse failed to start"
+          exit 1
+  
       - name: Test
         working-directory: ${{github.workspace}}/build/ut
         run: ./clickhouse-cpp-ut

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -14,13 +14,6 @@ on:
 
 env:
   BUILD_TYPE: Release
-  CLICKHOUSE_USER: default
-  CLICKHOUSE_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
-  CLICKHOUSE_SECURE_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
-  CLICKHOUSE_SECURE_PORT: 9440
-  CLICKHOUSE_SECURE_USER: default
-  CLICKHOUSE_SECURE_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
-  CLICKHOUSE_SECURE_DB: default
 
 jobs:
   build:
@@ -40,7 +33,7 @@ jobs:
           SSL_INSTALL: openssl
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
           fetch-tags: true
@@ -67,21 +60,25 @@ jobs:
             --config ${{env.BUILD_TYPE}} \
             --target all
 
-      - name: Start tls offoader proxy
-        # that mimics non-secure clickhouse running on localhost
-        # by tunneling queries to remote tls server
-        # (needed because we can't start real clickhouse instance on macOS)
+      - name: Install and start ClickHouse
+        working-directory: ${{ runner.temp }}
         run: |
-              wget https://github.com/filimonov/go-tlsoffloader/releases/download/v0.1.2/go-tlsoffloader_0.1.2_Darwin_x86_64.tar.gz
-              tar -xvzf go-tlsoffloader_0.1.2_Darwin_x86_64.tar.gz
-              ./go-tlsoffloader -l localhost:9000 -b ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}:9440 &
+          curl https://builds.clickhouse.com/25.12/macos-aarch64/clickhouse -o clickhouse
+          chmod +x ./clickhouse
+          sudo mkdir -p /var/lib/clickhouse /var/log/clickhouse-server
+          sudo chown -R "$USER" /var/lib/clickhouse /var/log/clickhouse-server
+          nohup ./clickhouse server --config-file="$GITHUB_WORKSPACE/ci/docker-compose/config.xml" > clickhouse.log 2>&1 &
+          for i in {1..60}; do
+            if curl -fsS http://localhost:8123/ > /dev/null; then
+              echo "ClickHouse is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "ClickHouse failed to start"
+          tail -200 clickhouse.log || true
+          exit 1
 
       - name: Test
         working-directory: ${{github.workspace}}/build/ut
-        env:
-          # It is impossible to start CH server in docker on macOS due to github actions limitations,
-          # so we use remote server to execute tests, some do not allow some features for anonymoust/free users:
-          # - system.query_log used by 'Client/ClientCase.Query_ID' and 'Client/ClientCase.ClientName'
-          # - system.opentelemetry_span_log is used by 'Client/ClientCase.TracingContext'
-          GTEST_FILTER: "-Client/ClientCase.Query_ID*:Client/ClientCase.TracingContext/*:Client/ClientCase.ClientName/*"
         run: ./clickhouse-cpp-ut ${GTEST_FILTER}

--- a/.github/workflows/windows_mingw.yml
+++ b/.github/workflows/windows_mingw.yml
@@ -15,27 +15,6 @@ on:
 
 env:
   BUILD_TYPE: Release
-  CLICKHOUSE_USER: default
-  CLICKHOUSE_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
-
-  #
-  # CLICKHOUSE_HOST: localhost
-  # CLICKHOUSE_PORT: 9000
-  # CLICKHOUSE_USER: default
-  # CLICKHOUSE_PASSWORD:
-  # CLICKHOUSE_DB:   default
-  #
-  # CLICKHOUSE_SECURE_HOST:     github.demo.trial.altinity.cloud
-  # CLICKHOUSE_SECURE_PORT:     9440
-  # CLICKHOUSE_SECURE_USER:     demo
-  # CLICKHOUSE_SECURE_PASSWORD: demo
-  # CLICKHOUSE_SECURE_DB:       default
-  #
-  # CLICKHOUSE_SECURE2_HOST:    gh-api.clickhouse.tech
-  # CLICKHOUSE_SECURE2_PORT:    9440
-  # CLICKHOUSE_SECURE2_USER:    explorer
-  # CLICKHOUSE_SECURE2_PASSWORD:
-  # CLICKHOUSE_SECURE2_DB:      default
 
 jobs:
   build:
@@ -54,7 +33,7 @@ jobs:
         shell: msys2 {0}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
           fetch-tags: true
@@ -80,22 +59,33 @@ jobs:
       - name: Build
         run: cmake --build build --config ${{env.BUILD_TYPE}} --target all
 
-      - name: Start tls offoader proxy
-        # that mimics non-secure clickhouse running on localhost
-        # by tunneling queries to remote tls server
-        # (needed because we can't start real clickhouse instance on windows)
+      - name: Enable WSL and Install Dependencies
+        uses: Vampire/setup-wsl@v5
+        with:
+            distribution: Ubuntu-24.04
+            additional-packages:
+              podman
+              podman-compose
+
+      - name: Start ClickHouse Server
+        shell: wsl-bash {0}
         run: |
-              wget https://github.com/filimonov/go-tlsoffloader/releases/download/v0.1.2/go-tlsoffloader_0.1.2_Windows_x86_64.tar.gz
-              tar -xvzf go-tlsoffloader_0.1.2_Windows_x86_64.tar.gz
-              ./go-tlsoffloader.exe -l localhost:9000 -b ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}:9440 &
+          echo "Starting ClickHouse container"
+          cd $(wslpath -u "${{ github.workspace }}/ci/")
+          podman-compose up -d
+
+          echo "Waiting for ClickHouse to start..."
+          timeout 60s bash -c \
+              'until curl -s -o /dev/null -w "%{http_code}" http://localhost:8123 | grep -q "200"; do sleep 2; done'
+
+          echo "Checking ClickHouse version"
+          curl -s http://localhost:8123/?query=SELECT%20VERSION%28%29
+
+      - name: Ping ClickHouse Server from Windows
+        run: |
+            curl.exe http://localhost:8123/?query=SELECT%20VERSION%28%29
 
       - name: Test
-        env:
-          # It is impossible to start CH server in docker on Windows due to github actions limitations,
-          # so we use remote server to execute tests, some do not allow some features for anonymoust/free users:
-          # - system.query_log used by 'Client/ClientCase.Query_ID' and 'Client/ClientCase.ClientName'
-          # - system.opentelemetry_span_log is used by 'Client/ClientCase.TracingContext'
-          GTEST_FILTER: "-Client/ClientCase.Query_ID*:Client/ClientCase.TracingContext/*:Client/ClientCase.ClientName/*"
         run: ./build/ut/clickhouse-cpp-ut.exe ${GTEST_FILTER}
 
       - name: Test (simple)

--- a/.github/workflows/windows_msvc.yml
+++ b/.github/workflows/windows_msvc.yml
@@ -15,32 +15,13 @@ on:
 
 env:
   BUILD_TYPE: Release
-  CLICKHOUSE_USER: default
-  CLICKHOUSE_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
-  # CLICKHOUSE_HOST: localhost
-  # CLICKHOUSE_PORT: 9000
-  # CLICKHOUSE_USER: default
-  # CLICKHOUSE_PASSWORD:
-  # CLICKHOUSE_DB:   default
-  #
-  # CLICKHOUSE_SECURE_HOST:     github.demo.trial.altinity.cloud
-  # CLICKHOUSE_SECURE_PORT:     9440
-  # CLICKHOUSE_SECURE_USER:     demo
-  # CLICKHOUSE_SECURE_PASSWORD: demo
-  # CLICKHOUSE_SECURE_DB:       default
-  #
-  # CLICKHOUSE_SECURE2_HOST:    gh-api.clickhouse.tech
-  # CLICKHOUSE_SECURE2_PORT:    9440
-  # CLICKHOUSE_SECURE2_USER:    explorer
-  # CLICKHOUSE_SECURE2_PASSWORD:
-  # CLICKHOUSE_SECURE2_DB:      default
 
 jobs:
   build:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 100
           fetch-tags: true
@@ -52,23 +33,32 @@ jobs:
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
-      - name: Start tls offoader proxy
-        shell: bash
-        # that mimics non-secure clickhouse running on localhost
-        # by tunneling queries to remote tls server
-        # (needed because we can't start real clickhouse instance on windows)
+      - name: Enable WSL and Install Dependencies
+        uses: Vampire/setup-wsl@v5
+        with:
+            distribution: Ubuntu-24.04
+            additional-packages:
+              podman
+              podman-compose
+
+      - name: Start ClickHouse Server
+        shell: wsl-bash {0}
         run: |
-              choco install wget
-              wget https://github.com/filimonov/go-tlsoffloader/releases/download/v0.1.2/go-tlsoffloader_0.1.2_Windows_x86_64.tar.gz
-              tar -xvzf go-tlsoffloader_0.1.2_Windows_x86_64.tar.gz
-              ./go-tlsoffloader.exe -l localhost:9000 -b ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}:9440 &
+          echo "Starting ClickHouse container"
+          cd $(wslpath -u "${{ github.workspace }}/ci/")
+          podman-compose up -d
+
+          echo "Waiting for ClickHouse to start..."
+          timeout 60s bash -c \
+              'until curl -s -o /dev/null -w "%{http_code}" http://localhost:8123 | grep -q "200"; do sleep 2; done'
+
+          echo "Checking ClickHouse version"
+          curl -s http://localhost:8123/?query=SELECT%20VERSION%28%29
+
+      - name: Ping ClickHouse Server from Windows
+        run: |
+            curl.exe http://localhost:8123/?query=SELECT%20VERSION%28%29
 
       - name: Test
-        env:
-          # It is impossible to start CH server in docker on Windows due to github actions limitations,
-          # so we use remote server to execute tests, some do not allow some features for anonymoust/free users:
-          # - system.query_log used by 'Client/ClientCase.Query_ID' and 'Client/ClientCase.ClientName'
-          # - system.opentelemetry_span_log is used by 'Client/ClientCase.TracingContext'
-          GTEST_FILTER: "-Client/ClientCase.Query_ID*:Client/ClientCase.TracingContext/*:Client/ClientCase.ClientName/*"
         working-directory: ${{github.workspace}}/build/ut
         run: Release\clickhouse-cpp-ut.exe "${{env.GTEST_FILTER}}"

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+    clickhouse:
+        image: 'docker.io/clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-25.12-alpine}'
+        container_name: 'clickhouse-odbc-clickhouse-server'
+        environment:
+            CLICKHOUSE_SKIP_USER_SETUP: 1
+        ports:
+            - '8123:8123'
+            - '9000:9000'
+        ulimits:
+            nofile:
+                soft: 262144
+                hard: 262144
+        volumes:
+            - './docker-compose/config.xml:/etc/clickhouse-server/config.xml:z'
+            - './docker-compose/users.xml:/etc/clickhouse-server/users.xml:z'
+        networks:
+            - clickhouse-odbc
+
+networks:
+    clickhouse-odbc:
+        driver: bridge

--- a/ci/docker-compose/config.xml
+++ b/ci/docker-compose/config.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<clickhouse>
+
+  <http_port>8123</http_port>
+  <tcp_port>9000</tcp_port>
+
+  <users_config>users.xml</users_config>
+  <default_profile>default</default_profile>
+  <default_database>default</default_database>
+
+  <mark_cache_size>5368709120</mark_cache_size>
+
+  <path>/var/lib/clickhouse/</path>
+  <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
+  <user_files_path>/var/lib/clickhouse/user_files/</user_files_path>
+  <access_control_path>/var/lib/clickhouse/access/</access_control_path>
+  <keep_alive_timeout>3</keep_alive_timeout>
+
+  <logger>
+    <level>debug</level>
+    <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+    <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+    <size>1000M</size>
+    <count>10</count>
+    <console>1</console>
+  </logger>
+
+  <query_log>
+    <database>system</database>
+    <table>query_log</table>
+    <partition_by>toYYYYMM(event_date)</partition_by>
+    <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+  </query_log>
+
+  <format_schema_path>/var/lib/clickhouse/format_schemas/</format_schema_path>
+  <user_directories>
+    <users_xml>
+      <path>users.xml</path>
+    </users_xml>
+  </user_directories>
+
+  <opentelemetry_span_log>
+    <engine>
+      engine MergeTree
+      partition by toYYYYMM(finish_date)
+      order by (finish_date, finish_time_us, trace_id)
+    </engine>
+    <database>system</database>
+    <table>opentelemetry_span_log</table>
+    <flush_interval_milliseconds>7500</flush_interval_milliseconds>
+  </opentelemetry_span_log>
+
+</clickhouse>

--- a/ci/docker-compose/users.xml
+++ b/ci/docker-compose/users.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<clickhouse>
+
+  <profiles>
+    <default>
+      <load_balancing>random</load_balancing>
+      <enable_time_time64_type>1</enable_time_time64_type>
+    </default>
+  </profiles>
+
+  <users>
+    <default>
+      <password></password>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+      <profile>default</profile>
+      <quota>default</quota>
+      <access_management>1</access_management>
+    </default>
+  </users>
+
+  <quotas>
+    <default>
+      <interval>
+        <duration>3600</duration>
+        <queries>0</queries>
+        <errors>0</errors>
+        <result_rows>0</result_rows>
+        <read_rows>0</read_rows>
+        <execution_time>0</execution_time>
+      </interval>
+    </default>
+  </quotas>
+</clickhouse>

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -1592,7 +1592,7 @@ using namespace clickhouse;
 const auto QUERIES = std::vector<std::string>{
     "SELECT version()",
     "SELECT fqdn()",
-    "SELECT buildId()",
+    "SELECT blockSize()",
     "SELECT uptime()",
     "SELECT now()"
 };

--- a/ut/ssl_ut.cpp
+++ b/ut/ssl_ut.cpp
@@ -14,7 +14,7 @@ namespace {
     const auto QUERIES = std::vector<std::string> {
         "SELECT version()",
         "SELECT fqdn()",
-        "SELECT buildId()",
+        "SELECT blockSize()",
         "SELECT uptime()",
         "SELECT now()"
     };
@@ -38,10 +38,10 @@ INSTANTIATE_TEST_SUITE_P(
     RemoteTLS, ReadonlyClientTest,
     ::testing::Values(ReadonlyClientTest::ParamType {
         ClientOptions()
-            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE_HOST",     "github.demo.trial.altinity.cloud"))
+            .SetHost(           getEnvOrDefault("CLICKHOUSE_SECURE_HOST",     "play.clickhouse.com"))
             .SetPort(   getEnvOrDefault<size_t>("CLICKHOUSE_SECURE_PORT",     "9440"))
-            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE_USER",     "demo"))
-            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE_PASSWORD", "demo"))
+            .SetUser(           getEnvOrDefault("CLICKHOUSE_SECURE_USER",     "explorer"))
+            .SetPassword(       getEnvOrDefault("CLICKHOUSE_SECURE_PASSWORD", ""))
             .SetDefaultDatabase(getEnvOrDefault("CLICKHOUSE_SECURE_DB",       "default"))
             .SetSendRetries(1)
             .SetPingBeforeQuery(true)


### PR DESCRIPTION
Testing the library against ClickHouse Cloud has been challenging, particularly because tests from external PRs could not reach the ClickHouse Cloud instance. This was due to the required credentials being stored in organization-only secrets.

This PR replaces ClickHouse Cloud with a locally run server across all CI workflows, so the test suite no longer depends on shared cloud credentials or a TLS offloader proxy.

- Linux: switch from an ad hoc `docker run` setup to a Docker instance managed by Docker Compose.
- macOS: download the official ClickHouse binary and run it directly against the same `config.xml` used by the Docker Compose-managed instance on Linux.
- Windows: install WSL + Podman/Podman Compose and run the same `docker-compose.yml` inside WSL.
- Remove all `INTEGRATIONS_TEAM_TESTS_CLOUD_*` secrets and `CLICKHOUSE_SECURE_*` environment variables that pointed to remote instances.
- Update the `RemoteTLS` SSL suite to point to the public `play.clickhouse.com` instance.
- Replace `SELECT buildId()` with `SELECT blockSize()` in readonly client queries — `buildId()` is not available on macOS for custom ClickHouse versions.