### PR TITLE
Deprecate Abseil-backed 128-bit value APIs

### DIFF
--- a/clickhouse/columns/decimal.cpp
+++ b/clickhouse/columns/decimal.cpp
@@ -158,6 +158,10 @@ Int128 ColumnDecimal::At(size_t i) const {
     }
 }
 
+Int128 ColumnDecimal::operator[](size_t i) const {
+    return At(i);
+}
+
 std::string ColumnDecimal::StringAt(size_t i) const {
     auto scale = GetScale();
 

--- a/clickhouse/columns/decimal.h
+++ b/clickhouse/columns/decimal.h
@@ -14,11 +14,11 @@ public:
 
     ColumnDecimal(size_t precision, size_t scale);
 
-    void Append(const Int128& value);
+    CH_ABSEIL_BIGNUM_DEPRECATED void Append(const Int128& value);
     void Append(const std::string& value);
 
-    Int128 At(size_t i) const;
-    inline auto operator[](size_t i) const { return At(i); }
+    CH_ABSEIL_BIGNUM_DEPRECATED Int128 At(size_t i) const;
+    CH_ABSEIL_BIGNUM_DEPRECATED Int128 operator[](size_t i) const;
 
     // Returns string representation of the decimal value
     std::string StringAt(size_t i) const;

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -64,6 +64,11 @@ const T& ColumnVector<T>::At(size_t n) const {
 }
 
 template <typename T>
+const T& ColumnVector<T>::operator [] (size_t n) const {
+    return data_.at(n);
+}
+
+template <typename T>
 void ColumnVector<T>::Append(ColumnRef column) {
     if (auto col = column->As<ColumnVector<T>>()) {
         data_.insert(data_.end(), col->data_.begin(), col->data_.end());
@@ -106,6 +111,46 @@ void ColumnVector<T>::Swap(Column& other) {
 template <typename T>
 ItemView ColumnVector<T>::GetItem(size_t index) const  {
     return ItemView{type_->GetCode(), data_[index]};
+}
+
+template <>
+void ColumnVector<Int128>::Append(const Int128& value) {
+    data_.push_back(value);
+}
+
+template <>
+const Int128& ColumnVector<Int128>::At(size_t n) const {
+    return data_.at(n);
+}
+
+template <>
+const Int128& ColumnVector<Int128>::operator [] (size_t n) const {
+    return data_.at(n);
+}
+
+template <>
+std::vector<Int128>& ColumnVector<Int128>::GetWritableData() {
+    return data_;
+}
+
+template <>
+void ColumnVector<UInt128>::Append(const UInt128& value) {
+    data_.push_back(value);
+}
+
+template <>
+const UInt128& ColumnVector<UInt128>::At(size_t n) const {
+    return data_.at(n);
+}
+
+template <>
+const UInt128& ColumnVector<UInt128>::operator [] (size_t n) const {
+    return data_.at(n);
+}
+
+template <>
+std::vector<UInt128>& ColumnVector<UInt128>::GetWritableData() {
+    return data_;
 }
 
 template class ColumnVector<int8_t>;

--- a/clickhouse/columns/numeric.h
+++ b/clickhouse/columns/numeric.h
@@ -28,7 +28,7 @@ public:
     const T& At(size_t n) const;
 
     /// Returns element at given row number.
-    inline const T& operator [] (size_t n) const { return At(n); }
+    const T& operator [] (size_t n) const;
 
     void Erase(size_t pos, size_t count = 1);
 
@@ -79,5 +79,23 @@ using ColumnInt128  = ColumnVector<Int128>;
 
 using ColumnFloat32 = ColumnVector<float>;
 using ColumnFloat64 = ColumnVector<double>;
+
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED void ColumnVector<Int128>::Append(const Int128& value);
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED const Int128& ColumnVector<Int128>::At(size_t n) const;
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED const Int128& ColumnVector<Int128>::operator [] (size_t n) const;
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED std::vector<Int128>& ColumnVector<Int128>::GetWritableData();
+
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED void ColumnVector<UInt128>::Append(const UInt128& value);
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED const UInt128& ColumnVector<UInt128>::At(size_t n) const;
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED const UInt128& ColumnVector<UInt128>::operator [] (size_t n) const;
+template <>
+CH_ABSEIL_BIGNUM_DEPRECATED std::vector<UInt128>& ColumnVector<UInt128>::GetWritableData();
 
 }

--- a/clickhouse/types/bignum.h
+++ b/clickhouse/types/bignum.h
@@ -4,6 +4,13 @@
 #include <string>
 #include <string_view>
 
+#if CH_USE_ABSEIL_FOR_BIGNUM
+#define CH_ABSEIL_BIGNUM_DEPRECATED \
+    [[deprecated("clickhouse-cpp Abseil-backed Int128/UInt128 APIs are deprecated and will be removed soon; configure with -DCH_USE_ABSEIL_FOR_BIGNUM=OFF to use the non-Abseil implementation.")]]
+#else
+#define CH_ABSEIL_BIGNUM_DEPRECATED
+#endif
+
 
  #if defined(__SIZEOF_INT128__)                                                                       
  #define CH_CPP_HAS_INT128 1                                                                  
@@ -157,36 +164,36 @@ namespace clickhouse {
 class Bignum {
 public:
 
-    static Int128 StringToInt128(std::string_view str);
-    static UInt128 StringToUInt128(std::string_view str);
+    CH_ABSEIL_BIGNUM_DEPRECATED static Int128 StringToInt128(std::string_view str);
+    CH_ABSEIL_BIGNUM_DEPRECATED static UInt128 StringToUInt128(std::string_view str);
 
-    static std::string Int128ToString(const Int128 x);
-    static std::string UInt128ToString(const UInt128 x);
+    CH_ABSEIL_BIGNUM_DEPRECATED static std::string Int128ToString(const Int128 x);
+    CH_ABSEIL_BIGNUM_DEPRECATED static std::string UInt128ToString(const UInt128 x);
 
 
 #if CH_USE_ABSEIL_FOR_BIGNUM
 
-    static inline Int128 MakeInt128(int64_t hi, uint64_t lo) {
+    CH_ABSEIL_BIGNUM_DEPRECATED static inline Int128 MakeInt128(int64_t hi, uint64_t lo) {
         return absl::MakeInt128(hi, lo);
     }
 
-    static inline UInt128 MakeUInt128(uint64_t hi, uint64_t lo) {
+    CH_ABSEIL_BIGNUM_DEPRECATED static inline UInt128 MakeUInt128(uint64_t hi, uint64_t lo) {
         return absl::MakeUint128(hi, lo);
     }
 
-    static inline uint64_t Int128Low64(Int128 v) {
+    CH_ABSEIL_BIGNUM_DEPRECATED static inline uint64_t Int128Low64(Int128 v) {
         return absl::Int128Low64(v);
     }
 
-    static inline int64_t Int128High64(Int128 v) {
+    CH_ABSEIL_BIGNUM_DEPRECATED static inline int64_t Int128High64(Int128 v) {
         return absl::Int128High64(v);
     }
 
-    static inline uint64_t UInt128Low64(UInt128 v) {
+    CH_ABSEIL_BIGNUM_DEPRECATED static inline uint64_t UInt128Low64(UInt128 v) {
         return absl::Uint128Low64(v);
     }
 
-    static inline uint64_t UInt128High64(UInt128 v) {
+    CH_ABSEIL_BIGNUM_DEPRECATED static inline uint64_t UInt128High64(UInt128 v) {
         return absl::Uint128High64(v);
     }
 


### PR DESCRIPTION
Add conditional deprecation warnings for public APIs that pass, return, or expose Int128/UInt128 values when clickhouse-cpp is built with CH_USE_ABSEIL_FOR_BIGNUM enabled.

The Int128/UInt128 aliases themselves are not deprecated to avoid warnings for plain declarations. Instead, warnings are emitted at value-facing API use sites, including Bignum helpers, Decimal Int128 accessors, Type::CreateSimple specializations, and ColumnVector<Int128>/ColumnVector<UInt128> value accessors.

Users can opt into the future non-Abseil implementation with: -DCH_USE_ABSEIL_FOR_BIGNUM=OFF