### PR TITLE
contrib/cityhash: namespace config.h as city_config.h for vendored builds

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -78,13 +78,13 @@ cc_library(
     name = "cityhash",
     srcs = [
         "contrib/cityhash/cityhash/city.cc",
-        "contrib/cityhash/cityhash/config.h",
+        "contrib/cityhash/cityhash/city_config.h",
     ],
     hdrs = [
         "contrib/cityhash/cityhash/city.h",
         "contrib/cityhash/cityhash/citycrc.h",
     ],
-    # config.h gates __builtin_expect off with `#if WIN32 || WIN64`, but
+    # city_config.h gates __builtin_expect off with `#if WIN32 || WIN64`, but
     # MSVC only predefines `_WIN32`/`_WIN64` — under CMake it's CMake that
     # defines WIN32, which Bazel's MSVC toolchain doesn't. Define it here
     # so the GCC/Clang-only builtin isn't used on MSVC.

--- a/contrib/cityhash/cityhash/city.cc
+++ b/contrib/cityhash/cityhash/city.cc
@@ -27,7 +27,7 @@
 // possible hash functions, by using SIMD instructions, or by
 // compromising on hash quality.
 
-#include "config.h"
+#include "city_config.h"
 #include "city.h"
 
 #include <algorithm>
@@ -47,7 +47,7 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
   return result;
 }
 
-#if !defined(WORDS_BIGENDIAN)
+#if !defined(CITY_WORDS_BIGENDIAN)
 
 #define uint32_in_expected_order(x) (x)
 #define uint64_in_expected_order(x) (x)
@@ -72,10 +72,10 @@ static uint32 UNALIGNED_LOAD32(const char *p) {
 #define uint32_in_expected_order(x) (bswap_32(x))
 #define uint64_in_expected_order(x) (bswap_64(x))
 
-#endif  // WORDS_BIGENDIAN
+#endif  // CITY_WORDS_BIGENDIAN
 
 #if !defined(LIKELY)
-#if HAVE_BUILTIN_EXPECT
+#if CITY_HAVE_BUILTIN_EXPECT
 #define LIKELY(x) (__builtin_expect(!!(x), 1))
 #else
 #define LIKELY(x) (x)

--- a/contrib/cityhash/cityhash/city_config.h
+++ b/contrib/cityhash/cityhash/city_config.h
@@ -1,82 +1,88 @@
-/* config.h.  Generated from config.h.in by configure.  */
-/* config.h.in.  Generated from configure.ac by autoheader.  */
+/* city_config.h.  Renamed from the autoconf-generated config.h; every macro
+   it defines carries a CITY_ prefix so a consumer that vendors these sources
+   next to its own autoconf config.h sees no name collisions. */
+/* Originally generated from config.h.in by configure / autoheader. */
 
 /* Define if building universal (internal helper macro) */
-/* #undef AC_APPLE_UNIVERSAL_BUILD */
+/* #undef CITY_AC_APPLE_UNIVERSAL_BUILD */
 
 /* Define to 1 if the compiler supports __builtin_expect. */
 #if WIN32 || WIN64
-#	define HAVE_BUILTIN_EXPECT 0
+#	define CITY_HAVE_BUILTIN_EXPECT 0
 #else
-#	define HAVE_BUILTIN_EXPECT 1
+#	define CITY_HAVE_BUILTIN_EXPECT 1
 #endif
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H 1
+#define CITY_HAVE_DLFCN_H 1
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-#define HAVE_INTTYPES_H 1
+#define CITY_HAVE_INTTYPES_H 1
 
 /* Define to 1 if you have the <memory.h> header file. */
-#define HAVE_MEMORY_H 1
+#define CITY_HAVE_MEMORY_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
-#define HAVE_STDINT_H 1
+#define CITY_HAVE_STDINT_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#define HAVE_STDLIB_H 1
+#define CITY_HAVE_STDLIB_H 1
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+#define CITY_HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <string.h> header file. */
-#define HAVE_STRING_H 1
+#define CITY_HAVE_STRING_H 1
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#define HAVE_SYS_STAT_H 1
+#define CITY_HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#define HAVE_SYS_TYPES_H 1
+#define CITY_HAVE_SYS_TYPES_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H 1
+#define CITY_HAVE_UNISTD_H 1
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
-#define LT_OBJDIR ".libs/"
+#define CITY_LT_OBJDIR ".libs/"
 
 /* Define to the address where bug reports for this package should be sent. */
-#define PACKAGE_BUGREPORT "cityhash-discuss@googlegroups.com"
+#define CITY_PACKAGE_BUGREPORT "cityhash-discuss@googlegroups.com"
 
 /* Define to the full name of this package. */
-#define PACKAGE_NAME "CityHash"
+#define CITY_PACKAGE_NAME "CityHash"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "CityHash 1.0.2"
+#define CITY_PACKAGE_STRING "CityHash 1.0.2"
 
 /* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "cityhash"
+#define CITY_PACKAGE_TARNAME "cityhash"
 
 /* Define to the home page for this package. */
-#define PACKAGE_URL ""
+#define CITY_PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "1.0.2"
+#define CITY_PACKAGE_VERSION "1.0.2"
 
 /* Define to 1 if you have the ANSI C header files. */
-#define STDC_HEADERS 1
+#define CITY_STDC_HEADERS 1
 
-/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+/* Define CITY_WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
+#if defined CITY_AC_APPLE_UNIVERSAL_BUILD
 # if defined __BIG_ENDIAN__
-#  define WORDS_BIGENDIAN 1
+#  define CITY_WORDS_BIGENDIAN 1
 # endif
 #else
-# ifndef WORDS_BIGENDIAN
-/* #  undef WORDS_BIGENDIAN */
+# ifndef CITY_WORDS_BIGENDIAN
+/* #  undef CITY_WORDS_BIGENDIAN */
 # endif
 #endif
+
+/* The placeholders below would define *standard* symbols (size_t, uint*_t, ...)
+   on deficient platforms, not CityHash macros, so they are left unprefixed.
+   All are inert (commented) in this checked-in copy. */
 
 /* Define for Solaris 2.5.1 so the uint32_t typedef from <sys/synch.h>,
    <pthread.h>, or <semaphore.h> is not used. If the typedef were allowed, the


### PR DESCRIPTION
city.cc does an unguarded `#include "config.h"`. The generic name collides with (or is shadowed by) a consumer's own autoconf `config.h` when the tree is vendored, and breaks outright on builds without an autoconf step that prune the generated header:

    fatal error C1083: Cannot open include file: 'config.h'

Rename the checked-in header to `city_config.h` and `CITY_`-prefix every macro it defines, updating the two usages in city.cc (`CITY_WORDS_BIGENDIAN`, `CITY_HAVE_BUILTIN_EXPECT`) and the Bazel `srcs` entry. The header is static (the `#if WIN32 || WIN64` `HAVE_BUILTIN_EXPECT` block is a hand edit, not autoconf output), so there is no `configure` step to keep in sync.

Inert `#undef` placeholders for standard types (`size_t`, `uint*_t`, ...) stay unprefixed: they would define standard symbols on deficient platforms, not CityHash macros. The pre/post object file for city.cc is byte-identical, so no runtime or wire-hash change.