### PR TITLE
client: add BeginInsert(const Query&) overload

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -531,6 +531,10 @@ Block Client::Impl::BeginInsert(Query query) {
         throw ValidationError("cannot execute query while executing another operation");
     }
 
+    if (query.HasEventCallbacks()) {
+        throw ValidationError("Query callbacks are not supported in BeginInsert");
+    }
+
     EnsureNull en(static_cast<QueryEvents*>(&query), &events_);
 
     if (options_.ping_before_query) {

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -1377,6 +1377,10 @@ Block Client::BeginInsert(const Query& query) {
     return impl_->BeginInsert(query);
 }
 
+Block Client::BeginInsert(const std::string& query, const std::string& query_id) {
+    return impl_->BeginInsert(Query(query, query_id));
+}
+
 void Client::SendInsertBlock(const Block& block) {
     impl_->SendInsertBlock(block);
 }

--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -546,7 +546,7 @@ Block Client::Impl::BeginInsert(Query query) {
         return true;
     });
 
-    SendQuery(query.GetText());
+    SendQuery(query);
 
     // Wait for a data packet and return
     uint64_t server_packet = 0;
@@ -1373,12 +1373,8 @@ void Client::Insert(const std::string& table_name, const std::string& query_id, 
     impl_->Insert(table_name, query_id, block);
 }
 
