### PR TITLE
client: add SelectWithExternalData(const Query&, ExternalTables) overload

### DIFF
--- a/clickhouse/client.cpp
+++ b/clickhouse/client.cpp
@@ -1354,6 +1354,10 @@ void Client::SelectWithExternalDataCancelable(const std::string& query, const st
     impl_->SelectWithExternalData(Query(query, query_id).OnDataCancelable(std::move(cb)), external_tables);
 }
 
+void Client::SelectWithExternalData(const Query& query, const ExternalTables& external_tables) {
+    impl_->SelectWithExternalData(query, external_tables);
+}
+
 void Client::BeginExecute(const Query& query) {
     impl_->BeginExecuteQuery(query);
 }

--- a/clickhouse/client.h
+++ b/clickhouse/client.h
@@ -270,6 +270,10 @@ public:
     void SelectWithExternalDataCancelable(const std::string& query, const ExternalTables& external_tables, SelectCancelableCallback cb);
     void SelectWithExternalDataCancelable(const std::string& query, const std::string& query_id, const ExternalTables& external_tables, SelectCancelableCallback cb);
 
+    /// Same as SelectWithExternalData but takes a fully-configured Query
+    /// (settings, params, callbacks, query_id, OnData) instead of a bare string.
+    void SelectWithExternalData(const Query& query, const ExternalTables& external_tables);
+
     /// EXPERIMENTAL. Intends for execute arbitrary queries while reading the data interactively with
     /// NextBlock().
     void BeginExecute(const Query& query);


### PR DESCRIPTION
Add void SelectWithExternalData(const Query& query, const ExternalTables& external_tables).

Same as the BeginInsert case: the Impl supported it, the public surface did not.

This completes the Query-based API for external-data selects.