### PR TITLE
Validate enum values when requested

### DIFF
--- a/clickhouse/columns/enum.cpp
+++ b/clickhouse/columns/enum.cpp
@@ -28,8 +28,8 @@ ColumnEnum<T>::ColumnEnum(TypeRef type, std::vector<T>&& data)
 
 template <typename T>
 void ColumnEnum<T>::Append(const T& value, bool checkValue) {
-    if  (checkValue) {
-        // TODO: type_->HasEnumValue(value), "Enum type doesn't have value " + std::to_string(value);
+    if (checkValue && !type_->As<EnumType>()->HasEnumValue(value)) {
+        throw ValidationError("Enum type doesn't have value " + std::to_string(value));
     }
     data_.push_back(value);
 }
@@ -56,8 +56,8 @@ std::string_view ColumnEnum<T>::NameAt(size_t n) const {
 
 template <typename T>
 void ColumnEnum<T>::SetAt(size_t n, const T& value, bool checkValue) {
-    if (checkValue) {
-        // TODO: type_->HasEnumValue(value), "Enum type doesn't have value " + std::to_string(value);
+    if (checkValue && !type_->As<EnumType>()->HasEnumValue(value)) {
+        throw ValidationError("Enum type doesn't have value " + std::to_string(value));
     }
     data_.at(n) = value;
 }

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -751,6 +751,20 @@ TEST(ColumnsCase, EnumTest) {
     ASSERT_TRUE(CreateColumnByType("Enum8('Hi' = 1, 'Hello' = 2)")->Type()->IsEqual(Type::CreateEnum8(enum_items)));
 }
 
+TEST(ColumnsCase, EnumCheckValue) {
+    auto column = std::make_shared<ColumnEnum8>(Type::CreateEnum8({{"Hi", 1}, {"Hello", 2}}));
+
+    EXPECT_NO_THROW(column->Append(1, true));
+    EXPECT_THROW(column->Append(3, true), ValidationError);
+    EXPECT_EQ(column->Size(), 1u);
+
+    EXPECT_NO_THROW(column->SetAt(0, 2, true));
+    EXPECT_EQ(column->At(0), 2);
+
+    EXPECT_THROW(column->SetAt(0, 3, true), ValidationError);
+    EXPECT_EQ(column->At(0), 2);
+}
+
 TEST(ColumnsCase, NullableSlice) {
     auto data = std::make_shared<ColumnUInt32>(MakeNumbers());
     auto nulls = std::make_shared<ColumnUInt8>(MakeBools());


### PR DESCRIPTION
## What changed

- **Validate numeric enum values** when `checkValue` is `true` in `Append()` and `SetAt()`.
- Throw `ValidationError` when the value is not defined in the enum type.
- Keep the default unchecked behavior unchanged.

## Tests

- `cmake --build build --target clickhouse-cpp-ut --parallel 8`
- `./build/ut/clickhouse-cpp-ut --gtest_filter='ColumnsCase.Enum*'`