### PR TITLE
client: pass full Query to SendQuery in BeginInsert (preserve query_id)

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -546,7 +546,7 @@ Block Client::Impl::BeginInsert(Query query) {
         return true;
     });
 
-    SendQuery(query.GetText());
+    SendQuery(query);
 
     // Wait for a data packet and return
     uint64_t server_packet = 0;


### PR DESCRIPTION
BeginInsert(Query query) was calling SendQuery(query.GetText()).

The implicit Query(string) constructor uses an empty default query id, so any query_id the caller supplied was silently dropped. The INSERT would land in system.query_log with an auto-generated id.

Pass the full Query object (the one-shot Insert path already did this).

This was originally carried as a local patch and is exercised by real usage that cares about stable query ids for auditing.