### PR TITLE
Allow accessing ColumnArrays backing column

### DIFF
--- a/clickhouse/columns/array.cpp
+++ b/clickhouse/columns/array.cpp
@@ -163,8 +163,12 @@ size_t ColumnArray::GetSize(size_t n) const {
     return (n == 0) ? (*offsets_)[n] : ((*offsets_)[n] - (*offsets_)[n - 1]);
 }
 
-ColumnRef ColumnArray::GetData() {
+ColumnRef ColumnArray::GetData() const {
     return data_;
+}
+
+const std::shared_ptr<ColumnUInt64>& ColumnArray::GetOffsets() const {
+    return offsets_;
 }
 
 void ColumnArray::Reset() {

--- a/clickhouse/columns/array.cpp
+++ b/clickhouse/columns/array.cpp
@@ -163,11 +163,19 @@ size_t ColumnArray::GetSize(size_t n) const {
     return (n == 0) ? (*offsets_)[n] : ((*offsets_)[n] - (*offsets_)[n - 1]);
 }
 
-ColumnRef ColumnArray::GetData() const {
+ColumnRef ColumnArray::GetData() {
     return data_;
 }
 
-const std::shared_ptr<ColumnUInt64>& ColumnArray::GetOffsets() const {
+std::shared_ptr<const Column> ColumnArray::GetData() const {
+    return data_;
+}
+
+std::shared_ptr<ColumnUInt64>& ColumnArray::GetOffsets() {
+    return offsets_;
+}
+
+std::shared_ptr<const ColumnUInt64> ColumnArray::GetOffsets() const {
     return offsets_;
 }
 

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -79,11 +79,13 @@ public:
     void OffsetsIncrease(size_t);
 
     /// Gets the backing data array of the Array's. This does not include any Array Bounds.
-    ColumnRef GetData() const;
+    ColumnRef GetData();
+    std::shared_ptr<const Column> GetData() const;
 
     /// Gets all offsets denoting the list boundaries overlayed GetData.
     /// The layout is [size_i, ...] where `i` is the row.
-    const std::shared_ptr<ColumnUInt64>& GetOffsets() const;
+    std::shared_ptr<ColumnUInt64>& GetOffsets();
+    std::shared_ptr<const ColumnUInt64> GetOffsets() const;
 
     /// Gets the offset of the start of row `n` into `GetData()`.
     size_t GetOffset(size_t n) const;

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -78,14 +78,24 @@ public:
 
     void OffsetsIncrease(size_t);
 
+    /// Gets the backing data array of the Array's. This does not include any Array Bounds.
+    ColumnRef GetData() const;
+
+    /// Gets all offsets denoting the list boundaries overlayed GetData.
+    /// The layout is [size_i, ...] where `i` is the row.
+    const std::shared_ptr<ColumnUInt64>& GetOffsets() const;
+
+    /// Gets the offset of the start of row `n` into `GetData()`.
+    size_t GetOffset(size_t n) const;
+
+    /// Gets the element count of row `n`.
+    size_t GetSize(size_t n) const;
+
 protected:
     template<typename T> friend class ColumnArrayT;
 
     ColumnArray(ColumnArray&& array);
 
-    size_t GetOffset(size_t n) const;
-    size_t GetSize(size_t n) const;
-    ColumnRef GetData();
     void AddOffset(size_t n);
     void Reset();
 
@@ -262,11 +272,9 @@ public:
     template <typename Container>
     inline void Append(Container&& container) {
         using container_type = decltype(container);
-        if constexpr (std::is_lvalue_reference_v<container_type> || 
-            std::is_const_v<std::remove_reference_t<container_type>>) {
+        if constexpr (std::is_lvalue_reference_v<container_type> || std::is_const_v<std::remove_reference_t<container_type>>) {
             Append(std::begin(container), std::end(container));
-        }
-        else {
+        } else {
             Append(std::make_move_iterator(std::begin(container)),
                 std::make_move_iterator(std::end(container)));
         }

--- a/ut/column_array_ut.cpp
+++ b/ut/column_array_ut.cpp
@@ -436,3 +436,47 @@ TEST(ColumnArrayT, const_right_value_no_move) {
         EXPECT_EQ(values[2], value2);
     }
 }
+
+TEST(ColumnArray, GetData) {
+    auto col = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{1, 2, 3}));
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{4, 5}));
+
+    ColumnRef data = col->GetData();
+    EXPECT_EQ(data->Size(), 5u);
+
+    const auto& ccol = *col;
+    std::shared_ptr<const Column> cdata = ccol.GetData();
+    EXPECT_EQ(cdata->Size(), 5u);
+}
+
+TEST(ColumnArray, GetOffsets) {
+    auto col = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{1, 2, 3}));
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{4, 5}));
+
+    auto& offsets = col->GetOffsets();
+    ASSERT_EQ(offsets->Size(), 2u);
+    EXPECT_EQ((*offsets)[0], 3u);
+    EXPECT_EQ((*offsets)[1], 5u);
+
+    const auto& ccol = *col;
+    std::shared_ptr<const ColumnUInt64> coffsets = ccol.GetOffsets();
+    EXPECT_EQ((*coffsets)[0], 3u);
+    EXPECT_EQ((*coffsets)[1], 5u);
+}
+
+TEST(ColumnArray, GetOffsetAndSize) {
+    auto col = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{10, 20}));
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{30}));
+    col->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{}));
+
+    EXPECT_EQ(col->GetOffset(0), 0u);
+    EXPECT_EQ(col->GetOffset(1), 2u);
+    EXPECT_EQ(col->GetOffset(2), 3u);
+
+    EXPECT_EQ(col->GetSize(0), 2u);
+    EXPECT_EQ(col->GetSize(1), 1u);
+    EXPECT_EQ(col->GetSize(2), 0u);
+}


