### PR TITLE
Add names to `ColumnTupleT<...>` strong type

### DIFF
--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -71,11 +71,21 @@ public:
     ColumnTupleT(std::tuple<std::shared_ptr<Columns>...> columns)
         : ColumnTuple(TupleToVector(columns)), typed_columns_(std::move(columns)) {}
 
+    ColumnTupleT(std::tuple<std::shared_ptr<Columns>...> columns, std::vector<std::string> names)
+        : ColumnTuple(TupleToVector(columns), std::move(names)), typed_columns_(std::move(columns)) {}
+
     ColumnTupleT(std::vector<ColumnRef> columns)
         : ColumnTuple(columns), typed_columns_(VectorToTuple(std::move(columns))) {}
 
+    ColumnTupleT(std::vector<ColumnRef> columns, std::vector<std::string> names)
+        : ColumnTuple(columns, std::move(names)), typed_columns_(VectorToTuple(std::move(columns))) {}
+
     ColumnTupleT(const std::initializer_list<ColumnRef> columns)
         : ColumnTuple(columns), typed_columns_(VectorToTuple(std::move(columns))) {}
+
+    ColumnTupleT(std::initializer_list<ColumnRef> columns, std::vector<std::string> names)
+        : ColumnTuple(std::vector<ColumnRef>(columns), std::move(names))
+        , typed_columns_(VectorToTuple(std::vector<ColumnRef>(columns))) {}
 
     inline ValueType At(size_t index) const { return GetTupleOfValues(index); }
 
@@ -101,7 +111,8 @@ public:
         if (col.TupleSize() != std::tuple_size_v<TupleOfColumns>) {
             throw ValidationError("Can't wrap from " + col.GetType().GetName());
         }
-        return std::make_shared<ColumnTupleT<Columns...>>(VectorToTuple(std::move(col)));
+        auto names = col.Type()->As<TupleType>()->GetItemNames();
+        return std::make_shared<ColumnTupleT<Columns...>>(VectorToTuple(std::move(col)), std::move(names));
     }
 
     static auto Wrap(Column&& col) { return Wrap(std::move(dynamic_cast<ColumnTuple&&>(col))); }

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1139,6 +1139,53 @@ TEST(ColumnsCase, ColumnTupleT_Empty) {
     EXPECT_EQ(col.Size(), 0u);
 }
 
+TEST(ColumnsCase, ColumnTupleT_WithNames) {
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+
+    TestTuple col(
+        std::make_tuple(
+            std::make_shared<ColumnUInt64>(),
+            std::make_shared<ColumnString>()
+        ),
+        std::vector<std::string>{"id", "name"}
+    );
+    EXPECT_EQ(col.Type()->GetName(), "Tuple(id UInt64, name String)");
+
+    col.Append(std::make_tuple(uint64_t(42), std::string("hello")));
+    EXPECT_EQ(col.At(0), std::make_tuple(uint64_t(42), std::string_view("hello")));
+}
+
+TEST(ColumnsCase, ColumnTupleT_Wrap_PreservesNames) {
+    ColumnTuple base(
+        {std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()},
+        {"id", "name"}
+    );
+
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+    auto wrapped = TestTuple::Wrap(std::move(base));
+    EXPECT_EQ(wrapped->Type()->GetName(), "Tuple(id UInt64, name String)");
+}
+
+TEST(ColumnsCase, ColumnTupleT_Slice_PreservesNames) {
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+
+    auto col = std::make_shared<TestTuple>(
+        std::make_tuple(
+            std::make_shared<ColumnUInt64>(),
+            std::make_shared<ColumnString>()
+        ),
+        std::vector<std::string>{"id", "name"}
+    );
+    col->Append(std::make_tuple(uint64_t(1), std::string("a")));
+    col->Append(std::make_tuple(uint64_t(2), std::string("b")));
+
+    auto sliced = col->Slice(0, 1);
+    EXPECT_EQ(sliced->Type()->GetName(), "Tuple(id UInt64, name String)");
+
+    auto cloned = col->CloneEmpty();
+    EXPECT_EQ(cloned->Type()->GetName(), "Tuple(id UInt64, name String)");
+}
+
 TEST(ColumnsCase, ColumnMapT) {
     ColumnMapT<ColumnUInt64, ColumnString> col(
             std::make_shared<ColumnUInt64>(),


### PR DESCRIPTION
This adds field names to the `ColumnTupleT<...>` strong type wrapper.
Previously only the erased ColumnTuple supported field names, which meant
that `ColumnTupleT<...>::Wrap(ColumnTuple&&)` would drop the field names
and there was no way to create the strong type with column names in the
first place.

- Fixes https://github.com/ClickHouse/clickhouse-cpp/issues/507
