### PR TITLE
ci: declare contents:read on Windows MinGW build workflow

### DIFF
--- a/.github/workflows/windows_mingw.yml
+++ b/.github/workflows/windows_mingw.yml
@@ -37,6 +37,9 @@ env:
   # CLICKHOUSE_SECURE2_PASSWORD:
   # CLICKHOUSE_SECURE2_DB:      default
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Adds a workflow-level `permissions: contents: read` block. The build job checks out the repository (including submodules), installs the toolchain, then invokes `cmake` and the platform-native build to produce binaries. None of those steps call a GitHub API beyond the initial checkout.

The runtime supply-chain threat that this caps is the one CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) demonstrated. A tampered third-party action exfiltrates `GITHUB_TOKEN` from workflow logs and the leaked token retains whatever scope was issued at the workflow level. With `contents: read` declared in-file, any action - present or future - that runs in this workflow is bounded to read access, regardless of whatever the org default is set to. OpenSSF Scorecard's Token-Permissions check only credits the explicit per-workflow declaration.

YAML validated locally with `yaml.safe_load`.
