### PR TITLE
Validate FixedString sizes before swapping

### DIFF
--- a/clickhouse/columns/string.cpp
+++ b/clickhouse/columns/string.cpp
@@ -112,7 +112,11 @@ ColumnRef ColumnFixedString::CloneEmpty() const {
 
 void ColumnFixedString::Swap(Column& other) {
     auto & col = dynamic_cast<ColumnFixedString &>(other);
-    std::swap(string_size_, col.string_size_);
+    if (string_size_ != col.string_size_) {
+        throw ValidationError("Can't swap FixedString columns when sizes are not the same: "
+            + std::to_string(string_size_) + "(this) != "
+            + std::to_string(col.string_size_) + "(that)");
+    }
     data_.swap(col.data_);
 }
 

--- a/ut/columns_ut.cpp
+++ b/ut/columns_ut.cpp
@@ -259,6 +259,32 @@ TEST(ColumnsCase, FixedString_Type_Size_Eq10) {
     ASSERT_EQ(col->FixedSize(), col->Type()->As<FixedStringType>()->GetSize());
 }
 
+TEST(ColumnsCase, FixedStringSwap) {
+    auto column1 = std::make_shared<ColumnFixedString>(2);
+    auto column2 = std::make_shared<ColumnFixedString>(2);
+    column1->Append("aa");
+    column2->Append("bb");
+
+    column1->Swap(*column2);
+
+    EXPECT_EQ(column1->At(0), "bb");
+    EXPECT_EQ(column2->At(0), "aa");
+}
+
+TEST(ColumnsCase, FixedStringSwapDifferentSize) {
+    auto column1 = std::make_shared<ColumnFixedString>(2);
+    auto column2 = std::make_shared<ColumnFixedString>(4);
+    column1->Append("aa");
+    column2->Append("bbbb");
+
+    EXPECT_THROW(column1->Swap(*column2), ValidationError);
+
+    EXPECT_EQ(column1->FixedSize(), 2u);
+    EXPECT_EQ(column2->FixedSize(), 4u);
+    EXPECT_EQ(column1->At(0), "aa");
+    EXPECT_EQ(column2->At(0), "bbbb");
+}
+
 TEST(ColumnsCase, StringInit) {
     auto values = MakeStrings();
     auto col = std::make_shared<ColumnString>(values);


### PR DESCRIPTION
## What changed

- **Reject swaps between different FixedString sizes** before changing either column.
- Keep same-size swaps working as before.
- Add coverage for both valid and invalid swaps.

## Tests

- `cmake --build build --target clickhouse-cpp-ut --parallel 8`
- `./build/ut/clickhouse-cpp-ut --gtest_filter='ColumnsCase.*'`