### PR TITLE
Typed column access with `As<>` / `AsStrict<>`

### DIFF
--- a/clickhouse/columns/array.cpp
+++ b/clickhouse/columns/array.cpp
@@ -138,8 +138,11 @@ size_t ColumnArray::Size() const {
 
 void ColumnArray::Swap(Column& other) {
     auto & col = dynamic_cast<ColumnArray &>(other);
-    data_.swap(col.data_);
-    offsets_.swap(col.offsets_);
+    // Swap sub-column CONTENTS in place (never rebind the shared_ptr slots), so the data and
+    // offsets objects keep their identity and any As<>/Wrap views of this column stay coherent.
+    // The nested Swap also type-checks the element columns and throws on a mismatch.
+    data_->Swap(*col.data_);
+    offsets_->Swap(*col.offsets_);
 }
 
 void ColumnArray::OffsetsIncrease(size_t n) {

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -128,26 +128,28 @@ public:
         : ColumnArrayT(std::make_shared<NestedColumnType>(std::forward<Args>(args)...))
     {}
 
-    /** Create a ColumnArrayT from a ColumnArray, without copying data and offsets, but by 'stealing' those from `col`.
+    /** Create a ColumnArrayT that SHARES the internals of `col` (nested data and
+     *  offsets) via shared_ptr, WITHOUT stealing or copying them.
      *
-     *  Ownership of column internals is transferred to returned object, original (argument) object
-     *  MUST NOT BE USED IN ANY WAY, it is only safe to dispose it.
+     *  The original `col` remains fully valid and usable. Both the original and the
+     *  returned wrapper reference the same underlying columns, so mutations through
+     *  one are visible through the other.
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col in this case.
-     *  This is a static method to make such conversion verbose.
+     *  Throws an exception if `col` is of wrong type, it is safe to use original col
+     *  in this case. This is a static method to make such conversion verbose.
      */
-    static auto Wrap(ColumnArray&& col) {
-        auto nested_data = WrapColumn<NestedColumnType>(col.GetData());
+    static auto Wrap(const ColumnArray& col) {
+        auto nested_data = WrapColumn<NestedColumnType>(ColumnRef{col.data_});
         return std::make_shared<ColumnArrayT<NestedColumnType>>(nested_data, col.offsets_);
     }
 
-    static auto Wrap(Column&& col) {
-        return Wrap(std::move(dynamic_cast<ColumnArray&&>(col)));
+    static auto Wrap(const Column& col) {
+        return Wrap(dynamic_cast<const ColumnArray&>(col));
     }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(ColumnRef&& col) {
-        return Wrap(std::move(*col->AsStrict<ColumnArray>()));
+    static auto Wrap(const ColumnRef& col) {
+        return Wrap(*col->AsStrict<ColumnArray>());
     }
 
     /// A single (row) value of the Array-column, i.e. readonly array of items.

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -150,7 +150,9 @@ public:
         if (auto* c = dynamic_cast<const ColumnArray*>(&col)) {
             return Wrap(*c, error);
         }
-        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Array");
+        if (error) {
+            *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Array");
+        }
         return nullptr;
     }
 
@@ -162,14 +164,18 @@ public:
     static auto Wrap(const ColumnArray& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
     static auto Wrap(const Column& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
@@ -177,7 +183,9 @@ public:
     static auto Wrap(const ColumnRef& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -106,7 +106,7 @@ private:
 };
 
 template <typename ColumnType>
-class ColumnArrayT : public ColumnArray {
+class ColumnArrayT : public ColumnArray, public WrappableColumn<ColumnArrayT<ColumnType>, ColumnArray> {
 public:
     class ArrayValueView;
     using ValueType = ArrayValueView;
@@ -161,33 +161,8 @@ public:
         return Wrap(*col, error);
     }
 
-    static auto Wrap(const ColumnArray& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    static auto Wrap(const Column& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
+    // Throwing single-argument overloads (concrete type / Column& / ColumnRef&).
+    using WrappableColumn<ColumnArrayT<ColumnType>, ColumnArray>::Wrap;
 
     /// A single (row) value of the Array-column, i.e. readonly array of items.
     class ArrayValueView {

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -326,8 +326,9 @@ public:
 
     void Swap(Column& other) override {
         auto & col = dynamic_cast<ColumnArrayT<NestedColumnType> &>(other);
-        typed_nested_data_.swap(col.typed_nested_data_);
-        ColumnArray::Swap(other);
+        // Base swaps sub-column contents in place, preserving object identity, so the cached
+        // typed_nested_data_ still points at the correct object and must NOT be repointed.
+        ColumnArray::Swap(col);
     }
 
 private:

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -135,21 +135,51 @@ public:
      *  returned wrapper reference the same underlying columns, so mutations through
      *  one are visible through the other.
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col
-     *  in this case. This is a static method to make such conversion verbose.
+     *  The two-argument overloads are non-throwing: on a type mismatch they return
+     *  nullptr and, if `error` is non-null, assign a description to `*error`. The
+     *  single-argument overloads throw ValidationError on a type mismatch instead.
      */
-    static auto Wrap(const ColumnArray& col) {
-        auto nested_data = WrapColumn<NestedColumnType>(col.data_);
+    static std::shared_ptr<ColumnArrayT<NestedColumnType>> Wrap(const ColumnArray& col, ValidationError* error) {
+        auto nested_data = WrapColumn<NestedColumnType>(col.data_, error);
+        if (!nested_data) {
+            return nullptr;
+        }
         return std::make_shared<ColumnArrayT<NestedColumnType>>(nested_data, col.offsets_);
     }
 
+    static std::shared_ptr<ColumnArrayT<NestedColumnType>> Wrap(const Column& col, ValidationError* error) {
+        if (auto* c = dynamic_cast<const ColumnArray*>(&col)) {
+            return Wrap(*c, error);
+        }
+        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Array");
+        return nullptr;
+    }
+
+    // Helper to simplify integration with other APIs
+    static std::shared_ptr<ColumnArrayT<NestedColumnType>> Wrap(const ColumnRef& col, ValidationError* error) {
+        return Wrap(*col, error);
+    }
+
+    static auto Wrap(const ColumnArray& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
     static auto Wrap(const Column& col) {
-        return Wrap(dynamic_cast<const ColumnArray&>(col));
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
     }
 
     // Helper to simplify integration with other APIs
     static auto Wrap(const ColumnRef& col) {
-        return Wrap(*col->AsStrict<ColumnArray>());
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
     }
 
     /// A single (row) value of the Array-column, i.e. readonly array of items.

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -2,7 +2,6 @@
 
 #include "column.h"
 #include "numeric.h"
-#include "utils.h"
 
 #include <memory>
 

--- a/clickhouse/columns/array.h
+++ b/clickhouse/columns/array.h
@@ -139,7 +139,7 @@ public:
      *  in this case. This is a static method to make such conversion verbose.
      */
     static auto Wrap(const ColumnArray& col) {
-        auto nested_data = WrapColumn<NestedColumnType>(ColumnRef{col.data_});
+        auto nested_data = WrapColumn<NestedColumnType>(col.data_);
         return std::make_shared<ColumnArrayT<NestedColumnType>>(nested_data, col.offsets_);
     }
 

--- a/clickhouse/columns/column.h
+++ b/clickhouse/columns/column.h
@@ -26,26 +26,25 @@ public:
     virtual ~Column() {}
 
     /// Downcast pointer to the specific column's subtype.
+    ///
+    /// If T is a "wrappable" typed column (one exposing a static Wrap method, e.g.
+    /// ColumnArrayT/ColumnTupleT/ColumnMapT/ColumnNullableT/ColumnLowCardinalityT) and the
+    /// column is not already exactly T, this attempts to Wrap it as T (a storage-sharing
+    /// typed view). Returns nullptr when neither an exact cast nor a wrap is possible.
+    /// (Definitions are out-of-line below, after WrapColumn is declared.)
     template <typename T>
-    inline std::shared_ptr<T> As() {
-        return std::dynamic_pointer_cast<T>(shared_from_this());
-    }
+    inline std::shared_ptr<T> As();
 
-    /// Downcast pointer to the specific column's subtype.
+    /// Const overload. Unlike the non-const As(), this does NOT wrap: it only performs an
+    /// exact downcast and returns nullptr on mismatch (even for a wrappable T). Wrapping is
+    /// intentionally disabled here because it would synthesize a mutable, storage-sharing
+    /// view from a const column (requiring a const_cast), which is not const-correct.
     template <typename T>
-    inline std::shared_ptr<const T> As() const {
-        return std::dynamic_pointer_cast<const T>(shared_from_this());
-    }
+    inline std::shared_ptr<const T> As() const;
 
-    /// Downcast pointer to the specific column's subtype.
+    /// Like As(), but throws ValidationError instead of returning nullptr on failure.
     template <typename T>
-    inline std::shared_ptr<T> AsStrict() {
-        auto result = std::dynamic_pointer_cast<T>(shared_from_this());
-        if (!result) {
-            throw ValidationError("Can't cast from " + type_->GetName());
-        }
-        return result;
-    }
+    inline std::shared_ptr<T> AsStrict();
 
     /// Get type object of the column.
     inline TypeRef Type() const { return type_; }
@@ -153,6 +152,40 @@ inline std::shared_ptr<T> WrapColumn(const ColumnRef& column) {
         throw error;
     }
     return result;
+}
+
+template <typename T>
+inline std::shared_ptr<T> Column::As() {
+    if constexpr (HasWrapMethod<T>::value) {
+        if (auto exact = std::dynamic_pointer_cast<T>(shared_from_this())) {
+            return exact;
+        }
+        return WrapColumn<T>(shared_from_this(), nullptr);
+    } else {
+        return std::dynamic_pointer_cast<T>(shared_from_this());
+    }
+}
+
+template <typename T>
+inline std::shared_ptr<const T> Column::As() const {
+    // No wrapping for the const overload (see declaration): exact downcast only.
+    return std::dynamic_pointer_cast<const T>(shared_from_this());
+}
+
+template <typename T>
+inline std::shared_ptr<T> Column::AsStrict() {
+    if constexpr (HasWrapMethod<T>::value) {
+        if (auto exact = std::dynamic_pointer_cast<T>(shared_from_this())) {
+            return exact;
+        }
+        return WrapColumn<T>(shared_from_this());
+    } else {
+        auto result = std::dynamic_pointer_cast<T>(shared_from_this());
+        if (!result) {
+            throw ValidationError("Can't cast from " + type_->GetName());
+        }
+        return result;
+    }
 }
 
 }  // namespace clickhouse

--- a/clickhouse/columns/column.h
+++ b/clickhouse/columns/column.h
@@ -154,6 +154,40 @@ inline std::shared_ptr<T> WrapColumn(const ColumnRef& column) {
     return result;
 }
 
+// Provides the throwing single-argument Wrap overloads for typed columns.
+// Derived must supply the non-throwing two-argument Wrap(col, ValidationError*) overloads.
+// BaseColumn is Derived's concrete base (e.g. ColumnArray) so an already-typed
+// argument takes the direct path instead of the dynamic_cast'ing Column& overload.
+template <typename Derived, typename BaseColumn>
+struct WrappableColumn {
+    static auto Wrap(const BaseColumn& col) {
+        ValidationError error;
+        auto result = Derived::Wrap(col, &error);
+        if (!result) {
+            throw error;
+        }
+        return result;
+    }
+
+    static auto Wrap(const Column& col) {
+        ValidationError error;
+        auto result = Derived::Wrap(col, &error);
+        if (!result) {
+            throw error;
+        }
+        return result;
+    }
+
+    static auto Wrap(const ColumnRef& col) {
+        ValidationError error;
+        auto result = Derived::Wrap(col, &error);
+        if (!result) {
+            throw error;
+        }
+        return result;
+    }
+};
+
 template <typename T>
 inline std::shared_ptr<T> Column::As() {
     if constexpr (HasWrapMethod<T>::value) {

--- a/clickhouse/columns/column.h
+++ b/clickhouse/columns/column.h
@@ -4,8 +4,10 @@
 #include "../columns/itemview.h"
 #include "../exceptions.h"
 
+#include <algorithm>
 #include <memory>
 #include <stdexcept>
+#include <vector>
 
 namespace clickhouse {
 
@@ -103,5 +105,54 @@ public:
 protected:
     TypeRef type_;
 };
+
+template <typename T>
+std::vector<T> SliceVector(const std::vector<T>& vec, size_t begin, size_t len) {
+    std::vector<T> result;
+
+    if (begin < vec.size()) {
+        len = std::min(len, vec.size() - begin);
+        result.assign(vec.begin() + begin, vec.begin() + (begin + len));
+    }
+
+    return result;
+}
+
+template <typename T>
+struct HasWrapMethod {
+private:
+    static int detect(...);
+    template <typename U>
+    static decltype(U::Wrap(std::move(std::declval<ColumnRef>()))) detect(const U&);
+
+public:
+    static constexpr bool value = !std::is_same<int, decltype(detect(std::declval<T>()))>::value;
+};
+
+// Non-throwing: returns nullptr and (if `error` is non-null) fills `*error` when `column`
+// can't be wrapped as T.
+template <typename T>
+inline std::shared_ptr<T> WrapColumn(const ColumnRef& column, ValidationError* error) {
+    if constexpr (HasWrapMethod<T>::value) {
+        return T::Wrap(column, error);
+    } else {
+        auto result = column->template As<T>();
+        if (!result && error) {
+            *error = ValidationError("Can't wrap column of type " + column->GetType().GetName());
+        }
+        return result;
+    }
+}
+
+// Throwing convenience wrapper.
+template <typename T>
+inline std::shared_ptr<T> WrapColumn(const ColumnRef& column) {
+    ValidationError error;
+    auto result = WrapColumn<T>(column, &error);
+    if (!result) {
+        throw error;
+    }
+    return result;
+}
 
 }  // namespace clickhouse

--- a/clickhouse/columns/column.h
+++ b/clickhouse/columns/column.h
@@ -35,16 +35,23 @@ public:
     template <typename T>
     inline std::shared_ptr<T> As();
 
-    /// Const overload. Unlike the non-const As(), this does NOT wrap: it only performs an
-    /// exact downcast and returns nullptr on mismatch (even for a wrappable T). Wrapping is
-    /// intentionally disabled here because it would synthesize a mutable, storage-sharing
-    /// view from a const column (requiring a const_cast), which is not const-correct.
+    /// Const overload. Behaves like the non-const As(): for a wrappable T it first tries an
+    /// exact downcast, then falls back to Wrap, returning a storage-sharing view typed as
+    /// shared_ptr<const T> (read-only surface). Wrapping never mutates the source column; it
+    /// does require an internal const_pointer_cast because Wrap builds a mutable wrapper.
+    /// Caveat: the read-only guarantee is shallow -- the wrapper still holds non-const
+    /// references to the shared sub-columns, so a deliberate const_pointer_cast<T> could
+    /// still reach the underlying storage. Casual const use stays read-only.
     template <typename T>
     inline std::shared_ptr<const T> As() const;
 
     /// Like As(), but throws ValidationError instead of returning nullptr on failure.
     template <typename T>
     inline std::shared_ptr<T> AsStrict();
+
+    /// Const overload of AsStrict(); wraps like As() const and throws on failure.
+    template <typename T>
+    inline std::shared_ptr<const T> AsStrict() const;
 
     /// Get type object of the column.
     inline TypeRef Type() const { return type_; }
@@ -202,8 +209,17 @@ inline std::shared_ptr<T> Column::As() {
 
 template <typename T>
 inline std::shared_ptr<const T> Column::As() const {
-    // No wrapping for the const overload (see declaration): exact downcast only.
-    return std::dynamic_pointer_cast<const T>(shared_from_this());
+    if constexpr (HasWrapMethod<T>::value) {
+        if (auto exact = std::dynamic_pointer_cast<const T>(shared_from_this())) {
+            return exact;
+        }
+        // Wrap needs a mutable ColumnRef to build a storage-sharing view; the result is
+        // returned as shared_ptr<const T> so the caller keeps read-only access, and
+        // wrapping never mutates the source column.
+        return WrapColumn<T>(std::const_pointer_cast<Column>(shared_from_this()), nullptr);
+    } else {
+        return std::dynamic_pointer_cast<const T>(shared_from_this());
+    }
 }
 
 template <typename T>
@@ -215,6 +231,23 @@ inline std::shared_ptr<T> Column::AsStrict() {
         return WrapColumn<T>(shared_from_this());
     } else {
         auto result = std::dynamic_pointer_cast<T>(shared_from_this());
+        if (!result) {
+            throw ValidationError("Can't cast from " + type_->GetName());
+        }
+        return result;
+    }
+}
+
+template <typename T>
+inline std::shared_ptr<const T> Column::AsStrict() const {
+    if constexpr (HasWrapMethod<T>::value) {
+        if (auto exact = std::dynamic_pointer_cast<const T>(shared_from_this())) {
+            return exact;
+        }
+        // Throwing WrapColumn: raises ValidationError on a type mismatch.
+        return WrapColumn<T>(std::const_pointer_cast<Column>(shared_from_this()));
+    } else {
+        auto result = std::dynamic_pointer_cast<const T>(shared_from_this());
         if (!result) {
             throw ValidationError("Can't cast from " + type_->GetName());
         }

--- a/clickhouse/columns/enum.cpp
+++ b/clickhouse/columns/enum.cpp
@@ -1,5 +1,4 @@
 #include "enum.h"
-#include "utils.h"
 
 #include "../base/input.h"
 #include "../base/output.h"

--- a/clickhouse/columns/factory.cpp
+++ b/clickhouse/columns/factory.cpp
@@ -233,13 +233,25 @@ static ColumnRef CreateColumnFromAst(const TypeAst& ast, CreateColumnByTypeSetti
                 }
             }
             else {
+                // Create the base ColumnLowCardinality (like Array/Nullable/Tuple/Map create their
+                // base types). Callers can obtain the strongly-typed ColumnLowCardinalityT<...> view
+                // on demand via Column::As<ColumnLowCardinalityT<...>>(), which wraps it.
                 switch (nested.code) {
-                    // TODO (nemkov): update this to maximize code reuse.
                     case Type::String:
-                        return std::make_shared<ColumnLowCardinalityT<ColumnString>>();
                     case Type::FixedString:
-                        return std::make_shared<ColumnLowCardinalityT<ColumnFixedString>>(GetASTChildElement(nested, 0).value);
+                        return std::make_shared<ColumnLowCardinality>(CreateColumnFromAst(nested, settings));
                     case Type::Nullable:
+                        // Nullable needs its own case (it can't reuse the generic CreateColumnFromAst
+                        // path above) for two reasons:
+                        //   1. Constructor overload: ColumnLowCardinality has a dedicated
+                        //      ColumnLowCardinality(shared_ptr<ColumnNullable>) ctor that seeds the
+                        //      special NULL item at dictionary index 0 (via AppendNullItem()). We must
+                        //      pass a statically-typed shared_ptr<ColumnNullable> so that overload is
+                        //      selected; passing a ColumnRef would statically bind to the generic
+                        //      ColumnLowCardinality(ColumnRef) ctor, which only appends the default
+                        //      item and would omit the null item, producing an incorrect nullable
+                        //      dictionary.
+                        //   2. It lets us construct the ColumnNullable with an explicit UInt8 null-map.
                         return std::make_shared<ColumnLowCardinality>(
                             std::make_shared<ColumnNullable>(
                                 CreateColumnFromAst(GetASTChildElement(nested, 0), settings),

--- a/clickhouse/columns/geo.cpp
+++ b/clickhouse/columns/geo.cpp
@@ -1,7 +1,5 @@
 #include "geo.h"
 
-#include "utils.h"
-
 namespace {
 using namespace ::clickhouse;
 

--- a/clickhouse/columns/lowcardinality.cpp
+++ b/clickhouse/columns/lowcardinality.cpp
@@ -159,6 +159,7 @@ ColumnLowCardinality::ColumnLowCardinality(ColumnRef dictionary_column)
     : Column(Type::CreateLowCardinality(dictionary_column->Type())),
       dictionary_column_(dictionary_column->CloneEmpty()), // safe way to get an column of the same type.
       index_column_(std::make_shared<ColumnUInt32>()),
+      unique_items_map_(std::make_shared<UniqueItems>()),
       index_type_code_(Type::UInt32)
 {
     Setup(dictionary_column);
@@ -168,6 +169,7 @@ ColumnLowCardinality::ColumnLowCardinality(std::shared_ptr<ColumnNullable> dicti
     : Column(Type::CreateLowCardinality(dictionary_column->Type())),
       dictionary_column_(dictionary_column->CloneEmpty()), // safe way to get an column of the same type.
       index_column_(std::make_shared<ColumnUInt32>()),
+      unique_items_map_(std::make_shared<UniqueItems>()),
       index_type_code_(Type::UInt32)
 {
     AppendNullItem();
@@ -381,7 +383,7 @@ bool ColumnLowCardinality::LoadBody(InputStream* input, size_t rows) {
 
         dictionary_column_->Swap(*new_dictionary);
         index_column_.swap(new_index);
-        unique_items_map_.swap(new_unique_items_map);
+        unique_items_map_->swap(new_unique_items_map);
         index_type_code_ = index_column_->Type()->GetCode();
 
         return true;
@@ -418,7 +420,7 @@ void ColumnLowCardinality::SaveBody(OutputStream* output) {
 void ColumnLowCardinality::Clear() {
     index_column_->Clear();
     dictionary_column_->Clear();
-    unique_items_map_.clear();
+    unique_items_map_->clear();
 
     if (auto columnNullable = dictionary_column_->As<ColumnNullable>()) {
         AppendNullItem();
@@ -457,7 +459,7 @@ void ColumnLowCardinality::Swap(Column& other) {
     dictionary_column_->Swap(*col.dictionary_column_);
 
     index_column_.swap(col.index_column_);
-    unique_items_map_.swap(col.unique_items_map_);
+    unique_items_map_->swap(*col.unique_items_map_);
     std::swap(index_type_code_, col.index_type_code_);
 }
 
@@ -480,7 +482,7 @@ void ColumnLowCardinality::AppendUnsafe(const ItemView & value) {
     const auto key = computeHashKey(value);
     const auto initial_index_size = index_column_->Size();
     // If the value is unique, then we are going to append it to a dictionary, hence new index is Size().
-    auto [iterator, is_new_item] = unique_items_map_.try_emplace(key, dictionary_column_->Size());
+    auto [iterator, is_new_item] = unique_items_map_->try_emplace(key, dictionary_column_->Size());
     try {
         // Order is important, adding to dictionary last, since it is much (MUCH!!!!) harder
         // to remove item from dictionary column than from index column
@@ -497,7 +499,7 @@ void ColumnLowCardinality::AppendUnsafe(const ItemView & value) {
         if (index_column_->Size() != initial_index_size)
             removeLastIndex();
         if (is_new_item)
-            unique_items_map_.erase(iterator);
+            unique_items_map_->erase(iterator);
 
         throw;
     }
@@ -507,13 +509,13 @@ void ColumnLowCardinality::AppendNullItem()
 {
     const auto null_item = GetNullItemForDictionary(dictionary_column_);
     AppendToDictionary(*dictionary_column_, null_item);
-    unique_items_map_.emplace(computeHashKey(null_item), 0);
+    unique_items_map_->emplace(computeHashKey(null_item), 0);
 }
 
 void ColumnLowCardinality::AppendDefaultItem()
 {
     const auto defaultItem = GetDefaultItemForDictionary(dictionary_column_);
-    unique_items_map_.emplace(computeHashKey(defaultItem), dictionary_column_->Size());
+    unique_items_map_->emplace(computeHashKey(defaultItem), dictionary_column_->Size());
     AppendToDictionary(*dictionary_column_, defaultItem);
 }
 

--- a/clickhouse/columns/lowcardinality.cpp
+++ b/clickhouse/columns/lowcardinality.cpp
@@ -158,9 +158,8 @@ namespace clickhouse {
 ColumnLowCardinality::ColumnLowCardinality(ColumnRef dictionary_column)
     : Column(Type::CreateLowCardinality(dictionary_column->Type())),
       dictionary_column_(dictionary_column->CloneEmpty()), // safe way to get an column of the same type.
-      index_column_(std::make_shared<ColumnUInt32>()),
-      unique_items_map_(std::make_shared<UniqueItems>()),
-      index_type_code_(Type::UInt32)
+      index_(std::make_shared<IndexState>(IndexState{std::make_shared<ColumnUInt32>(), Type::UInt32})),
+      unique_items_map_(std::make_shared<UniqueItems>())
 {
     Setup(dictionary_column);
 }
@@ -168,9 +167,8 @@ ColumnLowCardinality::ColumnLowCardinality(ColumnRef dictionary_column)
 ColumnLowCardinality::ColumnLowCardinality(std::shared_ptr<ColumnNullable> dictionary_column)
     : Column(Type::CreateLowCardinality(dictionary_column->Type())),
       dictionary_column_(dictionary_column->CloneEmpty()), // safe way to get an column of the same type.
-      index_column_(std::make_shared<ColumnUInt32>()),
-      unique_items_map_(std::make_shared<UniqueItems>()),
-      index_type_code_(Type::UInt32)
+      index_(std::make_shared<IndexState>(IndexState{std::make_shared<ColumnUInt32>(), Type::UInt32})),
+      unique_items_map_(std::make_shared<UniqueItems>())
 {
     AppendNullItem();
     Setup(dictionary_column);
@@ -184,7 +182,7 @@ void ColumnLowCardinality::Reserve(size_t new_cap) {
     // NOTE(vnemkov): Formula below (`ceil(sqrt(x))`) is a gut-feeling-good-enough estimation,
     // feel free to replace/adjust if you have better one suported by actual data.
     dictionary_column_->Reserve(static_cast<size_t>(ceil(sqrt(static_cast<double>(new_cap)))));    
-    index_column_->Reserve(new_cap + 2); // + 1 for null item (at pos 0), + 1 for default item (at pos 1)
+    index_->column->Reserve(new_cap + 2); // + 1 for null item (at pos 0), + 1 for default item (at pos 1)
 }
 
 void ColumnLowCardinality::Setup(ColumnRef dictionary_column) {
@@ -200,7 +198,7 @@ void ColumnLowCardinality::Setup(ColumnRef dictionary_column) {
     AppendDefaultItem();
 
     if (dictionary_column->Size() != 0) {
-        // Add values, updating index_column_ and unique_items_map_.
+        // Add values, updating the index column and unique_items_map_.
 
         // TODO: it would be possible to eliminate copying
         // by adding InsertUnsafe(pos, ItemView) method to a Column
@@ -213,15 +211,15 @@ void ColumnLowCardinality::Setup(ColumnRef dictionary_column) {
 }
 
 std::uint64_t ColumnLowCardinality::getDictionaryIndex(std::uint64_t item_index) const {
-    switch (index_type_code_) {
+    switch (index_->type_code) {
         case Type::UInt8:
-            return static_cast<const ColumnUInt8&>(*index_column_)[item_index];
+            return static_cast<const ColumnUInt8&>(*index_->column)[item_index];
         case Type::UInt16:
-            return static_cast<const ColumnUInt16&>(*index_column_)[item_index];
+            return static_cast<const ColumnUInt16&>(*index_->column)[item_index];
         case Type::UInt32:
-            return static_cast<const ColumnUInt32&>(*index_column_)[item_index];
+            return static_cast<const ColumnUInt32&>(*index_->column)[item_index];
         case Type::UInt64:
-            return static_cast<const ColumnUInt64&>(*index_column_)[item_index];
+            return static_cast<const ColumnUInt64&>(*index_->column)[item_index];
         default:
             throw ValidationError("Invalid index column type");
     }
@@ -229,18 +227,18 @@ std::uint64_t ColumnLowCardinality::getDictionaryIndex(std::uint64_t item_index)
 
 void ColumnLowCardinality::appendIndex(std::uint64_t item_index) {
     // TODO (nemkov): handle case when index should go from UInt8 to UInt16, etc.
-    switch (index_type_code_) {
+    switch (index_->type_code) {
         case Type::UInt8:
-            static_cast<ColumnUInt8&>(*index_column_).Append(static_cast<uint8_t>(item_index));
+            static_cast<ColumnUInt8&>(*index_->column).Append(static_cast<uint8_t>(item_index));
             break;
         case Type::UInt16:
-            static_cast<ColumnUInt16&>(*index_column_).Append(static_cast<uint16_t>(item_index));
+            static_cast<ColumnUInt16&>(*index_->column).Append(static_cast<uint16_t>(item_index));
             break;
         case Type::UInt32:
-            static_cast<ColumnUInt32&>(*index_column_).Append(static_cast<uint32_t>(item_index));
+            static_cast<ColumnUInt32&>(*index_->column).Append(static_cast<uint32_t>(item_index));
             break;
         case Type::UInt64:
-            static_cast<ColumnUInt64&>(*index_column_).Append(static_cast<uint64_t>(item_index));
+            static_cast<ColumnUInt64&>(*index_->column).Append(static_cast<uint64_t>(item_index));
             break;
         default:
             throw ValidationError("Invalid index column type");
@@ -248,24 +246,24 @@ void ColumnLowCardinality::appendIndex(std::uint64_t item_index) {
 }
 
 void ColumnLowCardinality::removeLastIndex() {
-    switch (index_type_code_) {
+    switch (index_->type_code) {
         case Type::UInt8: {
-            auto& col = static_cast<ColumnUInt8&>(*index_column_);
+            auto& col = static_cast<ColumnUInt8&>(*index_->column);
             col.Erase(col.Size() - 1);
             break;
         }
         case Type::UInt16: {
-            auto& col = static_cast<ColumnUInt16&>(*index_column_);
+            auto& col = static_cast<ColumnUInt16&>(*index_->column);
             col.Erase(col.Size() - 1);
             break;
         }
         case Type::UInt32: {
-            auto& col = static_cast<ColumnUInt32&>(*index_column_);
+            auto& col = static_cast<ColumnUInt32&>(*index_->column);
             col.Erase(col.Size() - 1);
             break;
         }
         case Type::UInt64: {
-            auto& col = static_cast<ColumnUInt64&>(*index_column_);
+            auto& col = static_cast<ColumnUInt64&>(*index_->column);
             col.Erase(col.Size() - 1);
             break;
         }
@@ -391,9 +389,11 @@ bool ColumnLowCardinality::LoadBody(InputStream* input, size_t rows) {
         auto [new_dictionary, new_index, new_unique_items_map] = ::Load(dictionary_column_->CloneEmpty(), *input, rows);
 
         dictionary_column_->Swap(*new_dictionary);
-        index_column_.swap(new_index);
+        // Reassign the index column inside the SHARED bundle (not a local member slot) so the
+        // new index and its type code are visible through every wrapped view.
+        index_->column = std::move(new_index);
+        index_->type_code = index_->column->Type()->GetCode();
         unique_items_map_->swap(new_unique_items_map);
-        index_type_code_ = index_column_->Type()->GetCode();
 
         return true;
     } catch (...) {
@@ -408,7 +408,7 @@ void ColumnLowCardinality::SavePrefix(OutputStream* output) {
 
 void ColumnLowCardinality::SaveBody(OutputStream* output) {
     const uint64_t index_serialization_type =
-        static_cast<uint64_t>(indexTypeFromIndexColumn(*index_column_)) | IndexFlag::HasAdditionalKeysBit;
+        static_cast<uint64_t>(indexTypeFromIndexColumn(*index_->column)) | IndexFlag::HasAdditionalKeysBit;
     WireFormat::WriteFixed(*output, index_serialization_type);
 
     const uint64_t number_of_keys = dictionary_column_->Size();
@@ -420,14 +420,14 @@ void ColumnLowCardinality::SaveBody(OutputStream* output) {
         dictionary_column_->SaveBody(output);
     }
 
-    const uint64_t number_of_rows = index_column_->Size();
+    const uint64_t number_of_rows = index_->column->Size();
     WireFormat::WriteFixed(*output, number_of_rows);
 
-    index_column_->SaveBody(output);
+    index_->column->SaveBody(output);
 }
 
 void ColumnLowCardinality::Clear() {
-    index_column_->Clear();
+    index_->column->Clear();
     dictionary_column_->Clear();
     unique_items_map_->clear();
 
@@ -438,7 +438,7 @@ void ColumnLowCardinality::Clear() {
 }
 
 size_t ColumnLowCardinality::Size() const {
-    return index_column_->Size();
+    return index_->column->Size();
 }
 
 ColumnRef ColumnLowCardinality::Slice(size_t begin, size_t len) const {
@@ -467,9 +467,16 @@ void ColumnLowCardinality::Swap(Column& other) {
     // (needed for ColumnLowCardinalityT)
     dictionary_column_->Swap(*col.dictionary_column_);
 
-    index_column_.swap(col.index_column_);
+    // Swap the index bundle CONTENTS (column + type code) in place. Both sides' wrapped views
+    // share their respective IndexState object, so the swap is visible through every holder.
+    // (The index column can't be swapped content-wise like the dictionary: the two columns may
+    // have different numeric widths, hence the shared-bundle indirection.)
+    std::swap(*index_, *col.index_);
     unique_items_map_->swap(*col.unique_items_map_);
-    std::swap(index_type_code_, col.index_type_code_);
+
+    // NOTE: item_type_code_ is intentionally NOT swapped. It is derived solely from the dictionary
+    // type, and the guard above requires both columns to have the same dictionary type, so it is
+    // identical on both sides - swapping would be a no-op.
 }
 
 ItemView ColumnLowCardinality::GetItem(size_t index) const {
@@ -489,7 +496,7 @@ ItemView ColumnLowCardinality::GetItem(size_t index) const {
 // No checks regarding value type or validity of value is made.
 void ColumnLowCardinality::AppendUnsafe(const ItemView & value) {
     const auto key = computeHashKey(value);
-    const auto initial_index_size = index_column_->Size();
+    const auto initial_index_size = index_->column->Size();
     // If the value is unique, then we are going to append it to a dictionary, hence new index is Size().
     auto [iterator, is_new_item] = unique_items_map_->try_emplace(key, dictionary_column_->Size());
     try {
@@ -505,7 +512,7 @@ void ColumnLowCardinality::AppendUnsafe(const ItemView & value) {
         }
     }
     catch (...) {
-        if (index_column_->Size() != initial_index_size)
+        if (index_->column->Size() != initial_index_size)
             removeLastIndex();
         if (is_new_item)
             unique_items_map_->erase(iterator);

--- a/clickhouse/columns/lowcardinality.cpp
+++ b/clickhouse/columns/lowcardinality.cpp
@@ -188,6 +188,15 @@ void ColumnLowCardinality::Reserve(size_t new_cap) {
 }
 
 void ColumnLowCardinality::Setup(ColumnRef dictionary_column) {
+    // Cache the dictionary item type code: for a Nullable dictionary it is the code of the
+    // innermost non-nullable type, otherwise the dictionary's own type code. The dictionary
+    // type is invariant after construction, so this stays valid.
+    if (auto nullable = dictionary_column_->As<ColumnNullable>()) {
+        item_type_code_ = nullable->Nested()->Type()->GetCode();
+    } else {
+        item_type_code_ = dictionary_column_->Type()->GetCode();
+    }
+
     AppendDefaultItem();
 
     if (dictionary_column->Size() != 0) {

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -119,6 +119,10 @@ private:
     void AppendDefaultItem();
 
     Type::Code index_type_code_;
+    // Dictionary item type code (for a Nullable dictionary, the code of the innermost
+    // non-nullable type; otherwise the dictionary's own type code). Computed once in Setup()
+    // and used by ColumnLowCardinalityT to build ItemView on Append.
+    Type::Code item_type_code_;
 
 public:
     static details::LowCardinalityHashKey computeHashKey(const ItemView &);
@@ -130,7 +134,6 @@ template <typename DictionaryColumnType>
 class ColumnLowCardinalityT : public ColumnLowCardinality, public WrappableColumn<ColumnLowCardinalityT<DictionaryColumnType>, ColumnLowCardinality> {
 
     DictionaryColumnType& typed_dictionary_;
-    const Type::Code type_;
 
 public:
     using WrappedColumnType = DictionaryColumnType;
@@ -140,7 +143,6 @@ public:
     explicit ColumnLowCardinalityT(ColumnLowCardinality&& col)
         : ColumnLowCardinality(std::move(col))
         ,  typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary()))
-        ,  type_(GetTypeCode(typed_dictionary_))
     {
     }
 
@@ -149,7 +151,6 @@ public:
     explicit ColumnLowCardinalityT(const ColumnLowCardinality& col)
         : ColumnLowCardinality(col)
         ,  typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary()))
-        ,  type_(GetTypeCode(typed_dictionary_))
     {
     }
 
@@ -162,7 +163,6 @@ public:
     explicit ColumnLowCardinalityT(std::shared_ptr<DictionaryColumnType> dictionary_col)
         : ColumnLowCardinality(dictionary_col)
         , typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary()))
-        , type_(GetTypeCode(typed_dictionary_))
     {}
 
     /// Extended interface to simplify reading/adding individual items.
@@ -183,12 +183,12 @@ public:
     inline void Append(const ValueType & value) {
         if constexpr (IsNullable<WrappedColumnType>) {
             if (value.has_value()) {
-                AppendUnsafe(ItemView{type_, *value});
+                AppendUnsafe(ItemView{item_type_code_, *value});
             } else {
                 AppendUnsafe(ItemView{});
             }
         } else {
-            AppendUnsafe(ItemView{type_, value});
+            AppendUnsafe(ItemView{item_type_code_, value});
         }
     }
 
@@ -248,17 +248,6 @@ public:
     }
 
     ColumnRef CloneEmpty() const override { return Wrap(ColumnLowCardinality::CloneEmpty()); }
-
-private:
-
-    template <typename T>
-    static auto GetTypeCode(T& column) {
-        if constexpr (IsNullable<T>) {
-            return GetTypeCode(*column.Nested()->template AsStrict<typename T::NestedColumnType>());
-        } else {
-            return column.Type()->GetCode();
-        }
-    }
 };
 
 }

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -211,7 +211,11 @@ public:
      *  throw ValidationError on a type mismatch instead.
      */
     static std::shared_ptr<ColumnLowCardinalityT<WrappedColumnType>> Wrap(const ColumnLowCardinality& col, ValidationError* error) {
-        if (!col.dictionary_column_->template As<DictionaryColumnType>()) {
+        // Strict (non-wrapping) check on purpose: the constructor binds typed_dictionary_ as a
+        // DictionaryColumnType& via a reference dynamic_cast, so the stored dictionary must be
+        // exactly DictionaryColumnType. Using the wrapping As<> here could pass for a base
+        // dictionary and then make that reference cast throw std::bad_cast.
+        if (!std::dynamic_pointer_cast<DictionaryColumnType>(col.dictionary_column_)) {
             if (error) {
                 *error = ValidationError("Can't wrap LowCardinality column with dictionary of type "
                                          + col.dictionary_column_->GetType().GetName());

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -127,7 +127,7 @@ public:
 /** Type-aware wrapper that provides simple convenience interface for accessing/appending individual items.
  */
 template <typename DictionaryColumnType>
-class ColumnLowCardinalityT : public ColumnLowCardinality {
+class ColumnLowCardinalityT : public ColumnLowCardinality, public WrappableColumn<ColumnLowCardinalityT<DictionaryColumnType>, ColumnLowCardinality> {
 
     DictionaryColumnType& typed_dictionary_;
     const Type::Code type_;
@@ -240,33 +240,8 @@ public:
         return Wrap(*col, error);
     }
 
-    static auto Wrap(const ColumnLowCardinality& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    static auto Wrap(const Column& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
+    // Throwing single-argument overloads (concrete type / Column& / ColumnRef&).
+    using WrappableColumn<ColumnLowCardinalityT<DictionaryColumnType>, ColumnLowCardinality>::Wrap;
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnLowCardinality::Slice(begin, size));

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -206,17 +206,55 @@ public:
      *  wrapper reference the same underlying storage, so mutations through one are visible through
      *  the other and remain coherent (the dedup map is shared as well).
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col in this case.
-     *  This is a static method to make such conversion verbose.
+     *  The two-argument overloads are non-throwing: on a type mismatch they return nullptr and,
+     *  if `error` is non-null, assign a description to `*error`. The single-argument overloads
+     *  throw ValidationError on a type mismatch instead.
      */
-    static auto Wrap(const ColumnLowCardinality& col) {
+    static std::shared_ptr<ColumnLowCardinalityT<WrappedColumnType>> Wrap(const ColumnLowCardinality& col, ValidationError* error) {
+        if (!col.dictionary_column_->template As<DictionaryColumnType>()) {
+            if (error) {
+                *error = ValidationError("Can't wrap LowCardinality column with dictionary of type "
+                                         + col.dictionary_column_->GetType().GetName());
+            }
+            return nullptr;
+        }
         return std::make_shared<ColumnLowCardinalityT<WrappedColumnType>>(col);
     }
 
-    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnLowCardinality&>(col)); }
+    static std::shared_ptr<ColumnLowCardinalityT<WrappedColumnType>> Wrap(const Column& col, ValidationError* error) {
+        if (auto* c = dynamic_cast<const ColumnLowCardinality*>(&col)) {
+            return Wrap(*c, error);
+        }
+        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as LowCardinality");
+        return nullptr;
+    }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnLowCardinality>()); }
+    static std::shared_ptr<ColumnLowCardinalityT<WrappedColumnType>> Wrap(const ColumnRef& col, ValidationError* error) {
+        return Wrap(*col, error);
+    }
+
+    static auto Wrap(const ColumnLowCardinality& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    static auto Wrap(const Column& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    // Helper to simplify integration with other APIs
+    static auto Wrap(const ColumnRef& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnLowCardinality::Slice(begin, size));

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -45,31 +45,6 @@ public:
     template <typename T>
     friend class ColumnLowCardinalityT;
 
-private:
-    // IMPLEMENTATION NOTE: ColumnLowCardinalityT takes reference to underlying dictionary column object,
-    // so make sure to NOT change address of the dictionary object (with reset(), swap()) or with anything else.
-    ColumnRef dictionary_column_;
-
-    // The index column and its cached type code, bundled behind one shared_ptr. A wrapped view
-    // (ColumnLowCardinalityT::Wrap) shares this bundle, so that LoadBody()/Swap() - which REPLACE
-    // the index column, since its numeric width can change - stay coherent across every holder.
-    // The dictionary and dedup map are only ever mutated in place (never replaced), so they don't
-    // need this extra level of indirection.
-    struct IndexState {
-        ColumnRef column;
-        Type::Code type_code;
-    };
-    std::shared_ptr<IndexState> index_;
-
-    // Shared so that a wrapped (ColumnLowCardinalityT::Wrap) column shares the same dedup map as its
-    // source, keeping dictionary/index/map coherent across both holders (same semantics as other columns).
-    std::shared_ptr<UniqueItems> unique_items_map_;
-
-    // Dictionary item type code (for a Nullable dictionary, the code of the innermost
-    // non-nullable type; otherwise the dictionary's own type code). Computed once in Setup()
-    // and used by ColumnLowCardinalityT to build ItemView on Append.
-    Type::Code item_type_code_;
-
 protected:
     // Shallow copy: shares dictionary_column_, index_ (the index bundle) and unique_items_map_
     // (all shared_ptr) and copies the base type. Used by ColumnLowCardinalityT::Wrap to create a
@@ -136,14 +111,37 @@ private:
 
 public:
     static details::LowCardinalityHashKey computeHashKey(const ItemView &);
+
+private:
+    // IMPLEMENTATION NOTE: ColumnLowCardinalityT takes reference to underlying dictionary column object,
+    // so make sure to NOT change address of the dictionary object (with reset(), swap()) or with anything else.
+    ColumnRef dictionary_column_;
+
+    // The index column and its cached type code, bundled behind one shared_ptr. A wrapped view
+    // (ColumnLowCardinalityT::Wrap) shares this bundle, so that LoadBody()/Swap() - which REPLACE
+    // the index column, since its numeric width can change - stay coherent across every holder.
+    // The dictionary and dedup map are only ever mutated in place (never replaced), so they don't
+    // need this extra level of indirection.
+    struct IndexState {
+        ColumnRef column;
+        Type::Code type_code;
+    };
+    std::shared_ptr<IndexState> index_;
+
+    // Shared so that a wrapped (ColumnLowCardinalityT::Wrap) column shares the same dedup map as its
+    // source, keeping dictionary/index/map coherent across both holders (same semantics as other columns).
+    std::shared_ptr<UniqueItems> unique_items_map_;
+
+    // Dictionary item type code (for a Nullable dictionary, the code of the innermost
+    // non-nullable type; otherwise the dictionary's own type code). Computed once in Setup()
+    // and used by ColumnLowCardinalityT to build ItemView on Append.
+    Type::Code item_type_code_;
 };
 
 /** Type-aware wrapper that provides simple convenience interface for accessing/appending individual items.
  */
 template <typename DictionaryColumnType>
 class ColumnLowCardinalityT : public ColumnLowCardinality, public WrappableColumn<ColumnLowCardinalityT<DictionaryColumnType>, ColumnLowCardinality> {
-
-    DictionaryColumnType& typed_dictionary_;
 
 public:
     using WrappedColumnType = DictionaryColumnType;
@@ -174,6 +172,19 @@ public:
         : ColumnLowCardinality(dictionary_col)
         , typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary()))
     {}
+
+    // Used by Wrap() when the stored dictionary is a base column (e.g. a factory-built base
+    // ColumnNullable for LowCardinality(Nullable(String))) that had to be wrapped into the typed
+    // DictionaryColumnType. Shares col's internals (index bundle and dedup map), then swaps in the
+    // storage-sharing typed dictionary view so typed_dictionary_ binds to exactly a
+    // DictionaryColumnType. `typed_dictionary` MUST be a storage-sharing view of col's dictionary
+    // (as produced by DictionaryColumnType::Wrap), so mutations stay coherent across both holders.
+    ColumnLowCardinalityT(const ColumnLowCardinality& col, std::shared_ptr<DictionaryColumnType> typed_dictionary)
+        : ColumnLowCardinality(col)
+        , typed_dictionary_(*typed_dictionary)
+    {
+        dictionary_column_ = std::move(typed_dictionary);
+    }
 
     /// Extended interface to simplify reading/adding individual items.
 
@@ -221,18 +232,23 @@ public:
      *  throw ValidationError on a type mismatch instead.
      */
     static std::shared_ptr<ColumnLowCardinalityT<WrappedColumnType>> Wrap(const ColumnLowCardinality& col, ValidationError* error) {
-        // Strict (non-wrapping) check on purpose: the constructor binds typed_dictionary_ as a
-        // DictionaryColumnType& via a reference dynamic_cast, so the stored dictionary must be
-        // exactly DictionaryColumnType. Using the wrapping As<> here could pass for a base
-        // dictionary and then make that reference cast throw std::bad_cast.
-        if (!std::dynamic_pointer_cast<DictionaryColumnType>(col.dictionary_column_)) {
-            if (error) {
-                *error = ValidationError("Can't wrap LowCardinality column with dictionary of type "
-                                         + col.dictionary_column_->GetType().GetName());
-            }
+        // Fast path: the stored dictionary is already exactly DictionaryColumnType, so share it
+        // directly - typed_dictionary_ can bind to it via the reference dynamic_cast unchanged.
+        if (std::dynamic_pointer_cast<DictionaryColumnType>(col.dictionary_column_)) {
+            return std::make_shared<ColumnLowCardinalityT<WrappedColumnType>>(col);
+        }
+
+        // Fallback: the stored dictionary is a base column, not DictionaryColumnType (e.g. the
+        // factory builds LowCardinality(Nullable(String)) with a base ColumnNullable dictionary).
+        // Wrap it into the typed DictionaryColumnType - a storage-sharing view over the same
+        // underlying columns - and bind typed_dictionary_ to that. Binding to the base dictionary
+        // directly would make the reference dynamic_cast throw std::bad_cast.
+        auto typed_dictionary = WrapColumn<DictionaryColumnType>(col.dictionary_column_, error);
+        if (!typed_dictionary) {
+            // error (if requested) already set by WrapColumn.
             return nullptr;
         }
-        return std::make_shared<ColumnLowCardinalityT<WrappedColumnType>>(col);
+        return std::make_shared<ColumnLowCardinalityT<WrappedColumnType>>(col, typed_dictionary);
     }
 
     static std::shared_ptr<ColumnLowCardinalityT<WrappedColumnType>> Wrap(const Column& col, ValidationError* error) {
@@ -258,6 +274,11 @@ public:
     }
 
     ColumnRef CloneEmpty() const override { return Wrap(ColumnLowCardinality::CloneEmpty()); }
+
+private:
+
+    DictionaryColumnType& typed_dictionary_;
+
 };
 
 }

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -49,14 +49,30 @@ private:
     // IMPLEMENTATION NOTE: ColumnLowCardinalityT takes reference to underlying dictionary column object,
     // so make sure to NOT change address of the dictionary object (with reset(), swap()) or with anything else.
     ColumnRef dictionary_column_;
-    ColumnRef index_column_;
+
+    // The index column and its cached type code, bundled behind one shared_ptr. A wrapped view
+    // (ColumnLowCardinalityT::Wrap) shares this bundle, so that LoadBody()/Swap() - which REPLACE
+    // the index column, since its numeric width can change - stay coherent across every holder.
+    // The dictionary and dedup map are only ever mutated in place (never replaced), so they don't
+    // need this extra level of indirection.
+    struct IndexState {
+        ColumnRef column;
+        Type::Code type_code;
+    };
+    std::shared_ptr<IndexState> index_;
+
     // Shared so that a wrapped (ColumnLowCardinalityT::Wrap) column shares the same dedup map as its
     // source, keeping dictionary/index/map coherent across both holders (same semantics as other columns).
     std::shared_ptr<UniqueItems> unique_items_map_;
 
+    // Dictionary item type code (for a Nullable dictionary, the code of the innermost
+    // non-nullable type; otherwise the dictionary's own type code). Computed once in Setup()
+    // and used by ColumnLowCardinalityT to build ItemView on Append.
+    Type::Code item_type_code_;
+
 protected:
-    // Shallow copy: shares dictionary_column_, index_column_ and unique_items_map_ (all shared_ptr),
-    // copies index_type_code_ and the base type. Used by ColumnLowCardinalityT::Wrap to create a
+    // Shallow copy: shares dictionary_column_, index_ (the index bundle) and unique_items_map_
+    // (all shared_ptr) and copies the base type. Used by ColumnLowCardinalityT::Wrap to create a
     // non-destructive, storage-sharing view of `col`.
     ColumnLowCardinality(const ColumnLowCardinality& col) = default;
 
@@ -117,12 +133,6 @@ private:
     void Setup(ColumnRef dictionary_column);
     void AppendNullItem();
     void AppendDefaultItem();
-
-    Type::Code index_type_code_;
-    // Dictionary item type code (for a Nullable dictionary, the code of the innermost
-    // non-nullable type; otherwise the dictionary's own type code). Computed once in Setup()
-    // and used by ColumnLowCardinalityT to build ItemView on Append.
-    Type::Code item_type_code_;
 
 public:
     static details::LowCardinalityHashKey computeHashKey(const ItemView &);

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -229,7 +229,9 @@ public:
         if (auto* c = dynamic_cast<const ColumnLowCardinality*>(&col)) {
             return Wrap(*c, error);
         }
-        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as LowCardinality");
+        if (error) {
+            *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as LowCardinality");
+        }
         return nullptr;
     }
 
@@ -241,14 +243,18 @@ public:
     static auto Wrap(const ColumnLowCardinality& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
     static auto Wrap(const Column& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
@@ -256,7 +262,9 @@ public:
     static auto Wrap(const ColumnRef& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 

--- a/clickhouse/columns/lowcardinality.h
+++ b/clickhouse/columns/lowcardinality.h
@@ -50,7 +50,15 @@ private:
     // so make sure to NOT change address of the dictionary object (with reset(), swap()) or with anything else.
     ColumnRef dictionary_column_;
     ColumnRef index_column_;
-    UniqueItems unique_items_map_;
+    // Shared so that a wrapped (ColumnLowCardinalityT::Wrap) column shares the same dedup map as its
+    // source, keeping dictionary/index/map coherent across both holders (same semantics as other columns).
+    std::shared_ptr<UniqueItems> unique_items_map_;
+
+protected:
+    // Shallow copy: shares dictionary_column_, index_column_ and unique_items_map_ (all shared_ptr),
+    // copies index_type_code_ and the base type. Used by ColumnLowCardinalityT::Wrap to create a
+    // non-destructive, storage-sharing view of `col`.
+    ColumnLowCardinality(const ColumnLowCardinality& col) = default;
 
 public:
     ColumnLowCardinality(ColumnLowCardinality&& col) = default;
@@ -136,6 +144,15 @@ public:
     {
     }
 
+    // Shares the internals of `col` (dictionary, index and dedup map) via shared_ptr, WITHOUT
+    // stealing or copying them. Used by Wrap to create a non-destructive, storage-sharing view.
+    explicit ColumnLowCardinalityT(const ColumnLowCardinality& col)
+        : ColumnLowCardinality(col)
+        ,  typed_dictionary_(dynamic_cast<DictionaryColumnType &>(*GetDictionary()))
+        ,  type_(GetTypeCode(typed_dictionary_))
+    {
+    }
+
     template <typename ...Args>
     explicit ColumnLowCardinalityT(Args &&... args)
         : ColumnLowCardinalityT(std::make_shared<DictionaryColumnType>(std::forward<Args>(args)...))
@@ -182,23 +199,24 @@ public:
         }
     }
 
-    /** Create a ColumnLowCardinalityT from a ColumnLowCardinality, without copying data and offsets, but by
-     * 'stealing' those from `col`.
+    /** Create a ColumnLowCardinalityT that SHARES the internals of `col` (dictionary, index and
+     *  dedup map) via shared_ptr, WITHOUT stealing or copying them.
      *
-     *  Ownership of column internals is transferred to returned object, original (argument) object
-     *  MUST NOT BE USED IN ANY WAY, it is only safe to dispose it.
+     *  The original `col` remains fully valid and usable. Both the original and the returned
+     *  wrapper reference the same underlying storage, so mutations through one are visible through
+     *  the other and remain coherent (the dedup map is shared as well).
      *
      *  Throws an exception if `col` is of wrong type, it is safe to use original col in this case.
      *  This is a static method to make such conversion verbose.
      */
-    static auto Wrap(ColumnLowCardinality&& col) {
-        return std::make_shared<ColumnLowCardinalityT<WrappedColumnType>>(std::move(col));
+    static auto Wrap(const ColumnLowCardinality& col) {
+        return std::make_shared<ColumnLowCardinalityT<WrappedColumnType>>(col);
     }
 
-    static auto Wrap(Column&& col) { return Wrap(std::move(dynamic_cast<ColumnLowCardinality&&>(col))); }
+    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnLowCardinality&>(col)); }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(ColumnRef&& col) { return Wrap(std::move(*col->AsStrict<ColumnLowCardinality>())); }
+    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnLowCardinality>()); }
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnLowCardinality::Slice(begin, size));

--- a/clickhouse/columns/map.cpp
+++ b/clickhouse/columns/map.cpp
@@ -3,7 +3,6 @@
 #include <stdexcept>
 
 #include "../exceptions.h"
-#include "utils.h"
 
 namespace {
 

--- a/clickhouse/columns/map.cpp
+++ b/clickhouse/columns/map.cpp
@@ -76,7 +76,9 @@ ColumnRef ColumnMap::CloneEmpty() const {
 
 void ColumnMap::Swap(Column& other) {
     auto& col = dynamic_cast<ColumnMap&>(other);
-    data_.swap(col.data_);
+    // Swap the backing array's CONTENTS in place (never rebind the shared_ptr slot), so the
+    // array/tuple/leaf objects keep their identity and any As<>/Wrap views stay coherent.
+    data_->Swap(*col.data_);
 }
 
 ColumnRef ColumnMap::GetAsColumn(size_t n) const {

--- a/clickhouse/columns/map.h
+++ b/clickhouse/columns/map.h
@@ -119,7 +119,9 @@ public:
 
         inline auto At(const Key& key) const {
             auto it = Find(key);
-            if (it == end()) throw ValidationError("ColumnMap value key not found");
+            if (it == end()) {
+                throw ValidationError("ColumnMap value key not found");
+            }
             return (*it).second;
         }
 
@@ -263,7 +265,9 @@ public:
         if (auto* c = dynamic_cast<const ColumnMap*>(&col)) {
             return Wrap(*c, error);
         }
-        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Map");
+        if (error) {
+            *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Map");
+        }
         return nullptr;
     }
 
@@ -275,14 +279,18 @@ public:
     static auto Wrap(const ColumnMap& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
     static auto Wrap(const Column& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
@@ -290,7 +298,9 @@ public:
     static auto Wrap(const ColumnRef& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 

--- a/clickhouse/columns/map.h
+++ b/clickhouse/columns/map.h
@@ -240,15 +240,24 @@ public:
         typed_data_->Append(Iterator{value.begin(), functor}, Iterator{value.end(), functor});
     }
 
-    static auto Wrap(ColumnMap&& col) {
-        auto data = ArrayColumnType::Wrap(std::move(col.data_));
+    /** Create a ColumnMapT that SHARES the internals of `col` (its backing array of
+     *  key/value tuples) via shared_ptr, WITHOUT stealing or copying them.
+     *
+     *  The original `col` remains fully valid and usable. Both the original and the
+     *  returned wrapper reference the same underlying columns, so mutations through
+     *  one are visible through the other.
+     *
+     *  Throws if `col` is of the wrong type.
+     */
+    static auto Wrap(const ColumnMap& col) {
+        auto data = ArrayColumnType::Wrap(*col.data_);
         return std::make_shared<ColumnMapT<K, V>>(std::move(data));
     }
 
-    static auto Wrap(Column&& col) { return Wrap(std::move(dynamic_cast<ColumnMap&&>(col))); }
+    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnMap&>(col)); }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(ColumnRef&& col) { return Wrap(std::move(*col->AsStrict<ColumnMap>())); }
+    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnMap>()); }
 
 private:
     std::shared_ptr<ArrayColumnType> typed_data_;

--- a/clickhouse/columns/map.h
+++ b/clickhouse/columns/map.h
@@ -69,7 +69,7 @@ private:
 };
 
 template <typename K, typename V>
-class ColumnMapT : public ColumnMap {
+class ColumnMapT : public ColumnMap, public WrappableColumn<ColumnMapT<K, V>, ColumnMap> {
 public:
     using KeyColumnType   = K;
     using ValueColumnType = V;
@@ -276,33 +276,8 @@ public:
         return Wrap(*col, error);
     }
 
-    static auto Wrap(const ColumnMap& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    static auto Wrap(const Column& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
+    // Throwing single-argument overloads (concrete type / Column& / ColumnRef&).
+    using WrappableColumn<ColumnMapT<K, V>, ColumnMap>::Wrap;
 
 private:
     std::shared_ptr<ArrayColumnType> typed_data_;

--- a/clickhouse/columns/map.h
+++ b/clickhouse/columns/map.h
@@ -247,17 +247,52 @@ public:
      *  returned wrapper reference the same underlying columns, so mutations through
      *  one are visible through the other.
      *
-     *  Throws if `col` is of the wrong type.
+     *  The two-argument overloads are non-throwing: on a type mismatch they return
+     *  nullptr and, if `error` is non-null, assign a description to `*error`. The
+     *  single-argument overloads throw ValidationError on a type mismatch instead.
      */
-    static auto Wrap(const ColumnMap& col) {
-        auto data = ArrayColumnType::Wrap(*col.data_);
-        return std::make_shared<ColumnMapT<K, V>>(std::move(data));
+    static std::shared_ptr<ColumnMapT<K, V>> Wrap(const ColumnMap& col, ValidationError* error) {
+        auto data = ArrayColumnType::Wrap(*col.data_, error);
+        if (!data) {
+            return nullptr;
+        }
+        return std::make_shared<ColumnMapT<K, V>>(data);
     }
 
-    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnMap&>(col)); }
+    static std::shared_ptr<ColumnMapT<K, V>> Wrap(const Column& col, ValidationError* error) {
+        if (auto* c = dynamic_cast<const ColumnMap*>(&col)) {
+            return Wrap(*c, error);
+        }
+        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Map");
+        return nullptr;
+    }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnMap>()); }
+    static std::shared_ptr<ColumnMapT<K, V>> Wrap(const ColumnRef& col, ValidationError* error) {
+        return Wrap(*col, error);
+    }
+
+    static auto Wrap(const ColumnMap& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    static auto Wrap(const Column& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    // Helper to simplify integration with other APIs
+    static auto Wrap(const ColumnRef& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
 
 private:
     std::shared_ptr<ArrayColumnType> typed_data_;

--- a/clickhouse/columns/map.h
+++ b/clickhouse/columns/map.h
@@ -96,8 +96,9 @@ public:
 
     void Swap(Column& other) override {
         auto& col = dynamic_cast<ColumnMapT<K, V>&>(other);
-        col.typed_data_.swap(typed_data_);
-        ColumnMap::Swap(other);
+        // Base swaps the backing array's contents in place, preserving object identity, so the
+        // cached typed_data_ still points at the correct object and must NOT be repointed.
+        ColumnMap::Swap(col);
     }
 
     /// A single (row) value of the Map-column i.e. read-only map.

--- a/clickhouse/columns/nullable.cpp
+++ b/clickhouse/columns/nullable.cpp
@@ -95,8 +95,10 @@ void ColumnNullable::Swap(Column& other) {
     if (!nested_->Type()->IsEqual(col.nested_->Type()))
         throw ValidationError("Can't swap() Nullable columns of different types.");
 
-    nested_.swap(col.nested_);
-    nulls_.swap(col.nulls_);
+    // Swap sub-column CONTENTS in place (never rebind the shared_ptr slots), so the nested and
+    // nulls objects keep their identity and any As<>/Wrap views of this column stay coherent.
+    nested_->Swap(*col.nested_);
+    nulls_->Swap(*col.nulls_);
 }
 
 ItemView ColumnNullable::GetItem(size_t index) const  {

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -126,7 +126,9 @@ public:
         }
         auto nulls = col.Nulls()->As<ColumnUInt8>();
         if (!nulls) {
-            if (error) *error = ValidationError("Can't wrap Nullable column: unexpected null-map type");
+            if (error) {
+                *error = ValidationError("Can't wrap Nullable column: unexpected null-map type");
+            }
             return nullptr;
         }
         return std::make_shared<ColumnNullableT<NestedColumnType>>(nested, nulls);
@@ -136,7 +138,9 @@ public:
         if (auto* c = dynamic_cast<const ColumnNullable*>(&col)) {
             return Wrap(*c, error);
         }
-        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Nullable");
+        if (error) {
+            *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Nullable");
+        }
         return nullptr;
     }
 
@@ -148,14 +152,18 @@ public:
     static auto Wrap(const ColumnNullable& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
     static auto Wrap(const Column& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
@@ -163,7 +171,9 @@ public:
     static auto Wrap(const ColumnRef& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -2,6 +2,7 @@
 
 #include "column.h"
 #include "numeric.h"
+#include "utils.h"
 
 #include <optional>
 
@@ -108,25 +109,26 @@ public:
         }
     }
 
-    /** Create a ColumnNullableT from a ColumnNullable, without copying data and offsets, but by
-     * 'stealing' those from `col`.
+    /** Create a ColumnNullableT that SHARES the internals of `col` (nested data and
+     *  null map) via shared_ptr, WITHOUT stealing or copying them.
      *
-     *  Ownership of column internals is transferred to returned object, original (argument) object
-     *  MUST NOT BE USED IN ANY WAY, it is only safe to dispose it.
+     *  The original `col` remains fully valid and usable. Both the original and the
+     *  returned wrapper reference the same underlying columns, so mutations through
+     *  one are visible through the other.
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col in this case.
-     *  This is a static method to make such conversion verbose.
+     *  Throws an exception if `col` is of wrong type, it is safe to use original col
+     *  in this case. This is a static method to make such conversion verbose.
      */
-    static auto Wrap(ColumnNullable&& col) {
+    static auto Wrap(const ColumnNullable& col) {
         return std::make_shared<ColumnNullableT<NestedColumnType>>(
-            col.Nested()->AsStrict<NestedColumnType>(),
-            col.Nulls()->AsStrict<ColumnUInt8>()) ;
+            WrapColumn<NestedColumnType>(col.Nested()),
+            col.Nulls()->AsStrict<ColumnUInt8>());
     }
 
-    static auto Wrap(Column&& col) { return Wrap(std::move(dynamic_cast<ColumnNullable&&>(col))); }
+    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnNullable&>(col)); }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(ColumnRef&& col) { return Wrap(std::move(*col->AsStrict<ColumnNullable>())); }
+    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnNullable>()); }
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnNullable::Slice(begin, size));

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -116,19 +116,57 @@ public:
      *  returned wrapper reference the same underlying columns, so mutations through
      *  one are visible through the other.
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col
-     *  in this case. This is a static method to make such conversion verbose.
+     *  The two-argument overloads are non-throwing: on a type mismatch they return
+     *  nullptr and, if `error` is non-null, assign a description to `*error`. The
+     *  single-argument overloads throw ValidationError on a type mismatch instead.
      */
-    static auto Wrap(const ColumnNullable& col) {
-        return std::make_shared<ColumnNullableT<NestedColumnType>>(
-            WrapColumn<NestedColumnType>(col.Nested()),
-            col.Nulls()->AsStrict<ColumnUInt8>());
+    static std::shared_ptr<ColumnNullableT<NestedColumnType>> Wrap(const ColumnNullable& col, ValidationError* error) {
+        auto nested = WrapColumn<NestedColumnType>(col.Nested(), error);
+        if (!nested) {
+            return nullptr;
+        }
+        auto nulls = col.Nulls()->As<ColumnUInt8>();
+        if (!nulls) {
+            if (error) *error = ValidationError("Can't wrap Nullable column: unexpected null-map type");
+            return nullptr;
+        }
+        return std::make_shared<ColumnNullableT<NestedColumnType>>(nested, nulls);
     }
 
-    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnNullable&>(col)); }
+    static std::shared_ptr<ColumnNullableT<NestedColumnType>> Wrap(const Column& col, ValidationError* error) {
+        if (auto* c = dynamic_cast<const ColumnNullable*>(&col)) {
+            return Wrap(*c, error);
+        }
+        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Nullable");
+        return nullptr;
+    }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnNullable>()); }
+    static std::shared_ptr<ColumnNullableT<NestedColumnType>> Wrap(const ColumnRef& col, ValidationError* error) {
+        return Wrap(*col, error);
+    }
+
+    static auto Wrap(const ColumnNullable& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    static auto Wrap(const Column& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    // Helper to simplify integration with other APIs
+    static auto Wrap(const ColumnRef& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnNullable::Slice(begin, size));

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -64,7 +64,7 @@ private:
 };
 
 template <typename ColumnType>
-class ColumnNullableT : public ColumnNullable {
+class ColumnNullableT : public ColumnNullable, public WrappableColumn<ColumnNullableT<ColumnType>, ColumnNullable> {
 public:
     using NestedColumnType = ColumnType;
     using ValueType = std::optional<std::decay_t<decltype(std::declval<NestedColumnType>().At(0))>>;
@@ -149,33 +149,8 @@ public:
         return Wrap(*col, error);
     }
 
-    static auto Wrap(const ColumnNullable& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    static auto Wrap(const Column& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
+    // Throwing single-argument overloads (concrete type / Column& / ColumnRef&).
+    using WrappableColumn<ColumnNullableT<ColumnType>, ColumnNullable>::Wrap;
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnNullable::Slice(begin, size));

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -160,8 +160,9 @@ public:
 
     void Swap(Column& other) override {
         auto& col = dynamic_cast<ColumnNullableT<NestedColumnType>&>(other);
-        typed_nested_data_.swap(col.typed_nested_data_);
-        ColumnNullable::Swap(other);
+        // Base swaps sub-column contents in place, preserving object identity, so the cached
+        // typed_nested_data_ still points at the correct object and must NOT be repointed.
+        ColumnNullable::Swap(col);
     }
 
 private:

--- a/clickhouse/columns/nullable.h
+++ b/clickhouse/columns/nullable.h
@@ -2,7 +2,6 @@
 
 #include "column.h"
 #include "numeric.h"
-#include "utils.h"
 
 #include <optional>
 

--- a/clickhouse/columns/numeric.cpp
+++ b/clickhouse/columns/numeric.cpp
@@ -1,5 +1,4 @@
 #include "numeric.h"
-#include "utils.h"
 
 #include "../base/wire_format.h"
 

--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -1,5 +1,4 @@
 #include "string.h"
-#include "utils.h"
 
 #include "../base/wire_format.h"
 

--- a/clickhouse/columns/tuple.cpp
+++ b/clickhouse/columns/tuple.cpp
@@ -147,11 +147,21 @@ void ColumnTuple::Clear() {
 
 void ColumnTuple::Swap(Column& other) {
     auto & col = dynamic_cast<ColumnTuple &>(other);
-    if (columns_.size() != col.columns_.size())
+    if (columns_.size() != col.columns_.size()) {
         throw ValidationError("Can't swap() Tuple columns of different sizes.");
+    }
+
+    for (size_t i = 0; i < columns_.size(); ++i) {
+        if (!columns_[i]->Type()->IsEqual(col.columns_[i]->Type())) {
+            throw ValidationError(
+                "Can't swap() Tuple elements of types "
+                + columns_[i]->GetType().GetName() + " and "
+                + col.columns_[i]->GetType().GetName() + ".");
+        }
+    }
+
     // Swap each element's CONTENTS in place (never rebind the columns_ vector), so element
     // objects keep their identity and any As<>/Wrap views of this column stay coherent.
-    // The nested Swap also type-checks each element and throws on a mismatch.
     for (size_t i = 0; i < columns_.size(); ++i) {
         columns_[i]->Swap(*col.columns_[i]);
     }

--- a/clickhouse/columns/tuple.cpp
+++ b/clickhouse/columns/tuple.cpp
@@ -138,12 +138,23 @@ void ColumnTuple::SaveBody(OutputStream* output) {
 }
 
 void ColumnTuple::Clear() {
-    columns_.clear();
+    // Clear each element column in place (do NOT drop the element handles): this preserves the
+    // tuple structure and the element objects' identity, so any As<>/Wrap views stay coherent.
+    for (auto & column : columns_) {
+        column->Clear();
+    }
 }
 
 void ColumnTuple::Swap(Column& other) {
     auto & col = dynamic_cast<ColumnTuple &>(other);
-    columns_.swap(col.columns_);
+    if (columns_.size() != col.columns_.size())
+        throw ValidationError("Can't swap() Tuple columns of different sizes.");
+    // Swap each element's CONTENTS in place (never rebind the columns_ vector), so element
+    // objects keep their identity and any As<>/Wrap views of this column stay coherent.
+    // The nested Swap also type-checks each element and throws on a mismatch.
+    for (size_t i = 0; i < columns_.size(); ++i) {
+        columns_[i]->Swap(*col.columns_[i]);
+    }
 }
 
 }

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -62,7 +62,7 @@ private:
 };
 
 template <typename... Columns>
-class ColumnTupleT : public ColumnTuple {
+class ColumnTupleT : public ColumnTuple, public WrappableColumn<ColumnTupleT<Columns...>, ColumnTuple> {
 public:
     using TupleOfColumns = std::tuple<std::shared_ptr<Columns>...>;
 
@@ -141,33 +141,8 @@ public:
         return Wrap(*col, error);
     }
 
-    static auto Wrap(const ColumnTuple& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    static auto Wrap(const Column& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
-
-    // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) {
-        ValidationError error;
-        auto result = Wrap(col, &error);
-        if (!result) {
-            throw error;
-        }
-        return result;
-    }
+    // Throwing single-argument overloads (concrete type / Column& / ColumnRef&).
+    using WrappableColumn<ColumnTupleT<Columns...>, ColumnTuple>::Wrap;
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnTuple::Slice(begin, size));

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "column.h"
-#include "utils.h"
 
 #include <tuple>
 #include <vector>

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -3,6 +3,7 @@
 #include "column.h"
 #include "utils.h"
 
+#include <tuple>
 #include <vector>
 
 namespace clickhouse {
@@ -105,21 +106,59 @@ public:
      *  returned wrapper reference the same underlying element columns, so mutations
      *  through one are visible through the other.
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col
-     *  in this case. This is a static method to make such conversion verbose.
+     *  The two-argument overloads are non-throwing: on a type mismatch they return
+     *  nullptr and, if `error` is non-null, assign a description to `*error`. The
+     *  single-argument overloads throw ValidationError on a type mismatch instead.
      */
-    static auto Wrap(const ColumnTuple& col) {
+    static std::shared_ptr<ColumnTupleT<Columns...>> Wrap(const ColumnTuple& col, ValidationError* error) {
         if (col.TupleSize() != std::tuple_size_v<TupleOfColumns>) {
-            throw ValidationError("Can't wrap from " + col.GetType().GetName());
+            if (error) *error = ValidationError("Can't wrap from " + col.GetType().GetName());
+            return nullptr;
+        }
+        auto columns = TupleFromColumn(col, error);
+        const bool all_wrapped = std::apply(
+            [](const auto&... column) { return (... && static_cast<bool>(column)); }, columns);
+        if (!all_wrapped) {
+            return nullptr;
         }
         auto names = col.Type()->As<TupleType>()->GetItemNames();
-        return std::make_shared<ColumnTupleT<Columns...>>(TupleFromColumn(col), std::move(names));
+        return std::make_shared<ColumnTupleT<Columns...>>(std::move(columns), std::move(names));
     }
 
-    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnTuple&>(col)); }
+    static std::shared_ptr<ColumnTupleT<Columns...>> Wrap(const Column& col, ValidationError* error) {
+        if (auto* c = dynamic_cast<const ColumnTuple*>(&col)) {
+            return Wrap(*c, error);
+        }
+        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Tuple");
+        return nullptr;
+    }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnTuple>()); }
+    static std::shared_ptr<ColumnTupleT<Columns...>> Wrap(const ColumnRef& col, ValidationError* error) {
+        return Wrap(*col, error);
+    }
+
+    static auto Wrap(const ColumnTuple& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    static auto Wrap(const Column& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
+
+    // Helper to simplify integration with other APIs
+    static auto Wrap(const ColumnRef& col) {
+        ValidationError error;
+        auto result = Wrap(col, &error);
+        if (!result) throw error;
+        return result;
+    }
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnTuple::Slice(begin, size));
@@ -160,16 +199,19 @@ private:
         }
     }
 
+    // Builds a tuple of the element columns wrapped as their typed counterparts. Any element
+    // that can't be wrapped is left as a null shared_ptr (and `*error` is set if provided).
     template <size_t column_index = std::tuple_size_v<TupleOfColumns>>
-    inline static auto TupleFromColumn([[maybe_unused]] const ColumnTuple& col) {
+    inline static auto TupleFromColumn([[maybe_unused]] const ColumnTuple& col,
+                                       [[maybe_unused]] ValidationError* error) {
         static_assert(column_index <= std::tuple_size_v<TupleOfColumns>);
         if constexpr (column_index == 0) {
             return std::make_tuple();
         } else {
             using ColumnType =
                 typename std::tuple_element<column_index - 1, TupleOfColumns>::type::element_type;
-            auto column = WrapColumn<ColumnType>(col[column_index - 1]);
-            return std::tuple_cat(TupleFromColumn<column_index - 1>(col),
+            auto column = WrapColumn<ColumnType>(col[column_index - 1], error);
+            return std::tuple_cat(TupleFromColumn<column_index - 1>(col, error),
                                   std::make_tuple(std::move(column)));
         }
     }

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -152,8 +152,9 @@ public:
 
     void Swap(Column& other) override {
         auto& col = dynamic_cast<ColumnTupleT<Columns...>&>(other);
-        typed_columns_.swap(col.typed_columns_);
-        ColumnTuple::Swap(other);
+        // Base swaps element contents in place, preserving object identity, so the cached
+        // typed_columns_ still point at the correct objects and must NOT be repointed.
+        ColumnTuple::Swap(col);
     }
 
 private:

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -111,7 +111,9 @@ public:
      */
     static std::shared_ptr<ColumnTupleT<Columns...>> Wrap(const ColumnTuple& col, ValidationError* error) {
         if (col.TupleSize() != std::tuple_size_v<TupleOfColumns>) {
-            if (error) *error = ValidationError("Can't wrap from " + col.GetType().GetName());
+            if (error) {
+                *error = ValidationError("Can't wrap from " + col.GetType().GetName());
+            }
             return nullptr;
         }
         auto columns = TupleFromColumn(col, error);
@@ -128,7 +130,9 @@ public:
         if (auto* c = dynamic_cast<const ColumnTuple*>(&col)) {
             return Wrap(*c, error);
         }
-        if (error) *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Tuple");
+        if (error) {
+            *error = ValidationError("Can't wrap column of type " + col.GetType().GetName() + " as Tuple");
+        }
         return nullptr;
     }
 
@@ -140,14 +144,18 @@ public:
     static auto Wrap(const ColumnTuple& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
     static auto Wrap(const Column& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 
@@ -155,7 +163,9 @@ public:
     static auto Wrap(const ColumnRef& col) {
         ValidationError error;
         auto result = Wrap(col, &error);
-        if (!result) throw error;
+        if (!result) {
+            throw error;
+        }
         return result;
     }
 

--- a/clickhouse/columns/tuple.h
+++ b/clickhouse/columns/tuple.h
@@ -98,27 +98,28 @@ public:
         AppendTuple(std::move(value));
     }
 
-    /** Create a ColumnTupleT from a ColumnTuple, without copying data and offsets, but by
-     * 'stealing' those from `col`.
+    /** Create a ColumnTupleT that SHARES the internals of `col` (its element columns)
+     *  via shared_ptr, WITHOUT stealing or copying them.
      *
-     *  Ownership of column internals is transferred to returned object, original (argument) object
-     *  MUST NOT BE USED IN ANY WAY, it is only safe to dispose it.
+     *  The original `col` remains fully valid and usable. Both the original and the
+     *  returned wrapper reference the same underlying element columns, so mutations
+     *  through one are visible through the other.
      *
-     *  Throws an exception if `col` is of wrong type, it is safe to use original col in this case.
-     *  This is a static method to make such conversion verbose.
+     *  Throws an exception if `col` is of wrong type, it is safe to use original col
+     *  in this case. This is a static method to make such conversion verbose.
      */
-    static auto Wrap(ColumnTuple&& col) {
+    static auto Wrap(const ColumnTuple& col) {
         if (col.TupleSize() != std::tuple_size_v<TupleOfColumns>) {
             throw ValidationError("Can't wrap from " + col.GetType().GetName());
         }
         auto names = col.Type()->As<TupleType>()->GetItemNames();
-        return std::make_shared<ColumnTupleT<Columns...>>(VectorToTuple(std::move(col)), std::move(names));
+        return std::make_shared<ColumnTupleT<Columns...>>(TupleFromColumn(col), std::move(names));
     }
 
-    static auto Wrap(Column&& col) { return Wrap(std::move(dynamic_cast<ColumnTuple&&>(col))); }
+    static auto Wrap(const Column& col) { return Wrap(dynamic_cast<const ColumnTuple&>(col)); }
 
     // Helper to simplify integration with other APIs
-    static auto Wrap(ColumnRef&& col) { return Wrap(std::move(*col->AsStrict<ColumnTuple>())); }
+    static auto Wrap(const ColumnRef& col) { return Wrap(*col->AsStrict<ColumnTuple>()); }
 
     ColumnRef Slice(size_t begin, size_t size) const override {
         return Wrap(ColumnTuple::Slice(begin, size));
@@ -156,6 +157,20 @@ private:
             auto result = TupleToVector<T, index - 1>(value);
             result.push_back(std::get<index - 1>(value));
             return result;
+        }
+    }
+
+    template <size_t column_index = std::tuple_size_v<TupleOfColumns>>
+    inline static auto TupleFromColumn([[maybe_unused]] const ColumnTuple& col) {
+        static_assert(column_index <= std::tuple_size_v<TupleOfColumns>);
+        if constexpr (column_index == 0) {
+            return std::make_tuple();
+        } else {
+            using ColumnType =
+                typename std::tuple_element<column_index - 1, TupleOfColumns>::type::element_type;
+            auto column = WrapColumn<ColumnType>(col[column_index - 1]);
+            return std::tuple_cat(TupleFromColumn<column_index - 1>(col),
+                                  std::make_tuple(std::move(column)));
         }
     }
 

--- a/clickhouse/columns/utils.h
+++ b/clickhouse/columns/utils.h
@@ -1,59 +1,13 @@
 #pragma once
 
-#include <algorithm>
-#include <vector>
-#include <memory>
+// Deprecated header. The Wrap helpers (SliceVector, HasWrapMethod, WrapColumn)
+// moved into columns/column.h. Include "clickhouse/columns/column.h" instead.
+// This forwarding stub is kept for backward compatibility and will be removed
+// in a future release.
+#if defined(__GNUC__) || defined(__clang__) || (defined(_MSC_VER) && _MSC_VER >= 1929)
+#  warning "clickhouse/columns/utils.h is deprecated; include \"clickhouse/columns/column.h\" instead"
+#else
+#  pragma message("clickhouse/columns/utils.h is deprecated; include \"clickhouse/columns/column.h\" instead")
+#endif
+
 #include "column.h"
-
-namespace clickhouse {
-
-template <typename T>
-std::vector<T> SliceVector(const std::vector<T>& vec, size_t begin, size_t len) {
-    std::vector<T> result;
-
-    if (begin < vec.size()) {
-        len = std::min(len, vec.size() - begin);
-        result.assign(vec.begin() + begin, vec.begin() + (begin + len));
-    }
-
-    return result;
-}
-
-template <typename T>
-struct HasWrapMethod {
-private:
-    static int detect(...);
-    template <typename U>
-    static decltype(U::Wrap(std::move(std::declval<ColumnRef>()))) detect(const U&);
-
-public:
-    static constexpr bool value = !std::is_same<int, decltype(detect(std::declval<T>()))>::value;
-};
-
-// Non-throwing: returns nullptr and (if `error` is non-null) fills `*error` when `column`
-// can't be wrapped as T.
-template <typename T>
-inline std::shared_ptr<T> WrapColumn(const ColumnRef& column, ValidationError* error) {
-    if constexpr (HasWrapMethod<T>::value) {
-        return T::Wrap(column, error);
-    } else {
-        auto result = column->template As<T>();
-        if (!result && error) {
-            *error = ValidationError("Can't wrap column of type " + column->GetType().GetName());
-        }
-        return result;
-    }
-}
-
-// Throwing convenience wrapper.
-template <typename T>
-inline std::shared_ptr<T> WrapColumn(const ColumnRef& column) {
-    ValidationError error;
-    auto result = WrapColumn<T>(column, &error);
-    if (!result) {
-        throw error;
-    }
-    return result;
-}
-
-}

--- a/clickhouse/columns/utils.h
+++ b/clickhouse/columns/utils.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <vector>
 #include <memory>
+#include "column.h"
 
 namespace clickhouse {
 
@@ -29,13 +30,30 @@ public:
     static constexpr bool value = !std::is_same<int, decltype(detect(std::declval<T>()))>::value;
 };
 
+// Non-throwing: returns nullptr and (if `error` is non-null) fills `*error` when `column`
+// can't be wrapped as T.
+template <typename T>
+inline std::shared_ptr<T> WrapColumn(const ColumnRef& column, ValidationError* error) {
+    if constexpr (HasWrapMethod<T>::value) {
+        return T::Wrap(column, error);
+    } else {
+        auto result = column->template As<T>();
+        if (!result && error) {
+            *error = ValidationError("Can't wrap column of type " + column->GetType().GetName());
+        }
+        return result;
+    }
+}
+
+// Throwing convenience wrapper.
 template <typename T>
 inline std::shared_ptr<T> WrapColumn(const ColumnRef& column) {
-    if constexpr (HasWrapMethod<T>::value) {
-        return T::Wrap(column);
-    } else {
-        return column->template AsStrict<T>();
+    ValidationError error;
+    auto result = WrapColumn<T>(column, &error);
+    if (!result) {
+        throw error;
     }
+    return result;
 }
 
 }

--- a/clickhouse/columns/utils.h
+++ b/clickhouse/columns/utils.h
@@ -30,9 +30,9 @@ public:
 };
 
 template <typename T>
-inline std::shared_ptr<T> WrapColumn(ColumnRef&& column) {
+inline std::shared_ptr<T> WrapColumn(const ColumnRef& column) {
     if constexpr (HasWrapMethod<T>::value) {
-        return T::Wrap(std::move(column));
+        return T::Wrap(column);
     } else {
         return column->template AsStrict<T>();
     }

--- a/clickhouse/columns/uuid.cpp
+++ b/clickhouse/columns/uuid.cpp
@@ -1,5 +1,4 @@
 #include "uuid.h"
-#include "utils.h"
 #include "../exceptions.h"
 
 #include <stdexcept>

--- a/clickhouse/exceptions.h
+++ b/clickhouse/exceptions.h
@@ -14,6 +14,11 @@ class Error : public std::runtime_error {
 // Caused by any user-related code, like invalid column types or arguments passed to any method.
 class ValidationError : public Error {
     using Error::Error;
+
+public:
+    // Convenience default constructor, useful for creating an empty error to pass as an
+    // output parameter (e.g. to Column*T::Wrap(col, &error)).
+    ValidationError() : Error(std::string()) {}
 };
 
 // Buffers+IO errors, failure to serialize/deserialize, checksum mismatches, etc.

--- a/ut/CMakeLists.txt
+++ b/ut/CMakeLists.txt
@@ -7,6 +7,7 @@ SET ( clickhouse-cpp-ut-src
     block_ut.cpp
     client_ut.cpp
     columns_ut.cpp
+    column_as_ut.cpp
     column_array_ut.cpp
     itemview_ut.cpp
     socket_ut.cpp

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -1,6 +1,7 @@
 #include <clickhouse/columns/bool.h>
 #include <clickhouse/columns/factory.h>
 #include <clickhouse/columns/date.h>
+#include <clickhouse/columns/lowcardinality.h>
 #include <clickhouse/columns/numeric.h>
 #include <clickhouse/columns/string.h>
 #include <clickhouse/columns/tuple.h>
@@ -43,6 +44,28 @@ TEST(CreateColumnByType, LowCardinalityAsWrappedColumn) {
 
     ASSERT_EQ(Type::FixedString, CreateColumnByType("LowCardinality(FixedString(10000))", create_column_settings)->GetType().GetCode());
     ASSERT_EQ(Type::FixedString, CreateColumnByType("LowCardinality(FixedString(10000))", create_column_settings)->As<ColumnFixedString>()->GetType().GetCode());
+}
+
+TEST(CreateColumnByType, LowCardinality) {
+    // In the default (non-wrapped) mode, LowCardinality(String)/LowCardinality(FixedString) map to
+    // the base ColumnLowCardinality (like Array/Nullable/Tuple/Map do), and the strongly-typed
+    // ColumnLowCardinalityT<...> view is obtained on demand via the wrapping As<>.
+    {
+        auto col = CreateColumnByType("LowCardinality(String)");
+        ASSERT_NE(nullptr, col);
+        EXPECT_EQ("LowCardinality(String)", col->GetType().GetName());
+        // Concrete type is the base ColumnLowCardinality, not ColumnLowCardinalityT<...>.
+        EXPECT_NE(nullptr, col->As<ColumnLowCardinality>());
+        // The wrapping As<> yields the strongly-typed view.
+        EXPECT_NE(nullptr, col->As<ColumnLowCardinalityT<ColumnString>>());
+    }
+    {
+        auto col = CreateColumnByType("LowCardinality(FixedString(10000))");
+        ASSERT_NE(nullptr, col);
+        EXPECT_EQ("LowCardinality(FixedString(10000))", col->GetType().GetName());
+        EXPECT_NE(nullptr, col->As<ColumnLowCardinality>());
+        EXPECT_NE(nullptr, col->As<ColumnLowCardinalityT<ColumnFixedString>>());
+    }
 }
 
 TEST(CreateColumnByType, DateTime) {
@@ -162,6 +185,8 @@ INSTANTIATE_TEST_SUITE_P(Parametrized, CreateColumnByTypeWithName, ::testing::Va
 
 INSTANTIATE_TEST_SUITE_P(Nested, CreateColumnByTypeWithName, ::testing::Values(
     "Nullable(FixedString(10000))",
+    "LowCardinality(String)",
+    "LowCardinality(FixedString(10000))",
     "Nullable(LowCardinality(FixedString(10000)))",
     "Array(Nullable(LowCardinality(FixedString(10000))))",
     "Array(Enum8('ONE' = 1, 'TWO' = 2))"

--- a/ut/CreateColumnByType_ut.cpp
+++ b/ut/CreateColumnByType_ut.cpp
@@ -68,6 +68,44 @@ TEST(CreateColumnByType, LowCardinality) {
     }
 }
 
+TEST(CreateColumnByType, LowCardinalityNullable) {
+    // The factory builds LowCardinality(Nullable(String)) as a base ColumnLowCardinality whose
+    // dictionary is a base ColumnNullable (not a typed ColumnNullableT<ColumnString>). The wrapping
+    // As<> must still produce the strongly-typed view by wrapping that base dictionary into the
+    // typed one, sharing its underlying storage.
+    using TypedLC = ColumnLowCardinalityT<ColumnNullableT<ColumnString>>;
+
+    auto col = CreateColumnByType("LowCardinality(Nullable(String))");
+    ASSERT_NE(nullptr, col);
+    EXPECT_EQ("LowCardinality(Nullable(String))", col->GetType().GetName());
+    EXPECT_NE(nullptr, col->As<ColumnLowCardinality>());
+
+    auto typed = col->As<TypedLC>();
+    ASSERT_NE(nullptr, typed);
+
+    // Appends through the typed view are visible via the base handle (shared storage), and the
+    // typed accessors round-trip both real values and nulls.
+    typed->Append(std::string("abc"));
+    typed->Append(std::nullopt);
+    typed->Append(std::string("abc"));
+
+    EXPECT_EQ(3u, typed->Size());
+    EXPECT_EQ(3u, col->Size());
+    EXPECT_EQ(std::optional<std::string>("abc"), typed->At(0));
+    EXPECT_EQ(std::nullopt, typed->At(1));
+    EXPECT_EQ(std::optional<std::string>("abc"), typed->At(2));
+
+    // A second independent wrap of the same base column observes the same shared data.
+    auto typed2 = col->As<TypedLC>();
+    ASSERT_NE(nullptr, typed2);
+    EXPECT_EQ(3u, typed2->Size());
+    EXPECT_EQ(std::optional<std::string>("abc"), typed2->At(0));
+    EXPECT_EQ(std::nullopt, typed2->At(1));
+
+    // A dictionary whose nested type does not match must still be rejected.
+    EXPECT_EQ(nullptr, col->As<ColumnLowCardinalityT<ColumnNullableT<ColumnFixedString>>>());
+}
+
 TEST(CreateColumnByType, DateTime) {
     ASSERT_NE(nullptr, CreateColumnByType("DateTime"));
     ASSERT_NE(nullptr, CreateColumnByType("DateTime('Europe/Moscow')"));

--- a/ut/column_array_ut.cpp
+++ b/ut/column_array_ut.cpp
@@ -337,6 +337,86 @@ TEST(ColumnArrayT, Wrap_UInt64_2D) {
     EXPECT_TRUE(CompareRecursive(values, array));
 }
 
+TEST(ColumnArrayT, Wrap_AcceptsLvalue) {
+    // Wrap no longer requires an rvalue: lvalues and const sources are accepted.
+
+    const std::vector<std::vector<uint64_t>> values = {
+        {1u, 2u},
+        {3u},
+        {}
+    };
+
+    auto arr = CreateArray<ColumnUInt64>(values);
+
+    // Lvalue ColumnRef, no std::move required and not consumed.
+    ColumnRef ref = arr;
+    auto w1 = ColumnArrayT<ColumnUInt64>::Wrap(ref);
+    EXPECT_TRUE(CompareRecursive(values, *w1));
+    EXPECT_NE(ref, nullptr);
+
+    // Const lvalue concrete column.
+    const ColumnArray& cref = *arr;
+    auto w2 = ColumnArrayT<ColumnUInt64>::Wrap(cref);
+    EXPECT_TRUE(CompareRecursive(values, *w2));
+
+    // Non-const lvalue concrete column.
+    auto w3 = ColumnArrayT<ColumnUInt64>::Wrap(*arr);
+    EXPECT_TRUE(CompareRecursive(values, *w3));
+}
+
+TEST(ColumnArrayT, Wrap_DoesNotStealSource_UInt64) {
+    // Wrap shares storage with the source ColumnArray and leaves its contents intact.
+
+    const std::vector<std::vector<uint64_t>> values = {
+        {1u, 2u, 3u},
+        {4u, 5u, 6u, 7u, 8u, 9u},
+        {0u},
+        {},
+        {13, 14}
+    };
+
+    auto original = CreateArray<ColumnUInt64>(values);
+    // Keep an independent handle to the same underlying ColumnArray.
+    auto keep = original;
+    auto wrapped_array = ColumnArrayT<ColumnUInt64>::Wrap(std::move(original));
+
+    // Wrapper sees the same data.
+    EXPECT_TRUE(CompareRecursive(values, *wrapped_array));
+
+    // Source array contents are left intact (not stolen from).
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(keep->Size(), values.size());
+
+    // Storage is shared: appending a row through the source is visible via the wrapper.
+    keep->AppendAsColumn(std::make_shared<ColumnUInt64>(std::vector<uint64_t>{42, 43}));
+    EXPECT_EQ(wrapped_array->Size(), values.size() + 1);
+    EXPECT_EQ(wrapped_array->At(values.size()).At(0), 42u);
+    EXPECT_EQ(wrapped_array->At(values.size()).At(1), 43u);
+}
+
+TEST(ColumnArrayT, Wrap_DoesNotStealSource_UInt64_2D) {
+    // Wrap shares all nesting layers with the source.
+
+    const std::vector<std::vector<std::vector<uint64_t>>> values = {
+        {{1u, 2u}, {3u}},
+        {{4u}, {5u, 6u, 7u}, {8u, 9u}, {}},
+        {{0u}},
+        {{}},
+        {{13}, {14, 15}}
+    };
+
+    auto original = Create2DArray<ColumnUInt64>(values);
+    auto keep = original;
+    auto wrapped_array = ColumnArrayT<ColumnArrayT<ColumnUInt64>>::Wrap(std::move(original));
+
+    EXPECT_TRUE(CompareRecursive(values, *wrapped_array));
+
+    // Source array contents are left intact (not stolen from).
+    ASSERT_NE(keep, nullptr);
+    EXPECT_EQ(keep->Size(), values.size());
+    EXPECT_TRUE(CompareRecursive(values, *ColumnArrayT<ColumnArrayT<ColumnUInt64>>::Wrap(std::move(keep))));
+}
+
 TEST(ColumnArrayT, Bool) {
     // Check inserting\reading back data from clickhouse::ColumnArrayT<ColumnBool>
 

--- a/ut/column_as_ut.cpp
+++ b/ut/column_as_ut.cpp
@@ -1,0 +1,283 @@
+#include <clickhouse/columns/array.h>
+#include <clickhouse/columns/factory.h>
+#include <clickhouse/columns/lowcardinality.h>
+#include <clickhouse/columns/map.h>
+#include <clickhouse/columns/nullable.h>
+#include <clickhouse/columns/numeric.h>
+#include <clickhouse/columns/string.h>
+#include <clickhouse/columns/tuple.h>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <map>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <vector>
+
+namespace {
+using namespace clickhouse;
+
+struct ArrayAsTestCase {
+    using TypedColumn = ColumnArrayT<ColumnUInt64>;
+    using Value = std::vector<uint64_t>;
+
+    static const char* TypeName() { return "Array(UInt64)"; }
+
+    static std::array<Value, 3> Values() {
+        return {{{1, 2}, {7}, {9, 10, 11}}};
+    }
+
+    static void Append(TypedColumn& column, const Value& value) {
+        column.Append(value);
+    }
+
+    static void ExpectValue(const TypedColumn& column, size_t index, const Value& expected) {
+        const auto actual = column.At(index);
+        ASSERT_EQ(expected.size(), actual.size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            EXPECT_EQ(expected[i], actual[i]);
+        }
+    }
+};
+
+struct NullableAsTestCase {
+    using TypedColumn = ColumnNullableT<ColumnUInt64>;
+    using Value = std::optional<uint64_t>;
+
+    static const char* TypeName() { return "Nullable(UInt64)"; }
+
+    static std::array<Value, 3> Values() {
+        return {{uint64_t{1}, std::nullopt, uint64_t{42}}};
+    }
+
+    static void Append(TypedColumn& column, const Value& value) {
+        column.Append(value);
+    }
+
+    static void ExpectValue(const TypedColumn& column, size_t index, const Value& expected) {
+        EXPECT_EQ(expected, column.At(index));
+    }
+};
+
+struct TupleAsTestCase {
+    using TypedColumn = ColumnTupleT<ColumnUInt64, ColumnString>;
+    using Value = std::tuple<uint64_t, std::string>;
+
+    static const char* TypeName() { return "Tuple(UInt64, String)"; }
+
+    static std::array<Value, 3> Values() {
+        return {{{1, "one"}, {2, "two"}, {3, "three"}}};
+    }
+
+    static void Append(TypedColumn& column, const Value& value) {
+        column.Append(value);
+    }
+
+    static void ExpectValue(const TypedColumn& column, size_t index, const Value& expected) {
+        const auto actual = column.At(index);
+        EXPECT_EQ(std::get<0>(expected), std::get<0>(actual));
+        EXPECT_EQ(std::string_view(std::get<1>(expected)), std::get<1>(actual));
+    }
+};
+
+struct MapAsTestCase {
+    using TypedColumn = ColumnMapT<ColumnString, ColumnUInt64>;
+    using Value = std::map<std::string, uint64_t>;
+
+    static const char* TypeName() { return "Map(String, UInt64)"; }
+
+    static std::array<Value, 3> Values() {
+        return {{{{"one", 1}}, {{"two", 2}, {"second", 20}}, {{"three", 3}}}};
+    }
+
+    static void Append(TypedColumn& column, const Value& value) {
+        column.Append(value);
+    }
+
+    static void ExpectValue(const TypedColumn& column, size_t index, const Value& expected) {
+        const auto actual = column.At(index);
+        ASSERT_EQ(expected.size(), actual.size());
+        for (const auto& [key, value] : expected) {
+            EXPECT_EQ(value, actual.At(std::string_view(key)));
+        }
+    }
+};
+
+struct LowCardinalityAsTestCase {
+    using TypedColumn = ColumnLowCardinalityT<ColumnString>;
+    using Value = std::string;
+
+    static const char* TypeName() { return "LowCardinality(String)"; }
+
+    static std::array<Value, 3> Values() {
+        return {{"alpha", "beta", "alpha"}};
+    }
+
+    static void Append(TypedColumn& column, const Value& value) {
+        column.Append(std::string_view(value));
+    }
+
+    static void ExpectValue(const TypedColumn& column, size_t index, const Value& expected) {
+        EXPECT_EQ(std::string_view(expected), column.At(index));
+    }
+};
+
+template <typename T>
+class ColumnAsTest : public testing::Test {
+protected:
+    using TypedColumn = typename T::TypedColumn;
+    using Value = typename T::Value;
+
+    static ColumnRef MakeBaseColumn() {
+        return CreateColumnByType(T::TypeName());
+    }
+
+    static void AppendToBase(const ColumnRef& column, const Value& value) {
+        auto donor = MakeBaseColumn();
+        T::Append(*donor->template AsStrict<TypedColumn>(), value);
+        column->Append(std::move(donor));
+    }
+
+    static void ExpectValues(
+        const std::shared_ptr<TypedColumn>& column,
+        const std::vector<Value>& expected) {
+        ASSERT_EQ(expected.size(), column->Size());
+        for (size_t i = 0; i < expected.size(); ++i) {
+            T::ExpectValue(*column, i, expected[i]);
+        }
+    }
+};
+
+using ColumnAsTestCases = testing::Types<
+    ArrayAsTestCase,
+    NullableAsTestCase,
+    TupleAsTestCase,
+    MapAsTestCase,
+    LowCardinalityAsTestCase>;
+
+TYPED_TEST_SUITE(ColumnAsTest, ColumnAsTestCases);
+
+TYPED_TEST(ColumnAsTest, SharesMutationsInBothDirections) {
+    using TypedColumn = typename TestFixture::TypedColumn;
+    const auto values = TypeParam::Values();
+    auto base = TestFixture::MakeBaseColumn();
+
+    ASSERT_NE(nullptr, base);
+    EXPECT_EQ(nullptr, std::dynamic_pointer_cast<TypedColumn>(base));
+
+    auto first_view = base->template As<TypedColumn>();
+    auto second_view = base->template AsStrict<TypedColumn>();
+    ASSERT_NE(nullptr, first_view);
+    ASSERT_NE(nullptr, second_view);
+    EXPECT_NE(first_view.get(), second_view.get());
+    EXPECT_NE(base.get(), static_cast<Column*>(first_view.get()));
+
+    TestFixture::AppendToBase(base, values[0]);
+    EXPECT_EQ(1u, base->Size());
+    TestFixture::ExpectValues(first_view, {values[0]});
+    TestFixture::ExpectValues(second_view, {values[0]});
+
+    TypeParam::Append(*first_view, values[1]);
+    EXPECT_EQ(2u, base->Size());
+    TestFixture::ExpectValues(first_view, {values[0], values[1]});
+    TestFixture::ExpectValues(second_view, {values[0], values[1]});
+
+    TypeParam::Append(*second_view, values[2]);
+    EXPECT_EQ(3u, base->Size());
+    TestFixture::ExpectValues(first_view, {values[0], values[1], values[2]});
+    TestFixture::ExpectValues(second_view, {values[0], values[1], values[2]});
+}
+
+TYPED_TEST(ColumnAsTest, AsOnAliasReturnsSameInstance) {
+    using TypedColumn = typename TestFixture::TypedColumn;
+    const auto values = TypeParam::Values();
+    auto base = TestFixture::MakeBaseColumn();
+    ASSERT_NE(nullptr, base);
+
+    auto typed_alias = base->template AsStrict<TypedColumn>();
+    auto same_alias = typed_alias->template As<TypedColumn>();
+    ASSERT_NE(nullptr, same_alias);
+    EXPECT_EQ(typed_alias.get(), same_alias.get());
+
+    TypeParam::Append(*same_alias, values[0]);
+    EXPECT_EQ(1u, base->Size());
+    TestFixture::ExpectValues(typed_alias, {values[0]});
+
+    TestFixture::AppendToBase(base, values[1]);
+    EXPECT_EQ(2u, same_alias->Size());
+    TestFixture::ExpectValues(same_alias, {values[0], values[1]});
+}
+
+TYPED_TEST(ColumnAsTest, ClearPreservesAllViewsAndAllowsReuse) {
+    const auto values = TypeParam::Values();
+    auto base = TestFixture::MakeBaseColumn();
+    ASSERT_NE(nullptr, base);
+
+    auto first_view = base->template AsStrict<typename TestFixture::TypedColumn>();
+    auto second_view = base->template AsStrict<typename TestFixture::TypedColumn>();
+    TestFixture::AppendToBase(base, values[0]);
+    TestFixture::AppendToBase(base, values[1]);
+
+    base->Clear();
+    EXPECT_EQ(0u, base->Size());
+    TestFixture::ExpectValues(first_view, {});
+    TestFixture::ExpectValues(second_view, {});
+
+    TypeParam::Append(*first_view, values[2]);
+    EXPECT_EQ(1u, base->Size());
+    TestFixture::ExpectValues(second_view, {values[2]});
+
+    second_view->Clear();
+    EXPECT_EQ(0u, base->Size());
+    TestFixture::ExpectValues(first_view, {});
+    TestFixture::ExpectValues(second_view, {});
+
+    TestFixture::AppendToBase(base, values[1]);
+    EXPECT_EQ(1u, base->Size());
+    TestFixture::ExpectValues(first_view, {values[1]});
+    TestFixture::ExpectValues(second_view, {values[1]});
+}
+
+TYPED_TEST(ColumnAsTest, SwapPreservesAllViewsAndAllowsReuse) {
+    const auto values = TypeParam::Values();
+    auto first_base = TestFixture::MakeBaseColumn();
+    auto second_base = TestFixture::MakeBaseColumn();
+    ASSERT_NE(nullptr, first_base);
+    ASSERT_NE(nullptr, second_base);
+
+    TestFixture::AppendToBase(first_base, values[0]);
+    TestFixture::AppendToBase(second_base, values[1]);
+    TestFixture::AppendToBase(second_base, values[2]);
+
+    auto first_view = first_base->template AsStrict<typename TestFixture::TypedColumn>();
+    auto first_second_view = first_base->template AsStrict<typename TestFixture::TypedColumn>();
+    auto second_view = second_base->template AsStrict<typename TestFixture::TypedColumn>();
+    auto second_second_view = second_base->template AsStrict<typename TestFixture::TypedColumn>();
+
+    first_base->Swap(*second_base);
+    TestFixture::ExpectValues(first_view, {values[1], values[2]});
+    TestFixture::ExpectValues(first_second_view, {values[1], values[2]});
+    TestFixture::ExpectValues(second_view, {values[0]});
+    TestFixture::ExpectValues(second_second_view, {values[0]});
+
+    TypeParam::Append(*first_view, values[0]);
+    EXPECT_EQ(3u, first_base->Size());
+    TestFixture::ExpectValues(first_second_view, {values[1], values[2], values[0]});
+
+    first_view->Swap(*second_view);
+    EXPECT_EQ(1u, first_base->Size());
+    EXPECT_EQ(3u, second_base->Size());
+    TestFixture::ExpectValues(first_view, {values[0]});
+    TestFixture::ExpectValues(first_second_view, {values[0]});
+    TestFixture::ExpectValues(second_view, {values[1], values[2], values[0]});
+    TestFixture::ExpectValues(second_second_view, {values[1], values[2], values[0]});
+
+    TypeParam::Append(*second_second_view, values[1]);
+    EXPECT_EQ(4u, second_base->Size());
+    TestFixture::ExpectValues(second_view, {values[1], values[2], values[0], values[1]});
+}
+
+}  // namespace

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1088,6 +1088,69 @@ TEST(ColumnsCase, ColumnLowCardinalityString_Append_and_Read) {
     }
 }
 
+TEST(ColumnsCase, ColumnLowCardinalityT_Wrap_DoesNotStealSource) {
+    // Populate via the typed column (the only ergonomic per-value insert path), then Wrap it
+    // through an untyped ColumnRef handle, as with a column received from a query.
+    auto source = std::make_shared<ColumnLowCardinalityT<ColumnString>>();
+    source->Append("a");
+    source->Append("b");
+    source->Append("a");
+
+    ColumnRef untyped = source;
+    auto wrapped = ColumnLowCardinalityT<ColumnString>::Wrap(untyped);
+
+    // Wrapper reads the same data.
+    ASSERT_EQ(wrapped->Size(), 3u);
+    EXPECT_EQ(wrapped->At(0), "a");
+    EXPECT_EQ(wrapped->At(1), "b");
+    EXPECT_EQ(wrapped->At(2), "a");
+
+    // Source (and the untyped handle) are left intact after Wrap (non-stealing).
+    EXPECT_NE(untyped, nullptr);
+    ASSERT_EQ(source->Size(), 3u);
+    EXPECT_EQ(source->At(0), "a");
+    EXPECT_EQ(source->At(2), "a");
+
+    // Storage (dictionary + index + dedup map) is shared and stays coherent:
+    // a new unique value appended via the source, and a repeat appended via the wrapper.
+    const auto dict_before = source->GetDictionarySize();
+    source->Append("c");     // new unique -> dictionary grows, visible via the wrapper
+    wrapped->Append("a");    // repeat -> deduped against the shared map, no dictionary growth
+
+    EXPECT_EQ(source->Size(), 5u);
+    EXPECT_EQ(wrapped->Size(), 5u);
+    EXPECT_EQ(wrapped->At(3), "c");
+    EXPECT_EQ(wrapped->At(4), "a");
+    EXPECT_EQ(source->At(4), "a");
+    // "c" added exactly one dictionary entry; "a" added none (shared dedup map).
+    EXPECT_EQ(source->GetDictionarySize(), dict_before + 1);
+    EXPECT_EQ(wrapped->GetDictionarySize(), dict_before + 1);
+}
+
+TEST(ColumnsCase, ColumnLowCardinalityT_Wrap_AcceptsLvalue) {
+    auto source = std::make_shared<ColumnLowCardinalityT<ColumnString>>();
+    source->Append("x");
+    source->Append("y");
+
+    using LC = ColumnLowCardinalityT<ColumnString>;
+
+    // Non-const lvalue (untyped base reference), no std::move required.
+    ColumnLowCardinality& base = *source;
+    auto w1 = LC::Wrap(base);
+    EXPECT_EQ(w1->At(0), "x");
+
+    // Const lvalue.
+    const ColumnLowCardinality& cref = *source;
+    auto w2 = LC::Wrap(cref);
+    EXPECT_EQ(w2->At(1), "y");
+
+    // Lvalue ColumnRef, no std::move required and not consumed.
+    ColumnRef ref = source;
+    auto w3 = LC::Wrap(ref);
+    EXPECT_EQ(w3->Size(), 2u);
+    EXPECT_NE(ref, nullptr);
+}
+
 TEST(ColumnsCase, ColumnLowCardinalityString_Clear_and_Append) {
     const size_t items_count = 11;
     ColumnLowCardinalityT<ColumnString> col;

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1507,6 +1507,218 @@ TEST(ColumnsCase, ColumnTupleT_Wrap_PreservesNames) {
     EXPECT_EQ(wrapped->Type()->GetName(), "Tuple(id UInt64, name String)");
 }
 
+// --- Swap/Clear must stay coherent with As<>/Wrap views (contents swapped/cleared in place) ---
+
+TEST(ColumnsCase, ColumnArrayT_Swap_VisibleThroughAlias) {
+    auto a = std::make_shared<ColumnArrayT<ColumnUInt64>>();
+    a->Append(std::vector<uint64_t>{1, 2, 3});
+    auto b = std::make_shared<ColumnArrayT<ColumnUInt64>>();
+    b->Append(std::vector<uint64_t>{7, 8});
+
+    // Alias sharing a's storage.
+    auto alias_a = ColumnArrayT<ColumnUInt64>::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+
+    a->Swap(*b);
+
+    // a now holds b's row, b holds a's row.
+    ASSERT_EQ(a->Size(), 1u);
+    EXPECT_EQ(a->At(0).size(), 2u);
+    ASSERT_EQ(b->Size(), 1u);
+    EXPECT_EQ(b->At(0).size(), 3u);
+
+    // The swap is visible through the alias (sub-object identity preserved).
+    ASSERT_EQ(alias_a->Size(), 1u);
+    EXPECT_EQ(alias_a->At(0).size(), 2u);
+    EXPECT_EQ(alias_a->At(0)[0], 7u);
+}
+
+TEST(ColumnsCase, ColumnNullableT_Swap_VisibleThroughAlias) {
+    auto a = std::make_shared<ColumnNullableT<ColumnUInt64>>();
+    a->Append(1);
+    a->Append(std::nullopt);
+    auto b = std::make_shared<ColumnNullableT<ColumnUInt64>>();
+    b->Append(42);
+
+    auto alias_a = ColumnNullableT<ColumnUInt64>::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+
+    a->Swap(*b);
+
+    ASSERT_EQ(a->Size(), 1u);
+    EXPECT_EQ(a->At(0), std::optional<uint64_t>(42));
+    ASSERT_EQ(b->Size(), 2u);
+
+    // Visible through the alias.
+    ASSERT_EQ(alias_a->Size(), 1u);
+    EXPECT_EQ(alias_a->At(0), std::optional<uint64_t>(42));
+}
+
+TEST(ColumnsCase, ColumnTupleT_Swap_VisibleThroughAlias) {
+    ColumnTuple a({std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()});
+    a[0]->AsStrict<ColumnUInt64>()->Append(1);
+    a[1]->AsStrict<ColumnString>()->Append("a");
+
+    ColumnTuple b({std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()});
+    b[0]->AsStrict<ColumnUInt64>()->Append(2);
+    b[1]->AsStrict<ColumnString>()->Append("b");
+
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+    auto alias_a = TestTuple::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+
+    a.Swap(b);
+
+    EXPECT_EQ(a.Size(), 1u);
+    EXPECT_EQ(a[0]->AsStrict<ColumnUInt64>()->At(0), 2u);
+    EXPECT_EQ(b[0]->AsStrict<ColumnUInt64>()->At(0), 1u);
+
+    // Visible through the alias.
+    EXPECT_EQ(alias_a->At(0), std::make_tuple(uint64_t(2), std::string_view("b")));
+}
+
+TEST(ColumnsCase, ColumnTuple_Swap_DifferentSizeThrows) {
+    ColumnTuple a({std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()});
+    ColumnTuple b({std::make_shared<ColumnUInt64>()});
+    EXPECT_THROW(a.Swap(b), ValidationError);
+}
+
+TEST(ColumnsCase, ColumnTuple_Clear_PreservesStructure_AndAlias) {
+    ColumnTuple col({std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()});
+    col[0]->AsStrict<ColumnUInt64>()->Append(1);
+    col[1]->AsStrict<ColumnString>()->Append("a");
+
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+    auto alias = TestTuple::Wrap(col);
+    ASSERT_NE(alias, nullptr);
+    ASSERT_EQ(alias->Size(), 1u);
+
+    col.Clear();
+
+    // Structure is preserved (columns not dropped) and data is cleared in place.
+    EXPECT_EQ(col.Size(), 0u);
+    EXPECT_EQ(col.TupleSize(), 2u);
+    // Clear propagates to the alias.
+    EXPECT_EQ(alias->Size(), 0u);
+
+    // Re-appending through the original element columns is visible via the alias.
+    col[0]->AsStrict<ColumnUInt64>()->Append(2);
+    col[1]->AsStrict<ColumnString>()->Append("b");
+    ASSERT_EQ(alias->Size(), 1u);
+    EXPECT_EQ(alias->At(0), std::make_tuple(uint64_t(2), std::string_view("b")));
+}
+
+TEST(ColumnsCase, ColumnMapT_Swap_VisibleThroughAlias) {
+    using TestMap = ColumnMapT<ColumnString, ColumnUInt64>;
+
+    auto a = std::make_shared<TestMap>(std::make_shared<ColumnString>(), std::make_shared<ColumnUInt64>());
+    a->Append(std::map<std::string, uint64_t>{{"x", 1}});
+    auto b = std::make_shared<TestMap>(std::make_shared<ColumnString>(), std::make_shared<ColumnUInt64>());
+    b->Append(std::map<std::string, uint64_t>{{"y", 2}, {"z", 3}});
+
+    auto alias_a = TestMap::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+
+    a->Swap(*b);
+
+    ASSERT_EQ(a->Size(), 1u);
+    EXPECT_EQ(a->At(0).size(), 2u);
+    ASSERT_EQ(b->Size(), 1u);
+    EXPECT_EQ(b->At(0).size(), 1u);
+
+    // Visible through the alias.
+    ASSERT_EQ(alias_a->Size(), 1u);
+    EXPECT_EQ(alias_a->At(0).size(), 2u);
+    EXPECT_EQ(alias_a->At(0)["y"], 2u);
+}
+
+// --- Deep-nested aliases: in-place Swap/Clear must recurse to shared leaf objects ---
+
+namespace {
+// Builds a single-row Map(UInt64, Array(Nullable(String))): one map row with one entry
+// {key -> arr}. Uses the single-offset ColumnArray ctor so the backing array has exactly one row.
+std::shared_ptr<ColumnMap> MakeDeepMapRow(uint64_t key, std::vector<std::optional<std::string>> arr) {
+    auto keys = std::make_shared<ColumnUInt64>();
+    auto vals = std::make_shared<ColumnArrayT<ColumnNullableT<ColumnString>>>();
+    keys->Append(key);
+    vals->Append(arr);
+    auto tuple = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{keys, vals});
+    return std::make_shared<ColumnMap>(std::make_shared<ColumnArray>(tuple));
+}
+}
+
+TEST(ColumnsCase, DeepMap_Swap_VisibleThroughAlias) {
+    using DeepMap = ColumnMapT<ColumnUInt64, ColumnArrayT<ColumnNullableT<ColumnString>>>;
+
+    auto a = MakeDeepMapRow(1, {std::string("a"), std::string("b"), std::string("c")});
+    auto b = MakeDeepMapRow(1, {std::string("x"), std::nullopt});
+
+    auto alias_a = DeepMap::Wrap(a);  // deep typed view created BEFORE the swap
+    ASSERT_NE(alias_a, nullptr);
+    ASSERT_EQ(alias_a->At(0).At(1).Size(), 3u);
+
+    a->Swap(*b);
+
+    // The swap recurses down to the shared leaf columns, so the pre-existing alias now
+    // reflects B's data: the value-array flips size 3 -> 2 and the null survives.
+    auto arr = alias_a->At(0).At(1);
+    ASSERT_EQ(arr.Size(), 2u);
+    EXPECT_EQ(arr[0], std::optional<std::string_view>("x"));
+    EXPECT_EQ(arr[1], std::optional<std::string_view>{});
+
+    // b now holds a's original data.
+    auto arr_b = DeepMap::Wrap(b)->At(0).At(1);
+    EXPECT_EQ(arr_b.Size(), 3u);
+    EXPECT_EQ(arr_b[0], std::optional<std::string_view>("a"));
+}
+
+TEST(ColumnsCase, DeepMap_Clear_VisibleThroughAlias_NoStaleEntries) {
+    using DeepMap = ColumnMapT<ColumnUInt64, ColumnArrayT<ColumnNullableT<ColumnString>>>;
+
+    auto a = MakeDeepMapRow(1, {std::string("a"), std::string("b"), std::string("c")});
+    auto alias_a = DeepMap::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+    ASSERT_EQ(alias_a->Size(), 1u);
+
+    a->Clear();
+
+    // Clear recurses to the shared leaves in place, so the alias goes empty too.
+    EXPECT_EQ(a->Size(), 0u);
+    EXPECT_EQ(alias_a->Size(), 0u);
+
+    // Re-appending a fresh row must not resurface the pre-clear ["a","b","c"] entry.
+    a->Append(MakeDeepMapRow(1, {std::string("z")}));
+    ASSERT_EQ(alias_a->Size(), 1u);
+    auto arr = alias_a->At(0).At(1);
+    ASSERT_EQ(arr.Size(), 1u);
+    EXPECT_EQ(arr[0], std::optional<std::string_view>("z"));
+}
+
+TEST(ColumnsCase, DeepNestedArray_Swap_VisibleThroughAlias) {
+    using DeepArray = ColumnArrayT<ColumnArrayT<ColumnNullableT<ColumnString>>>;
+
+    auto a = std::make_shared<DeepArray>();
+    a->Append(std::vector<std::vector<std::optional<std::string>>>{
+        {std::string("a")}, {std::string("b"), std::string("c")}});
+    auto b = std::make_shared<DeepArray>();
+    b->Append(std::vector<std::vector<std::optional<std::string>>>{
+        {std::string("x"), std::nullopt}});
+
+    auto alias_a = DeepArray::Wrap(a);  // created BEFORE the swap
+    ASSERT_NE(alias_a, nullptr);
+    ASSERT_EQ(alias_a->At(0).Size(), 2u);
+
+    a->Swap(*b);
+
+    // Alias reflects B's data all the way down to the nullable-string leaves.
+    auto outer = alias_a->At(0);
+    ASSERT_EQ(outer.Size(), 1u);
+    auto inner = outer.At(0);
+    ASSERT_EQ(inner.Size(), 2u);
+    EXPECT_EQ(inner[0], std::optional<std::string_view>("x"));
+    EXPECT_EQ(inner[1], std::optional<std::string_view>{});
+}
+
 TEST(ColumnsCase, ColumnTupleT_Slice_PreservesNames) {
     using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1254,6 +1254,61 @@ TEST(ColumnsCase, ColumnTupleT) {
     EXPECT_EQ(val, col.At(0));
 }
 
+TEST(ColumnsCase, ColumnNullableT_Wrap_DoesNotStealSource) {
+    auto nested = std::make_shared<ColumnUInt64>();
+    auto nulls = std::make_shared<ColumnUInt8>();
+    ColumnNullable col(nested, nulls);
+
+    col.Append(false);
+    nested->Append(1);
+    col.Append(true);
+    nested->Append(0);
+
+    using TestNullable = ColumnNullableT<ColumnUInt64>;
+    auto wrapped = TestNullable::Wrap(std::move(col));
+
+    // Wrapper sees the same data.
+    EXPECT_EQ(wrapped->Size(), 2u);
+    EXPECT_EQ(wrapped->At(0), std::optional<uint64_t>(1));
+    EXPECT_EQ(wrapped->At(1), std::optional<uint64_t>{});
+
+    // Source column is left intact after Wrap (non-stealing).
+    EXPECT_EQ(col.Size(), 2u);
+    EXPECT_FALSE(col.IsNull(0));
+    EXPECT_TRUE(col.IsNull(1));
+
+    // Storage is shared: appending through the original is visible via the wrapper.
+    col.Append(false);
+    nested->Append(42);
+    EXPECT_EQ(wrapped->Size(), 3u);
+    EXPECT_EQ(wrapped->At(2), std::optional<uint64_t>(42));
+}
+
+TEST(ColumnsCase, ColumnNullableT_Wrap_AcceptsLvalue) {
+    auto nested = std::make_shared<ColumnUInt64>();
+    auto nulls = std::make_shared<ColumnUInt8>();
+    ColumnNullable col(nested, nulls);
+    col.Append(false);
+    nested->Append(7);
+
+    using TestNullable = ColumnNullableT<ColumnUInt64>;
+
+    // Non-const lvalue concrete column, no std::move required.
+    auto w1 = TestNullable::Wrap(col);
+    EXPECT_EQ(w1->At(0), std::optional<uint64_t>(7));
+
+    // Const lvalue concrete column.
+    const ColumnNullable& cref = col;
+    auto w2 = TestNullable::Wrap(cref);
+    EXPECT_EQ(w2->At(0), std::optional<uint64_t>(7));
+
+    // Lvalue ColumnRef, no std::move required and not consumed.
+    ColumnRef ref = std::make_shared<ColumnNullable>(nested, nulls);
+    auto w3 = TestNullable::Wrap(ref);
+    EXPECT_EQ(w3->At(0), std::optional<uint64_t>(7));
+    EXPECT_NE(ref, nullptr);
+}
+
 TEST(ColumnsCase, ColumnTupleT_Wrap) {
     ColumnTuple col ({
             std::make_shared<ColumnUInt64>(),
@@ -1273,6 +1328,84 @@ TEST(ColumnsCase, ColumnTupleT_Wrap) {
 
     EXPECT_EQ(wrapped_col->Size(), 1u);
     EXPECT_EQ(val, wrapped_col->At(0));
+}
+
+TEST(ColumnsCase, ColumnTupleT_Wrap_DoesNotStealSource) {
+    ColumnTuple col ({
+            std::make_shared<ColumnUInt64>(),
+            std::make_shared<ColumnString>(),
+            std::make_shared<ColumnFixedString>(3)
+        }
+    );
+
+    const auto val = std::make_tuple(1, "a", "bcd");
+
+    col[0]->AsStrict<ColumnUInt64>()->Append(std::get<0>(val));
+    col[1]->AsStrict<ColumnString>()->Append(std::get<1>(val));
+    col[2]->AsStrict<ColumnFixedString>()->Append(std::get<2>(val));
+
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString, ColumnFixedString>;
+    auto wrapped = TestTuple::Wrap(std::move(col));
+
+    // Wrapper sees the same data.
+    EXPECT_EQ(wrapped->Size(), 1u);
+    EXPECT_EQ(val, wrapped->At(0));
+
+    // Source column is left intact after Wrap (non-stealing).
+    EXPECT_EQ(col.TupleSize(), 3u);
+    EXPECT_EQ(col.Size(), 1u);
+
+    // Storage is shared: appending through the original element columns is visible via the wrapper.
+    col[0]->AsStrict<ColumnUInt64>()->Append(2);
+    col[1]->AsStrict<ColumnString>()->Append("xy");
+    col[2]->AsStrict<ColumnFixedString>()->Append("zzz");
+    EXPECT_EQ(wrapped->Size(), 2u);
+    EXPECT_EQ(std::make_tuple(2, "xy", "zzz"), wrapped->At(1));
+}
+
+TEST(ColumnsCase, ColumnTupleT_Wrap_DoesNotStealSource_PreservesNames) {
+    ColumnTuple base(
+        {std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()},
+        {"id", "name"}
+    );
+
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+    auto wrapped = TestTuple::Wrap(std::move(base));
+    EXPECT_EQ(wrapped->Type()->GetName(), "Tuple(id UInt64, name String)");
+
+    // Source remains usable after Wrap (non-stealing).
+    EXPECT_EQ(base.Type()->GetName(), "Tuple(id UInt64, name String)");
+    EXPECT_EQ(base.TupleSize(), 2u);
+}
+
+TEST(ColumnsCase, ColumnTupleT_Wrap_AcceptsLvalue) {
+    ColumnTuple col({
+        std::make_shared<ColumnUInt64>(),
+        std::make_shared<ColumnString>()
+    });
+    col[0]->AsStrict<ColumnUInt64>()->Append(1);
+    col[1]->AsStrict<ColumnString>()->Append("a");
+
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+
+    // Non-const lvalue concrete column, no std::move required.
+    auto w1 = TestTuple::Wrap(col);
+    EXPECT_EQ(w1->At(0), std::make_tuple(uint64_t(1), std::string_view("a")));
+
+    // Const lvalue concrete column.
+    const ColumnTuple& cref = col;
+    auto w2 = TestTuple::Wrap(cref);
+    EXPECT_EQ(w2->At(0), std::make_tuple(uint64_t(1), std::string_view("a")));
+
+    // Lvalue ColumnRef, no std::move required and not consumed.
+    ColumnRef ref = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{col[0], col[1]});
+    auto w3 = TestTuple::Wrap(ref);
+    EXPECT_EQ(w3->At(0), std::make_tuple(uint64_t(1), std::string_view("a")));
+    EXPECT_NE(ref, nullptr);
+
+    // Source column left intact.
+    EXPECT_EQ(col.TupleSize(), 2u);
+    EXPECT_EQ(col.Size(), 1u);
 }
 
 TEST(ColumnsCase, ColumnTupleT_Empty) {
@@ -1380,4 +1513,80 @@ TEST(ColumnsCase, ColumnMapT_Wrap) {
     EXPECT_THROW(map_view.At(0), ValidationError);
     EXPECT_EQ("123", map_view.At(1));
     EXPECT_EQ("abc", map_view.At(2));
+}
+
+TEST(ColumnsCase, ColumnMapT_Wrap_AcceptsLvalue) {
+    auto tupls = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{
+            std::make_shared<ColumnUInt64>(),
+            std::make_shared<ColumnString>()});
+
+    auto data = std::make_shared<ColumnArray>(tupls);
+
+    auto val = tupls->CloneEmpty()->As<ColumnTuple>();
+    (*val)[0]->AsStrict<ColumnUInt64>()->Append(1);
+    (*val)[1]->AsStrict<ColumnString>()->Append("123");
+    data->AppendAsColumn(val);
+
+    ColumnMap col{data};
+
+    using TestMap = ColumnMapT<ColumnUInt64, ColumnString>;
+
+    // Non-const lvalue concrete column, no std::move required.
+    auto w1 = TestMap::Wrap(col);
+    EXPECT_EQ("123", w1->At(0).At(1));
+
+    // Const lvalue concrete column.
+    const ColumnMap& cref = col;
+    auto w2 = TestMap::Wrap(cref);
+    EXPECT_EQ("123", w2->At(0).At(1));
+
+    // Lvalue ColumnRef, no std::move required and not consumed.
+    ColumnRef ref = std::make_shared<ColumnMap>(data);
+    auto w3 = TestMap::Wrap(ref);
+    EXPECT_EQ("123", w3->At(0).At(1));
+    EXPECT_NE(ref, nullptr);
+
+    // Source column left intact.
+    EXPECT_EQ(col.Size(), 1u);
+}
+
+TEST(ColumnsCase, ColumnMapT_Wrap_DoesNotStealSource) {
+    auto tupls = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{
+            std::make_shared<ColumnUInt64>(),
+            std::make_shared<ColumnString>()});
+
+    auto data = std::make_shared<ColumnArray>(tupls);
+
+    auto val = tupls->CloneEmpty()->As<ColumnTuple>();
+
+    (*val)[0]->AsStrict<ColumnUInt64>()->Append(1);
+    (*val)[1]->AsStrict<ColumnString>()->Append("123");
+
+    (*val)[0]->AsStrict<ColumnUInt64>()->Append(2);
+    (*val)[1]->AsStrict<ColumnString>()->Append("abc");
+
+    data->AppendAsColumn(val);
+
+    ColumnMap col{data};
+
+    using TestMap = ColumnMapT<ColumnUInt64, ColumnString>;
+    auto wrapped_col = TestMap::Wrap(std::move(col));
+
+    // Wrapper sees the same data.
+    auto map_view = wrapped_col->At(0);
+    EXPECT_THROW(map_view.At(0), ValidationError);
+    EXPECT_EQ("123", map_view.At(1));
+    EXPECT_EQ("abc", map_view.At(2));
+
+    // Source column is left intact after Wrap (non-stealing).
+    EXPECT_EQ(col.Size(), 1u);
+
+    // Storage is shared: appending a row through the original is visible via the wrapper.
+    auto val2 = tupls->CloneEmpty()->As<ColumnTuple>();
+    (*val2)[0]->AsStrict<ColumnUInt64>()->Append(7);
+    (*val2)[1]->AsStrict<ColumnString>()->Append("xyz");
+    data->AppendAsColumn(val2);
+
+    EXPECT_EQ(wrapped_col->Size(), 2u);
+    EXPECT_EQ("xyz", wrapped_col->At(1).At(7));
 }

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1127,6 +1127,69 @@ TEST(ColumnsCase, ColumnLowCardinalityT_Wrap_DoesNotStealSource) {
     EXPECT_EQ(wrapped->GetDictionarySize(), dict_before + 1);
 }
 
+TEST(ColumnsCase, ColumnLowCardinalityT_Swap_VisibleThroughAlias) {
+    auto a = std::make_shared<ColumnLowCardinalityT<ColumnString>>();
+    a->Append("a");
+    a->Append("b");
+    a->Append("a");
+    auto b = std::make_shared<ColumnLowCardinalityT<ColumnString>>();
+    b->Append("x");
+
+    // Typed view of `a`, created BEFORE the swap; shares a's dictionary and index bundle.
+    auto alias_a = ColumnLowCardinalityT<ColumnString>::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+    ASSERT_EQ(alias_a->Size(), 3u);
+
+    a->Swap(*b);
+
+    // a now holds b's data, b holds a's data.
+    ASSERT_EQ(a->Size(), 1u);
+    EXPECT_EQ(a->At(0), "x");
+    ASSERT_EQ(b->Size(), 3u);
+    EXPECT_EQ(b->At(0), "a");
+    EXPECT_EQ(b->At(1), "b");
+
+    // The swap is visible through the pre-existing alias: dictionary swapped in place and the
+    // shared index bundle swapped, so alias_a reflects b's data (size flips 3 -> 1).
+    ASSERT_EQ(alias_a->Size(), 1u);
+    EXPECT_EQ(alias_a->At(0), "x");
+}
+
+TEST(ColumnsCase, ColumnLowCardinalityT_Wrap_ThenLoad_VisibleThroughAlias) {
+    // Serialize a source LowCardinality column.
+    ColumnLowCardinalityT<ColumnString> src;
+    src.Append("p");
+    src.Append("q");
+    src.Append("p");
+
+    char buffer[256] = {'\0'};
+    {
+        ArrayOutput output(buffer, sizeof(buffer));
+        EXPECT_NO_THROW(src.Save(&output));
+    }
+
+    // A different target column, wrapped BEFORE the load.
+    auto target = std::make_shared<ColumnLowCardinalityT<ColumnString>>();
+    target->Append("z");
+    auto alias = ColumnLowCardinalityT<ColumnString>::Wrap(target);
+    ASSERT_NE(alias, nullptr);
+    ASSERT_EQ(alias->Size(), 1u);
+
+    // Load src's data into target: LoadBody swaps the dictionary in place and REPLACES the index
+    // column inside the shared bundle.
+    {
+        ArrayInput input(buffer, sizeof(buffer));
+        EXPECT_TRUE(target->Load(&input, 3));
+    }
+
+    ASSERT_EQ(target->Size(), 3u);
+    // The pre-existing alias reflects the loaded data (shared dictionary + index bundle).
+    ASSERT_EQ(alias->Size(), 3u);
+    EXPECT_EQ(alias->At(0), "p");
+    EXPECT_EQ(alias->At(1), "q");
+    EXPECT_EQ(alias->At(2), "p");
+}
+
 TEST(ColumnsCase, ColumnLowCardinalityT_Wrap_AcceptsLvalue) {
     auto source = std::make_shared<ColumnLowCardinalityT<ColumnString>>();
     source->Append("x");
@@ -1717,6 +1780,69 @@ TEST(ColumnsCase, DeepNestedArray_Swap_VisibleThroughAlias) {
     ASSERT_EQ(inner.Size(), 2u);
     EXPECT_EQ(inner[0], std::optional<std::string_view>("x"));
     EXPECT_EQ(inner[1], std::optional<std::string_view>{});
+}
+
+// --- Deep nesting with LowCardinality: Map(UInt64, Array(LowCardinality(Nullable(String)))) ---
+
+namespace {
+// Builds a single-row Map(UInt64, Array(LowCardinality(Nullable(String)))): one map row with one
+// entry {key -> arr}, where the value is an array of LowCardinality(Nullable(String)) items.
+std::shared_ptr<ColumnMap> MakeDeepLcMapRow(uint64_t key, std::vector<std::optional<std::string>> arr) {
+    auto keys = std::make_shared<ColumnUInt64>();
+    auto vals = std::make_shared<ColumnArrayT<ColumnLowCardinalityT<ColumnNullableT<ColumnString>>>>();
+    keys->Append(key);
+    vals->Append(arr);
+    auto tuple = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{keys, vals});
+    return std::make_shared<ColumnMap>(std::make_shared<ColumnArray>(tuple));
+}
+}
+
+TEST(ColumnsCase, DeepMapArrayLowCardinality_Swap_VisibleThroughAlias) {
+    using DeepLcMap = ColumnMapT<ColumnUInt64, ColumnArrayT<ColumnLowCardinalityT<ColumnNullableT<ColumnString>>>>;
+
+    auto a = MakeDeepLcMapRow(1, {std::string("a"), std::string("b"), std::string("c")});
+    auto b = MakeDeepLcMapRow(1, {std::string("x"), std::nullopt});
+
+    auto alias_a = DeepLcMap::Wrap(a);  // deep typed view created BEFORE the swap
+    ASSERT_NE(alias_a, nullptr);
+    ASSERT_EQ(alias_a->At(0).At(1).Size(), 3u);
+
+    a->Swap(*b);
+
+    // The swap recurses through Array -> LowCardinality (dictionary swapped in place, index bundle
+    // swapped) down to the Nullable(String) leaves, so the pre-existing alias reflects B's data:
+    // the value-array flips size 3 -> 2 and the null survives through LC -> Nullable.
+    auto arr = alias_a->At(0).At(1);
+    ASSERT_EQ(arr.Size(), 2u);
+    EXPECT_EQ(arr[0], std::optional<std::string_view>("x"));
+    EXPECT_EQ(arr[1], std::optional<std::string_view>{});
+
+    // b now holds a's original data.
+    auto arr_b = DeepLcMap::Wrap(b)->At(0).At(1);
+    ASSERT_EQ(arr_b.Size(), 3u);
+    EXPECT_EQ(arr_b[0], std::optional<std::string_view>("a"));
+}
+
+TEST(ColumnsCase, DeepMapArrayLowCardinality_Clear_VisibleThroughAlias) {
+    using DeepLcMap = ColumnMapT<ColumnUInt64, ColumnArrayT<ColumnLowCardinalityT<ColumnNullableT<ColumnString>>>>;
+
+    auto a = MakeDeepLcMapRow(1, {std::string("a"), std::string("b"), std::string("c")});
+    auto alias_a = DeepLcMap::Wrap(a);
+    ASSERT_NE(alias_a, nullptr);
+    ASSERT_EQ(alias_a->Size(), 1u);
+
+    a->Clear();
+
+    // Clear recurses to the shared leaves in place (incl. LowCardinality), so the alias empties too.
+    EXPECT_EQ(a->Size(), 0u);
+    EXPECT_EQ(alias_a->Size(), 0u);
+
+    // Re-appending a fresh row must not resurface the pre-clear entry.
+    a->Append(MakeDeepLcMapRow(1, {std::string("z")}));
+    ASSERT_EQ(alias_a->Size(), 1u);
+    auto arr = alias_a->At(0).At(1);
+    ASSERT_EQ(arr.Size(), 1u);
+    EXPECT_EQ(arr[0], std::optional<std::string_view>("z"));
 }
 
 TEST(ColumnsCase, ColumnTupleT_Slice_PreservesNames) {

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1845,6 +1845,62 @@ TEST(ColumnsCase, DeepMapArrayLowCardinality_Clear_VisibleThroughAlias) {
     EXPECT_EQ(arr[0], std::optional<std::string_view>("z"));
 }
 
+// --- const As()/AsStrict() wrap like their non-const counterparts ---
+
+TEST(ColumnsCase, Const_As_WrapsWrappableColumn) {
+    using TestArray = ColumnArrayT<ColumnUInt64>;
+
+    auto arr = std::make_shared<TestArray>();
+    arr->Append(std::vector<uint64_t>{1, 2, 3});
+
+    // View the column only through a const handle.
+    std::shared_ptr<const Column> c = arr;
+    auto view = c->As<TestArray>();
+    ASSERT_NE(view, nullptr);
+    static_assert(std::is_same_v<decltype(view), std::shared_ptr<const TestArray>>,
+                  "const As() must yield shared_ptr<const T>");
+
+    // Read access reflects the same shared storage.
+    ASSERT_EQ(view->Size(), 1u);
+    auto row = view->At(0);
+    ASSERT_EQ(row.Size(), 3u);
+    EXPECT_EQ(row[0], 1u);
+    EXPECT_EQ(row[2], 3u);
+}
+
+TEST(ColumnsCase, Const_As_ExactDowncastStillWorks) {
+    auto leaf = std::make_shared<ColumnUInt64>();
+    leaf->Append(42u);
+
+    std::shared_ptr<const Column> c = leaf;
+    auto exact = c->As<ColumnUInt64>();
+    ASSERT_NE(exact, nullptr);
+    ASSERT_EQ(exact->Size(), 1u);
+    EXPECT_EQ(exact->At(0), 42u);
+
+    // Non-wrappable mismatch returns nullptr (no throw).
+    EXPECT_EQ(c->As<ColumnString>(), nullptr);
+}
+
+TEST(ColumnsCase, Const_AsStrict_WrapsAndThrows) {
+    using TestArray = ColumnArrayT<ColumnUInt64>;
+
+    auto arr = std::make_shared<TestArray>();
+    arr->Append(std::vector<uint64_t>{7, 8});
+
+    std::shared_ptr<const Column> c = arr;
+    auto view = c->AsStrict<TestArray>();
+    ASSERT_NE(view, nullptr);
+    static_assert(std::is_same_v<decltype(view), std::shared_ptr<const TestArray>>,
+                  "const AsStrict() must yield shared_ptr<const T>");
+    ASSERT_EQ(view->At(0).Size(), 2u);
+
+    // Wrappable-but-incompatible element type throws.
+    EXPECT_THROW((void)c->AsStrict<ColumnArrayT<ColumnString>>(), ValidationError);
+    // Non-wrappable mismatch throws too.
+    EXPECT_THROW((void)c->AsStrict<ColumnString>(), ValidationError);
+}
+
 TEST(ColumnsCase, ColumnTupleT_Slice_PreservesNames) {
     using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1646,6 +1646,27 @@ TEST(ColumnsCase, ColumnTuple_Swap_DifferentSizeThrows) {
     EXPECT_THROW(a.Swap(b), ValidationError);
 }
 
+TEST(ColumnsCase, ColumnTuple_Swap_DifferentElementTypeDoesNotModify) {
+    auto a0 = std::make_shared<ColumnUInt64>();
+    auto a1 = std::make_shared<ColumnString>();
+    a0->Append(1);
+    a1->Append("a");
+    ColumnTuple a({a0, a1});
+
+    auto b0 = std::make_shared<ColumnUInt64>();
+    auto b1 = std::make_shared<ColumnUInt64>();
+    b0->Append(2);
+    b1->Append(3);
+    ColumnTuple b({b0, b1});
+
+    EXPECT_THROW(a.Swap(b), ValidationError);
+
+    EXPECT_EQ(a0->At(0), 1u);
+    EXPECT_EQ(a1->At(0), "a");
+    EXPECT_EQ(b0->At(0), 2u);
+    EXPECT_EQ(b1->At(0), 3u);
+}
+
 TEST(ColumnsCase, ColumnTuple_Clear_PreservesStructure_AndAlias) {
     ColumnTuple col({std::make_shared<ColumnUInt64>(), std::make_shared<ColumnString>()});
     col[0]->AsStrict<ColumnUInt64>()->Append(1);

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -1653,3 +1653,103 @@ TEST(ColumnsCase, ColumnMapT_Wrap_DoesNotStealSource) {
     EXPECT_EQ(wrapped_col->Size(), 2u);
     EXPECT_EQ("xyz", wrapped_col->At(1).At(7));
 }
+
+// --- Wrap error-reporting overloads ---------------------------------------------------------
+// The two-argument Wrap(col, ValidationError*) returns nullptr (never throws) on a type
+// mismatch; the single-argument Wrap(col) throws ValidationError on the same mismatch.
+
+TEST(ColumnsCase, ColumnArrayT_Wrap_TypeMismatch) {
+    using TestArray = ColumnArrayT<ColumnUInt64>;
+
+    // Right kind (Array), wrong element type (String instead of UInt64).
+    ColumnRef bad_element = std::make_shared<ColumnArray>(std::make_shared<ColumnString>());
+    // Wrong kind entirely.
+    ColumnRef not_array = std::make_shared<ColumnUInt64>();
+
+    ValidationError error;
+    EXPECT_NO_THROW({
+        EXPECT_EQ(TestArray::Wrap(bad_element, &error), nullptr);
+    });
+    EXPECT_FALSE(std::string_view(error.what()).empty());
+
+    // Passing nullptr for the error is allowed and still non-throwing.
+    EXPECT_NO_THROW({
+        EXPECT_EQ(TestArray::Wrap(not_array, nullptr), nullptr);
+    });
+
+    // Single-argument overload throws on the same mismatches.
+    EXPECT_THROW(TestArray::Wrap(bad_element), ValidationError);
+    EXPECT_THROW(TestArray::Wrap(not_array), ValidationError);
+
+    // Sanity: a matching column wraps fine through both overloads.
+    ColumnRef good = std::make_shared<ColumnArray>(std::make_shared<ColumnUInt64>());
+    EXPECT_NE(TestArray::Wrap(good, nullptr), nullptr);
+    EXPECT_NE(TestArray::Wrap(good), nullptr);
+}
+
+TEST(ColumnsCase, ColumnNullableT_Wrap_TypeMismatch) {
+    using TestNullable = ColumnNullableT<ColumnUInt64>;
+
+    // Nullable of the wrong nested type.
+    ColumnRef bad_nested = std::make_shared<ColumnNullable>(
+        std::make_shared<ColumnString>(), std::make_shared<ColumnUInt8>());
+    ColumnRef not_nullable = std::make_shared<ColumnUInt64>();
+
+    ValidationError error;
+    EXPECT_EQ(TestNullable::Wrap(bad_nested, &error), nullptr);
+    EXPECT_FALSE(std::string_view(error.what()).empty());
+    EXPECT_EQ(TestNullable::Wrap(not_nullable, nullptr), nullptr);
+
+    EXPECT_THROW(TestNullable::Wrap(bad_nested), ValidationError);
+    EXPECT_THROW(TestNullable::Wrap(not_nullable), ValidationError);
+}
+
+TEST(ColumnsCase, ColumnTupleT_Wrap_TypeMismatch) {
+    using TestTuple = ColumnTupleT<ColumnUInt64, ColumnString>;
+
+    // Correct arity, wrong element type.
+    ColumnRef bad_element = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{
+        std::make_shared<ColumnUInt64>(), std::make_shared<ColumnUInt64>()});
+    // Wrong arity.
+    ColumnRef bad_arity = std::make_shared<ColumnTuple>(std::vector<ColumnRef>{
+        std::make_shared<ColumnUInt64>()});
+    // Wrong kind.
+    ColumnRef not_tuple = std::make_shared<ColumnUInt64>();
+
+    ValidationError error;
+    EXPECT_EQ(TestTuple::Wrap(bad_element, &error), nullptr);
+    EXPECT_FALSE(std::string_view(error.what()).empty());
+    EXPECT_EQ(TestTuple::Wrap(bad_arity, nullptr), nullptr);
+    EXPECT_EQ(TestTuple::Wrap(not_tuple, nullptr), nullptr);
+
+    EXPECT_THROW(TestTuple::Wrap(bad_element), ValidationError);
+    EXPECT_THROW(TestTuple::Wrap(bad_arity), ValidationError);
+    EXPECT_THROW(TestTuple::Wrap(not_tuple), ValidationError);
+}
+
+TEST(ColumnsCase, ColumnMapT_Wrap_TypeMismatch) {
+    using TestMap = ColumnMapT<ColumnUInt64, ColumnString>;
+    ColumnRef not_map = std::make_shared<ColumnUInt64>();
+
+    ValidationError error;
+    EXPECT_EQ(TestMap::Wrap(not_map, &error), nullptr);
+    EXPECT_FALSE(std::string_view(error.what()).empty());
+    EXPECT_EQ(TestMap::Wrap(not_map, nullptr), nullptr);
+    EXPECT_THROW(TestMap::Wrap(not_map), ValidationError);
+}
+
+TEST(ColumnsCase, ColumnLowCardinalityT_Wrap_TypeMismatch) {
+    using TestLC = ColumnLowCardinalityT<ColumnString>;
+
+    // LowCardinality with the wrong (but valid) dictionary type.
+    ColumnRef bad_dict = std::make_shared<ColumnLowCardinality>(std::make_shared<ColumnFixedString>(4));
+    ColumnRef not_lc = std::make_shared<ColumnUInt64>();
+
+    ValidationError error;
+    EXPECT_EQ(TestLC::Wrap(bad_dict, &error), nullptr);
+    EXPECT_FALSE(std::string_view(error.what()).empty());
+    EXPECT_EQ(TestLC::Wrap(not_lc, nullptr), nullptr);
+
+    EXPECT_THROW(TestLC::Wrap(bad_dict), ValidationError);
+    EXPECT_THROW(TestLC::Wrap(not_lc), ValidationError);
+}


### PR DESCRIPTION
## TL;DR

`Column::As<T>()` and `Column::AsStrict<T>()` are now smarter for the *typed* column
templates (`ColumnArrayT`, `ColumnTupleT`, `ColumnMapT`, `ColumnNullableT`,
`ColumnLowCardinalityT`). When the requested `T` is one of these and the column is not
already exactly `T`, they **wrap** the column into a strongly-typed, storage-sharing view
instead of failing.

In practice this means you can take a column straight out of a `Select` result and ask for
the convenient typed interface directly:

```cpp
// block[0] is a base ColumnLowCardinality coming from the server.
if (auto lc = block[0]->As<ColumnLowCardinalityT<ColumnString>>()) {
    for (size_t i = 0; i < lc->Size(); ++i)
        std::cout << (*lc)[i] << "\n";   // typed operator[] -> std::string_view
}
```

No manual reconstruction, no exact-type juggling.

---

## Background: base columns vs. typed columns

ClickHouse composite types are represented by two layers in this library:

| Base column           | Typed wrapper                              | Adds                                            |
|-----------------------|--------------------------------------------|-------------------------------------------------|
| `ColumnArray`         | `ColumnArrayT<Nested>`                      | typed `At()`, `operator[]`, `Append(container)` |
| `ColumnNullable`      | `ColumnNullableT<Nested>`                   | `std::optional`-based `At()` / `operator[]`     |
| `ColumnTuple`         | `ColumnTupleT<Cols...>`                     | `std::tuple`-based `At()` / `operator[]`        |
| `ColumnMap`           | `ColumnMapT<Key, Value>`                    | key/value `At()`, iteration                     |
| `ColumnLowCardinality`| `ColumnLowCardinalityT<Dict>`               | typed `At()`, `operator[]`, `AppendMany()`      |

When you `Select`, the server-side columns are created by the factory as the **base**
types (`ColumnArray`, `ColumnNullable`, `ColumnTuple`, `ColumnMap`, `ColumnLowCardinality`).
The `…T<>` templates are the ergonomic, type-safe wrappers around them.

Previously, to get a typed view you needed the column to already *be* that exact type, or
you had to build the typed column yourself. Now `As<>`/`AsStrict<>` bridge the gap
automatically.

---

## Behavior

A type is **wrappable** if it exposes a static `Wrap` method. That is exactly the five
templates above (`ColumnArrayT`, `ColumnTupleT`, `ColumnMapT`, `ColumnNullableT`,
`ColumnLowCardinalityT`). Everything else (`ColumnString`, `ColumnUInt64`, …) is
non-wrappable and behaves as before.

| Call                    | Wrappable `T`                                                        | Non-wrappable `T`                       |
|-------------------------|----------------------------------------------------------------------|-----------------------------------------|
| `As<T>()` (non-const)   | exact cast first; otherwise wrap. Returns `nullptr` on mismatch.     | plain cast; `nullptr` on mismatch.      |
| `AsStrict<T>()`         | exact cast first; otherwise wrap. Throws `ValidationError` on failure.| plain cast; throws on failure.          |
| `As<T>() const`         | **exact cast only — no wrapping**; `nullptr` on mismatch.            | plain cast; `nullptr` on mismatch.      |

Notes:

- The exact-cast-first step means that if the column already *is* `T`, you get the very same
  object back (identity preserved, no new allocation).
- `Block::operator[]` returns a non-const `ColumnRef` by value, so `block[i]->As<…>()`
  always uses the wrapping (non-const) overload — wrapping works out of the box for `Select`
  results.

### Wrapping is a storage-sharing view

Wrapping does **not** copy or move the underlying data. The typed wrapper shares the same
storage (dictionary, offsets, index, nested columns) with the source via `shared_ptr`.
Mutations through one are visible through the other, and the source stays fully valid.

```cpp
auto base    = block[0]->As<ColumnArray>();                 // base view
auto typed   = block[0]->As<ColumnArrayT<ColumnUInt64>>();  // typed, shares the same storage
// reading through `typed` reflects exactly what `base` holds
```

---

## Examples

### LowCardinality

```cpp
client.Select("SELECT lc_col FROM my_table", [](const Block& block) {
    // Server sends a base ColumnLowCardinality; wrap it into the typed view.
    auto lc = block[0]->As<ColumnLowCardinalityT<ColumnString>>();
    if (!lc) return;
    for (size_t i = 0; i < lc->Size(); ++i)
        std::cout << lc->At(i) << "\n";   // std::string_view
});
```

### Array

```cpp
// Array(UInt64)
auto arr = block[0]->As<ColumnArrayT<ColumnUInt64>>();
for (size_t row = 0; row < arr->Size(); ++row) {
    auto values = arr->At(row);                 // ArrayValueView
    for (size_t j = 0; j < values.size(); ++j)
        std::cout << values[j] << " ";          // uint64_t
    std::cout << "\n";
}
```

### Nullable

```cpp
// Nullable(String)
auto n = block[0]->As<ColumnNullableT<ColumnString>>();
for (size_t i = 0; i < n->Size(); ++i) {
    std::optional<std::string_view> v = n->At(i);
    std::cout << (v ? std::string(*v) : std::string("<null>")) << "\n";
}
```

### Tuple

```cpp
// Tuple(UInt64, String)
auto t = block[0]->As<ColumnTupleT<ColumnUInt64, ColumnString>>();
for (size_t i = 0; i < t->Size(); ++i) {
    auto [id, name] = t->At(i);                 // std::tuple<uint64_t, std::string_view>
    std::cout << id << " => " << name << "\n";
}
```

### Map

```cpp
// Map(String, UInt64)
auto m = block[0]->As<ColumnMapT<ColumnString, ColumnUInt64>>();
for (size_t i = 0; i < m->Size(); ++i) {
    auto row = m->At(i);                         // MapValueView
    for (const auto& [key, value] : row)
        std::cout << key << "=" << value << " ";
    std::cout << "\n";
}
```

### Nested types

Wrapping recurses, so nested typed columns work too:

```cpp
// Array(LowCardinality(String))
auto arr = block[0]->As<ColumnArrayT<ColumnLowCardinalityT<ColumnString>>>();
```

### `As` vs `AsStrict`

`As` returns `nullptr` on a type mismatch — always check it:

```cpp
if (auto typed = column->As<ColumnArrayT<ColumnUInt64>>()) {
    // use typed
} else {
    // wrong type
}
```

`AsStrict` throws `clickhouse::ValidationError` instead, which is handy when a mismatch is a
programming error you want to surface immediately:

```cpp
auto typed = column->AsStrict<ColumnArrayT<ColumnUInt64>>();   // throws on mismatch
```

---

## How it works (brief)

- A compile-time trait, `HasWrapMethod<T>`, detects whether `T` exposes a static `Wrap`.
- For a wrappable `T`, `As`/`AsStrict` try `dynamic_pointer_cast<T>` first, then fall back to
  `WrapColumn<T>(...)`, which calls `T::Wrap(...)`.
- `T::Wrap(...)` builds the typed wrapper by sharing the source column's internal storage
  (`shared_ptr`), recursing into nested columns as needed.
- There are non-throwing cores (`Wrap(col, ValidationError*)`) used to implement `As`, and
  throwing one-argument forms used by `AsStrict`.

---

## Limitations & gotchas

- **Check for `nullptr` (or use `AsStrict`).** `As` signals a mismatch by returning
  `nullptr`; it does not throw for a plain type mismatch.

- **Wrapping allocates.** Unless the column already is `T` (exact-match fast path), wrapping
  creates a new wrapper object (with a distinct identity from the source, though it shares
  storage). These methods are not `noexcept`: allocation can still throw `std::bad_alloc`, and
  the throwing forms raise `ValidationError` on a mismatch.
