### PR TITLE
Make TLS config_settings public (sync BCR overlay patch)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,19 +34,26 @@ string_flag(
     ],
 )
 
+# Public visibility so the config_setting can be referenced from other
+# packages (e.g. ut/BUILD.bazel's `select()` on `//:tls_no`); Bazel's
+# config-setting visibility enforcement rejects the private default
+# across packages.
 config_setting(
     name = "tls_boringssl",
     flag_values = {":tls": "boringssl"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "tls_openssl",
     flag_values = {":tls": "openssl"},
+    visibility = ["//visibility:public"],
 )
 
 config_setting(
     name = "tls_no",
     flag_values = {":tls": "no"},
+    visibility = ["//visibility:public"],
 )
 
 # OpenSSL on Windows pulls in Win32 system libraries (the cert store via


### PR DESCRIPTION
## Summary

Syncs back the `config_setting_visibility.patch` that the `clickhouse-cpp-client` [Bazel Central Registry module](https://github.com/bazelbuild/bazel-central-registry/pull/9202) currently carries, so future BCR releases need no overlay patch.

The three TLS `config_setting` targets (`tls_boringssl`, `tls_openssl`, `tls_no`) are referenced cross-package — `ut/BUILD.bazel`'s `select()` keys on `//:tls_no`. Bazel's config-setting visibility enforcement (`--incompatible_enforce_config_setting_visibility` + `--incompatible_config_setting_private_default_visibility`, on by default in the BCR test environment) rejects the private default when a `config_setting` is used from another package. This makes the three settings `//visibility:public`.

## Why it wasn't caught here before

Our Bazel CI doesn't enable the config-setting visibility enforcement flags, so the cross-package `//:tls_no` reference resolved fine locally. The BCR presubmit runs with enforcement on, which is why the module needed the patch.

## Verification

Reproduced the BCR strictness locally with the enforcement flags:

- **Without the fix:** `bazel build //ut:unit_tests --incompatible_enforce_config_setting_visibility --incompatible_config_setting_private_default_visibility` →
  ```
  ERROR: ut/BUILD.bazel:35:8: in cc_test rule //ut:unit_tests: Visibility error
  ```
- **With the fix:** the same command builds successfully.

## Test plan

- [x] `bazel build //... --@clickhouse-cpp-client//:tls=no` succeeds.
- [x] `bazel test //ut:unit_tests` passes.
- [x] `bazel build //ut:unit_tests` with both enforcement flags succeeds (fails without this change).
