### PR TITLE
Rename Bazel module to clickhouse-cpp-client

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -40,16 +40,16 @@ jobs:
           repository-cache: true
 
       - name: Build project
-        run: bazel build //... --@clickhouse_cpp//:tls=${{ matrix.tls }}
+        run: bazel build //... --@clickhouse-cpp-client//:tls=${{ matrix.tls }}
 
       - name: Run unit tests
-        run: bazel test //ut:unit_tests --@clickhouse_cpp//:tls=${{ matrix.tls }} --test_output=errors
+        run: bazel test //ut:unit_tests --@clickhouse-cpp-client//:tls=${{ matrix.tls }} --test_output=errors
 
       # //ut:e2e_tests is tagged `manual`, so `bazel build //...` above
       # skips it; build it explicitly so the run step below doesn't pay
       # for compilation under the running-server timeout.
       - name: Build e2e tests
-        run: bazel build //ut:e2e_tests --@clickhouse_cpp//:tls=${{ matrix.tls }}
+        run: bazel build //ut:e2e_tests --@clickhouse-cpp-client//:tls=${{ matrix.tls }}
 
       # The e2e suite needs a live server on localhost:9000. Each OS starts
       # one the same way the CMake build's per-OS workflows do, since hosted
@@ -117,4 +117,4 @@ jobs:
           exit 1
 
       - name: Run e2e tests
-        run: bazel test //ut:e2e_tests --@clickhouse_cpp//:tls=${{ matrix.tls }} --test_output=errors
+        run: bazel test //ut:e2e_tests --@clickhouse-cpp-client//:tls=${{ matrix.tls }} --test_output=errors

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,8 +9,8 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 #
 # Differences from the CMake build that callers should be aware of:
 #   * TLS links against BoringSSL (`@boringssl`) by default; pass
-#     `--@clickhouse_cpp//:tls=openssl` to use the BCR OpenSSL module
-#     instead, or `--@clickhouse_cpp//:tls=no` to disable TLS
+#     `--@clickhouse-cpp-client//:tls=openssl` to use the BCR OpenSSL module
+#     instead, or `--@clickhouse-cpp-client//:tls=no` to disable TLS
 #     entirely. `USE_BORINGSSL` ifdef-guards the two OpenSSL-only
 #     surfaces (`SSL_CONF_*` command API and `SSL_read_ex`) that
 #     BoringSSL doesn't provide; see clickhouse/base/sslsocket.cpp.
@@ -19,9 +19,9 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 #     wire protocol needs ClickHouse's frozen CityHash variant, which
 #     differs from the stock BCR module (see the :cityhash target).
 
-# Selects the TLS implementation: `--@clickhouse_cpp//:tls=boringssl`
-# (default), `--@clickhouse_cpp//:tls=openssl`, or
-# `--@clickhouse_cpp//:tls=no` to disable TLS entirely (matching
+# Selects the TLS implementation: `--@clickhouse-cpp-client//:tls=boringssl`
+# (default), `--@clickhouse-cpp-client//:tls=openssl`, or
+# `--@clickhouse-cpp-client//:tls=no` to disable TLS entirely (matching
 # CMake's `WITH_OPENSSL=OFF` default). The two TLS libraries come from
 # BCR modules and are linked statically, keeping the build hermetic.
 string_flag(
@@ -89,7 +89,7 @@ cc_library(
 )
 
 # The main clickhouse-cpp library. Downstream callers use
-# `#include <clickhouse/client.h>` and link `@clickhouse_cpp//:clickhouse`.
+# `#include <clickhouse/client.h>` and link `@clickhouse-cpp-client//:clickhouse`.
 cc_library(
     name = "clickhouse",
     srcs = glob(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
-module(name = "clickhouse_cpp", version = "2.6.1")
+module(name = "clickhouse-cpp-client", version = "2.6.1")
 
 # Pinned to 20260107.1, the last version that declares
 # `compatibility_level = 1`, so that the module remains importable on


### PR DESCRIPTION
## Summary

Renames the Bazel module from `clickhouse_cpp` to **`clickhouse-cpp-client`**.

The name was discussed with folks from the Bazel community, and the conclusion was that `clickhouse-cpp-client` better reflects what the package actually is: a **client** library for talking to ClickHouse. A bare `clickhouse-cpp` is easy to misread as the C++ ClickHouse *server* (or as bundling server code), whereas the `-client` suffix makes the scope unambiguous. This is also the name the module is already published under on the [Bazel Central Registry](https://registry.bazel.build/), so aligning the in-repo `MODULE.bazel` removes the divergence between the source and the registry.

Until now the BCR entry carried an overlay that renamed the module, and the build-setting flag consumers used (`--@clickhouse_cpp//:tls=...`) didn't match the published name. After this change the repo and BCR agree, and future releases need no overlay rename.

## Changes

| File | Change |
|---|---|
| `MODULE.bazel` | `module(name = "clickhouse-cpp-client", …)` |
| `BUILD.bazel` | doc comments now reference `@clickhouse-cpp-client//:tls` / `@clickhouse-cpp-client//:clickhouse` |
| `.github/workflows/bazel.yml` | the four `--@clickhouse-cpp-client//:tls=${{ matrix.tls }}` invocations |

No `MODULE.bazel.lock` change (the lock tracks dependencies, not the root module name); the dependency graph is untouched.

## Flag usage after the rename

```
bazel build //:clickhouse                                          # BoringSSL (default)
bazel build //:clickhouse --@clickhouse-cpp-client//:tls=openssl   # OpenSSL from BCR
bazel build //:clickhouse --@clickhouse-cpp-client//:tls=no        # TLS disabled
```

## Test plan

- [x] `bazel build //... --@clickhouse-cpp-client//:tls=openssl` succeeds.
- [x] `bazel test //ut:unit_tests --@clickhouse-cpp-client//:tls=no` passes.
- [x] `bazel build //ut:e2e_tests --@clickhouse-cpp-client//:tls=boringssl` succeeds.
- [x] No stale `clickhouse_cpp` references remain in any Bazel/CI file.