-Block Client::BeginInsert(const std::string& query) {
-    return impl_->BeginInsert(Query(query));
-}
-
-Block Client::BeginInsert(const std::string& query, const std::string& query_id) {
-    return impl_->BeginInsert(Query(query, query_id));
+Block Client::BeginInsert(const Query& query) {
+    return impl_->BeginInsert(query);
 }
 
 void Client::SendInsertBlock(const Block& block) {

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -306,9 +306,8 @@ public:
     void Insert(const std::string& table_name, const std::string& query_id, const Block& block);
 
     /// Start an \p INSERT statement, insert batches of data, then finish the insert.
-    /// A bare string converts to a Query implicitly; use BeginInsert(const Query&)
-    /// to pass per-insert settings, params, and query_id. Event callbacks on the
-    /// Query are rejected (throws ValidationError): BeginInsert owns the data path.
+    /// Queries with event callbacks are not allowed.If the query has any event callbacks set, this
+    /// call throws ValidationError.
     Block BeginInsert(const Query& query);
     Block BeginInsert(const std::string& query, const std::string& query_id);
 

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -302,8 +302,10 @@ public:
     void Insert(const std::string& table_name, const std::string& query_id, const Block& block);
 
     /// Start an \p INSERT statement, insert batches of data, then finish the insert.
-    /// Use BeginInsert(const Query&) for settings, query_id, callbacks etc.
+    /// A bare string converts to a Query implicitly; use BeginInsert(const Query&)
+    /// for settings, params, callbacks etc.
     Block BeginInsert(const Query& query);
+    Block BeginInsert(const std::string& query, const std::string& query_id);
 
     /// Insert data using a \p block returned by \p BeginInsert.
     void SendInsertBlock(const Block& block);

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -303,7 +303,8 @@ public:
 
     /// Start an \p INSERT statement, insert batches of data, then finish the insert.
     /// A bare string converts to a Query implicitly; use BeginInsert(const Query&)
-    /// for settings, params, callbacks etc.
+    /// to pass per-insert settings, params, and query_id. Event callbacks on the
+    /// Query are rejected (throws ValidationError): BeginInsert owns the data path.
     Block BeginInsert(const Query& query);
     Block BeginInsert(const std::string& query, const std::string& query_id);
 

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -302,8 +302,8 @@ public:
     void Insert(const std::string& table_name, const std::string& query_id, const Block& block);
 
     /// Start an \p INSERT statement, insert batches of data, then finish the insert.
-    Block BeginInsert(const std::string& query);
-    Block BeginInsert(const std::string& query, const std::string& query_id);
+    /// Use BeginInsert(const Query&) for settings, query_id, callbacks etc.
+    Block BeginInsert(const Query& query);
 
     /// Insert data using a \p block returned by \p BeginInsert.
     void SendInsertBlock(const Block& block);

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -88,8 +88,8 @@ using ProfileCallback          = std::function<void(const Profile& profile)>;
 class Query : public QueryEvents {
 public:
      Query();
-     explicit Query(const char* query, const char* query_id = nullptr);
-     explicit Query(const std::string& query, const std::string& query_id = default_query_id);
+     Query(const char* query, const char* query_id = nullptr);
+     Query(const std::string& query, const std::string& query_id = default_query_id);
     ~Query() override;
 
     ///

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -88,8 +88,8 @@ using ProfileCallback          = std::function<void(const Profile& profile)>;
 class Query : public QueryEvents {
 public:
      Query();
-     Query(const char* query, const char* query_id = nullptr);
-     Query(const std::string& query, const std::string& query_id = default_query_id);
+     explicit Query(const char* query, const char* query_id = nullptr);
+     explicit Query(const std::string& query, const std::string& query_id = default_query_id);
     ~Query() override;
 
     ///

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -179,6 +179,14 @@ public:
         return *this;
     }
 
+    /// True if any server-event handler is installed. BeginInsert rejects such
+    /// a Query: it drives its own block-capture OnData and would otherwise let
+    /// the caller's handlers fire from the insert handshake's packet loop.
+    inline bool HasEventCallbacks() const {
+        return exception_cb_ || progress_cb_ || select_cb_ || select_cancelable_cb_
+            || select_server_log_cb_ || profile_events_callback_cb_ || profile_callback_cb_;
+    }
+
     static const std::string default_query_id;
 
 private:

--- a/clickhouse/query.h
+++ b/clickhouse/query.h
@@ -179,9 +179,7 @@ public:
         return *this;
     }
 
-    /// True if any server-event handler is installed. BeginInsert rejects such
-    /// a Query: it drives its own block-capture OnData and would otherwise let
-    /// the caller's handlers fire from the insert handshake's packet loop.
+    /// True if any server-event handler is installed.
     inline bool HasEventCallbacks() const {
         return exception_cb_ || progress_cb_ || select_cb_ || select_cancelable_cb_
             || select_server_log_cb_ || profile_events_callback_cb_ || profile_callback_cb_;

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -541,6 +541,45 @@ TEST_P(ClientCase, InsertData) {
     EXPECT_EQ(exp, row);
 }
 
+TEST_P(ClientCase, BeginInsertQuery) {
+    client_->Execute(
+            "CREATE TEMPORARY TABLE IF NOT EXISTS test_clickhouse_cpp_begin_insert_query (id UInt64)");
+
+    /// A Query carrying any event callback is rejected: BeginInsert drives its
+    /// own data path and the caller's handlers would otherwise fire from the
+    /// insert handshake's packet loop.
+    {
+        Query q("INSERT INTO test_clickhouse_cpp_begin_insert_query VALUES");
+        q.OnException([](const Exception&) {});
+        EXPECT_THROW(client_->BeginInsert(q), ValidationError);
+    }
+
+    /// A Query with per-insert settings and a query_id (no callbacks) streams
+    /// normally through the overload.
+    {
+        Query q("INSERT INTO test_clickhouse_cpp_begin_insert_query VALUES", "begin-insert-query-id");
+        q.SetSetting("max_block_size", {"100"});
+
+        auto block = client_->BeginInsert(q);
+        ASSERT_EQ(size_t(1), block.GetColumnCount());
+
+        auto id = block[0]->As<ColumnUInt64>();
+        id->Append(42);
+        block.RefreshRowCount();
+        client_->SendInsertBlock(block);
+        client_->EndInsert();
+    }
+
+    size_t row = 0;
+    client_->Select("SELECT id FROM test_clickhouse_cpp_begin_insert_query",
+        [&row](const Block& block) {
+            for (size_t c = 0; c < block.GetRowCount(); ++c, ++row) {
+                EXPECT_EQ(uint64_t(42), (*block[0]->As<ColumnUInt64>())[c]);
+            }
+        });
+    EXPECT_EQ(size_t(1), row);
+}
+
 TEST_P(ClientCase, Nullable) {
     /// Create a table.
     client_->Execute(

--- a/ut/client_ut.cpp
+++ b/ut/client_ut.cpp
@@ -541,43 +541,42 @@ TEST_P(ClientCase, InsertData) {
     EXPECT_EQ(exp, row);
 }
 
-TEST_P(ClientCase, BeginInsertQuery) {
+TEST_P(ClientCase, BeginInsertDoesNotAllowCallbacks) {
     client_->Execute(
-            "CREATE TEMPORARY TABLE IF NOT EXISTS test_clickhouse_cpp_begin_insert_query (id UInt64)");
+            "CREATE TEMPORARY TABLE IF NOT EXISTS test_clickhouse_cpp_begin_insert_callback (id UInt64)");
 
-    /// A Query carrying any event callback is rejected: BeginInsert drives its
-    /// own data path and the caller's handlers would otherwise fire from the
-    /// insert handshake's packet loop.
-    {
-        Query q("INSERT INTO test_clickhouse_cpp_begin_insert_query VALUES");
-        q.OnException([](const Exception&) {});
-        EXPECT_THROW(client_->BeginInsert(q), ValidationError);
-    }
+    Query prototype("INSERT INTO test_clickhouse_cpp_begin_insert_callback VALUES");
+    Query query = prototype;
+    client_->BeginInsert(query); // this should not throw any exceptions
+    client_->EndInsert();
 
-    /// A Query with per-insert settings and a query_id (no callbacks) streams
-    /// normally through the overload.
-    {
-        Query q("INSERT INTO test_clickhouse_cpp_begin_insert_query VALUES", "begin-insert-query-id");
-        q.SetSetting("max_block_size", {"100"});
+    query = prototype;
+    query.OnData([](const Block &){ std::terminate(); });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
 
-        auto block = client_->BeginInsert(q);
-        ASSERT_EQ(size_t(1), block.GetColumnCount());
+    query = prototype;
+    query.OnDataCancelable([](const Block &){ return false; });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
 
-        auto id = block[0]->As<ColumnUInt64>();
-        id->Append(42);
-        block.RefreshRowCount();
-        client_->SendInsertBlock(block);
-        client_->EndInsert();
-    }
+    query = prototype;
+    query.OnException([](const Exception &){ std::terminate(); });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
 
-    size_t row = 0;
-    client_->Select("SELECT id FROM test_clickhouse_cpp_begin_insert_query",
-        [&row](const Block& block) {
-            for (size_t c = 0; c < block.GetRowCount(); ++c, ++row) {
-                EXPECT_EQ(uint64_t(42), (*block[0]->As<ColumnUInt64>())[c]);
-            }
-        });
-    EXPECT_EQ(size_t(1), row);
+    query = prototype;
+    query.OnProgress([](const Progress &){ std::terminate(); });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
+
+    query = prototype;
+    query.OnServerLog([](const Block &){ return false; });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
+
+    query = prototype;
+    query.OnProfileEvents([](const Block &){ return false; });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
+
+    query = prototype;
+    query.OnProfile([](const Profile &){ return false; });
+    EXPECT_THROW(client_->BeginInsert(query), ValidationError);
 }
 
 TEST_P(ClientCase, Nullable) {


### PR DESCRIPTION
Add Block BeginInsert(const Query& query).

The Impl already supported a fully-configured Query (settings, params, query_id, OnData, etc.). The public surface only exposed the string forms.

This lets callers do proper streaming inserts with the full Query feature set (symmetric to the Query forms already available for Select/Execute).