### PR TITLE
client.cpp: remove support for nested exceptions

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -753,40 +753,14 @@ bool Client::Impl::ReceiveData() {
 
 bool Client::Impl::ReceiveException(bool rethrow) {
     std::shared_ptr<Exception> e(new Exception);
-    Exception* current = e.get();
+    bool has_nested = false; // obsolete: https://github.com/ClickHouse/ClickHouse/blob/ef11941cf5a/src/IO/ReadHelpers.cpp#L2017
 
-    bool exception_received = true;
-    do {
-        bool has_nested = false;
-
-        if (!WireFormat::ReadFixed(*input_, &current->code)) {
-           exception_received = false;
-           break;
-        }
-        if (!WireFormat::ReadString(*input_, &current->name)) {
-            exception_received = false;
-            break;
-        }
-        if (!WireFormat::ReadString(*input_, &current->display_text)) {
-            exception_received = false;
-            break;
-        }
-        if (!WireFormat::ReadString(*input_, &current->stack_trace)) {
-            exception_received = false;
-            break;
-        }
-        if (!WireFormat::ReadFixed(*input_, &has_nested)) {
-            exception_received = false;
-            break;
-        }
-
-        if (has_nested) {
-            current->nested.reset(new Exception);
-            current = current->nested.get();
-        } else {
-            break;
-        }
-    } while (true);
+    bool exception_received =
+        WireFormat::ReadFixed(*input_, &e->code)
+        && WireFormat::ReadString(*input_, &e->name)
+        && WireFormat::ReadString(*input_, &e->display_text)
+        && WireFormat::ReadString(*input_, &e->stack_trace)
+        && WireFormat::ReadFixed(*input_, &has_nested);
 
     if (events_) {
         events_->OnServerException(*e);

--- a/clickhouse/server_exception.h
+++ b/clickhouse/server_exception.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <memory>
 
 namespace clickhouse {
 struct Exception {
@@ -9,8 +8,6 @@ struct Exception {
     std::string name;
     std::string display_text;
     std::string stack_trace;
-    /// Pointer to nested exception.
-    std::unique_ptr<Exception> nested;
 };
 
 }


### PR DESCRIPTION
these are a vulnerability vector (stack overflow)

support removed in ClickHouse itself in 2020:
https://github.com/ClickHouse/ClickHouse/commit/67afaa9d93aa299b806a112044d3923faefed7ef