### PR DESCRIPTION
When working with a ColumnArray, it is oftentimes useful to be able to access the entire, contiguous backing array at once without having to do row-wise access.

This change simply allows reading access to the backing data array and the offsets.

In my concrete usecase I want to fetch data from clickhouse and put it into our columnar (Apache Arrow) data representation. Doing this recursively and efficiently gets much easier with this access.

Given that e.g. ColumnVector directly exposes writable access to its backing `std::vector` and ColumnArray itself is brittle
against modifcation of passed-in columns, I dont see a downside with making this API public.

# Example

```sql
CREATE TABLE test_array
(
    `id` UInt64,
    `value` Array(UInt32)
)
ENGINE = MergeTree
ORDER BY id
```

```sql
insert into test_array values 
    (1, [1]),
    (2, [2, 22]),
    (3, [3, 33, 33]),
    (4, [4, 44, 444, 4444])
```

For this table, `GetData()` would return a column with all arrays concatenated:

```
[1, 2, 22, 3, 33, 333, 4, 44, 444, 4444]
```

`GetOffsets()` returns the offsets for each row from the start of the `GetData()` column:

```
[1,3,6,10]
```

The first offset is always `zero` and is not included in the list. The last offset in the list represents the index past the last value in `GetData()` and is equal to the size of the `GetData()` column.

Code example:

```cpp
client.BeginSelect("SELECT id, value FROM test_array");

while (auto block = client.NextBlock()) {
    if (block->GetRowCount() == 0) {
        continue;
    }

    auto col_id = block->At(0)->AsStrict<clickhouse::ColumnUInt64>();
    auto col_arr = block->At(1)->AsStrict<clickhouse::ColumnArray>();

    auto offsets = col_arr->GetOffsets();
    auto data = col_arr->GetData()->AsStrict<clickhouse::ColumnUInt32>();

    std::cout << "data (" << data->Size() << " items): [";
    for (size_t j = 0; j < data->Size(); ++j) {
        std::cout << data->At(j) << ",";
    }
    std::cout << "\b]\n";

    std::cout << "offsets: [";
    for (size_t j = 0; j < offsets->Size(); ++j) {
        std::cout << offsets->At(j) << ",";
    }
    std::cout << "\b]\n";

    size_t offset = 0;
    for (size_t i = 0; i < block->GetRowCount(); ++i) {
        size_t arr_size = offsets->At(i) - offset;
        std::cout << "id: " << col_id->At(i) << " has " << arr_size << "items: [";
        for (size_t j = 0; j < arr_size; ++j) {
            std::cout << data->At(offset + j) << ",";
        }
        std::cout << "\b]\n";
        offset = offsets->At(i);
    }
}
```

This example outputs:

```
data size: 10
data (10 items): [1,2,22,3,33,33,4,44,444,4444]
offsets: [1,3,6,10]
id: 1 has 1 items: [1]
id: 2 has 2 items: [2,22]
id: 3 has 3 items: [3,33,33]
id: 4 has 4 items: [4,44,444,4444]
```